### PR TITLE
SONATA-308 - Add "add to basket" to be handled in popin

### DIFF
--- a/docs/reference/tutorials/index.rst
+++ b/docs/reference/tutorials/index.rst
@@ -17,6 +17,7 @@ So, let's get started!
     Create a category <create-category>
     Create a collection <create-collection>
     Create a product <create-product>
+    Basic options for product providers <product-provider-options>
     Create a delivery method <create-delivery-method>
     Create a payment method <create-payment-method>
     Extend the e-commerce part of Sonata <extend>

--- a/docs/reference/tutorials/product-provider-options.rst
+++ b/docs/reference/tutorials/product-provider-options.rst
@@ -1,0 +1,58 @@
+===================================
+Basic options for product providers
+===================================
+
+You can add options to your product provider.
+
+Available options
+=================
+
+There is some available options you can enable in your product provider class in order to alter the way your product is used.
+
+Here are some built-in options you can use:
+
+Enable a modal for "add to basket" product page button
+------------------------------------------------------
+
+This option will display your product in a modal (popin) after clicking on "add to basket" button on the product page
+with a small summary of your product.
+
+Start by adding the option in your product provider:
+
+::
+
+	<?php
+    namespace Application\Sonata\ProductBundle\Provider;
+
+    use JMS\Serializer\SerializerInterface;
+
+    use Sonata\ProductBundle\Model\BaseProductProvider;
+
+    /**
+     * TrainingProductProvider class
+     */
+    class TrainingProductProvider extends BaseProductProvider
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function __construct(SerializerInterface $serializer)
+        {
+            $this->serializer = $serializer;
+            $this->setOptions(array(
+                'product_add_modal' => true
+            ));
+        }
+
+        ...
+
+You also have to create a template file to display your products properties. Those will be rendered via
+a ``Resources/views/Training/properties.html.twig`` template. It can be something like:
+
+::
+    <dl>
+        {% if not product.isMaster %}
+            <dt>{{ 'training.level_title'|trans([], 'SonataProductBundle') }}</dt>
+            <dd>{{ product.level|trans([], 'SonataProductBundle') }}</dd>
+        {% endif %}
+    </dl>

--- a/src/Sonata/BasketBundle/Controller/BasketController.php
+++ b/src/Sonata/BasketBundle/Controller/BasketController.php
@@ -119,20 +119,35 @@ class BasketController extends Controller
         // if the form is valid add the product to the basket
         if ($form->isValid()) {
             $basket = $this->get('sonata.basket');
+            $basketElement = $form->getData();
+
+            $quantity = $basketElement->getQuantity();
+            $currency = $this->get('sonata.basket')->getCurrency();
+            $price = $provider->calculatePrice($product, $currency, $quantity);
 
             if ($basket->hasProduct($product)) {
-                $provider->basketMergeProduct($basket,  $product, $form->getData());
+                $provider->basketMergeProduct($basket, $product, $basketElement);
             } else {
-                $provider->basketAddProduct($basket,  $product, $form->getData());
+                $provider->basketAddProduct($basket, $product, $basketElement);
             }
 
-            return new RedirectResponse($this->generateUrl('sonata_basket_index'));
+            if ($request->isXmlHttpRequest() && $provider->getOption('product_add_modal')) {
+                return $this->render('SonataBasketBundle:Basket:add_product_popin.html.twig', array(
+                    'product'  => $product,
+                    'price'    => $price,
+                    'currency' => $currency,
+                    'quantity' => $quantity,
+                    'provider' => $provider,
+                ));
+            } else {
+                return new RedirectResponse($this->generateUrl('sonata_basket_index'));
+            }
         }
 
         // an error occur, forward the request to the view
         return $this->forward('SonataProductBundle:Product:view', array(
             'productId' => $product,
-            'slug'       => $product->getSlug(),
+            'slug'      => $product->getSlug(),
         ));
     }
 

--- a/src/Sonata/BasketBundle/Resources/public/modal.js
+++ b/src/Sonata/BasketBundle/Resources/public/modal.js
@@ -1,0 +1,23 @@
+var request = false;
+
+jQuery(document).ready(function() {
+    jQuery('form#form_add_basket').on('submit', function (e) {
+        e.preventDefault();
+
+        if (false === request) {
+            request = true;
+            var self = $(this);
+
+            jQuery.ajax({type: self.attr('method'), url: self.attr('action'), data: self.serialize(),
+                success: function (data) {
+                    if (data) {
+                        request = false;
+                        jQuery(self.attr('data-target')).html(data).modal('show');
+                    }
+                }
+            });
+        } else {
+            return false;
+        }
+    });
+});

--- a/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
+++ b/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
@@ -10,6 +10,10 @@
                 <source>message_no_basket_elements</source>
                 <target>There is no basket elements</target>
             </trans-unit>
+            <trans-unit id="sonata.basket.product.added">
+                <source>sonata.basket.product.added</source>
+                <target>Your item has been added!</target>
+            </trans-unit>
             <trans-unit id="sonata.basket.btn_update_basket">
                 <source>sonata.basket.btn_update_basket</source>
                 <target>Update the basket</target>

--- a/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
+++ b/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
@@ -10,6 +10,10 @@
                 <source>message_no_basket_elements</source>
                 <target>Aucun élément dans le panier</target>
             </trans-unit>
+            <trans-unit id="sonata.basket.product.added">
+                <source>sonata.basket.product.added</source>
+                <target>Votre produit a été ajouté !</target>
+            </trans-unit>
             <trans-unit id="sonata.basket.btn_update_basket">
                 <source>sonata.basket.btn_update_basket</source>
                 <target>Mettre à jour le panier</target>

--- a/src/Sonata/BasketBundle/Resources/views/Basket/add_product_form.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/add_product_form.html.twig
@@ -9,8 +9,16 @@ file that was distributed with this source code.
 
 #}
 
+{% if provider.getOption('product_add_modal') %}
+    {% block product_javascript_init %}
+        <script src="{{ asset('bundles/sonatabasket/modal.js') }}" type="text/javascript"></script>
+    {% endblock %}
+
+    <div id="add_basket_modal" class="modal hide"></div>
+{% endif %}
+
 <div class="row-fluid">
-    <form class="form-horizontal" action="{{ url('sonata_basket_add_product') }}" method="POST">
+    <form id="form_add_basket" class="form-horizontal" action="{{ url('sonata_basket_add_product') }}" method="POST"{% if provider.getOption('product_add_modal') %} data-target="#add_basket_modal"{% endif %}>
         <div class="control-group">
             <label class="control-label" style="width: auto;">{% trans from 'SonataProductBundle' %}sonata.product.label_quantity{% endtrans %}</label>
             <div class="controls" style="margin-left: 80px;">

--- a/src/Sonata/BasketBundle/Resources/views/Basket/add_product_popin.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/add_product_popin.html.twig
@@ -1,0 +1,45 @@
+<div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+    <div class="row-fluid">
+        <div class="span8 offset2">
+            <h3>{% trans from 'SonataBasketBundle' %}sonata.basket.product.added{% endtrans %}</h3>
+        </div>
+    </div>
+</div>
+
+<div class="modal-body">
+    {% block product_details %}
+        <div class="row-fluid" itemtype="http://schema.org/Product">
+            <div class="span3 offset1">
+                {% block product_image %}{% thumbnail product.image, 'small' with {'itemprop':'image', 'class': 'img-rounded', 'style': 'margin: 0 10px 10px 0;'} %}{% endblock%}
+            </div>
+
+            <div class="span7">
+                <h4 itemprop="name" style="margin-top: 0px;">{% block product_title %}{{ product.name }}{% endblock %}</h4>
+
+                {% block product_properties %}
+                    {{ render(controller(provider.baseControllerName ~ ':renderProperties', {product: product})) }}
+                {% endblock %}
+
+                <dl class="dl-horizontal" style="margin-bottom: 0;">
+                    <dt style="width: auto;">{{ 'header_basket_quantity'|trans([], 'SonataBasketBundle') }}</dt>
+                    <dd style="margin-left: 110px;">{{ quantity }}</dd>
+
+                    <dt style="width: auto;">{{ 'header_basket_price'|trans([], 'SonataBasketBundle') }}</dt>
+                    <dd style="margin-left: 110px;">{{ price|number_format_currency(currency) }}</dd>
+                </dl>
+            </div>
+        </div>
+    {% endblock %}
+</div>
+
+<div class="modal-footer">
+    <div class="row-fluid">
+        <div class="span5">
+            <a href="{{ url('sonata_product_view', {'productId': product.id, 'slug': product.slug}) }}" class="btn" style="margin-top: 5px;">&larr; Continue shopping</a>
+        </div>
+        <div class="span5 offset1">
+            <a href="{{ url('sonata_basket_index') }}" class="btn btn-primary btn-large">Proceed to checkout</a>
+        </div>
+    </div>
+</div>

--- a/src/Sonata/ProductBundle/Controller/BaseProductController.php
+++ b/src/Sonata/ProductBundle/Controller/BaseProductController.php
@@ -62,6 +62,22 @@ abstract class BaseProductController extends Controller
     }
 
     /**
+     * Renders product properties
+     *
+     * @param ProductInterface $product
+     *
+     * @return Response
+     */
+    public function renderPropertiesAction(ProductInterface $product)
+    {
+        $provider = $this->get('sonata.product.pool')->getProvider($product);
+
+        return $this->render(sprintf('%s:properties.html.twig', $provider->getBaseControllerName()), array(
+            'product' => $product
+        ));
+    }
+
+    /**
      * @param FormView               $formView
      * @param BasketElementInterface $basketElement
      * @param BasketInterface        $basket


### PR DESCRIPTION
I've added "add to basket" action in a Bootstrap modal. Looks like this:

![capture decran 2013-12-20 a 15 42 18](https://f.cloud.github.com/assets/103900/1790985/08c92562-6985-11e3-8f86-aef36aeccc95.png)

This PR requires the following PR to be merged before to enabled Bootstrap JS library in PageBundle and not only on AdminBundle: https://github.com/sonata-project/SonataPageBundle/pull/248
