### PR TITLE
SONATA-293 - Fix cross-selling block to return enabled products

### DIFF
--- a/src/Sonata/ProductBundle/Entity/ProductManager.php
+++ b/src/Sonata/ProductBundle/Entity/ProductManager.php
@@ -37,6 +37,8 @@ class ProductManager extends DoctrineBaseManager implements ProductManagerInterf
     {
         return $this->queryInSameCollections($productCollections, $limit)
             ->andWhere('p.parent IS NULL')
+            ->andWhere('p.enabled = :enabled')
+            ->setParameter('enabled', true)
             ->getQuery()
             ->execute();
     }


### PR DESCRIPTION
I've fixed product cross-selling block to return only enabled products.
