### PR TITLE
SONATA-179 - Enable modal for product status (enabled field)

### DIFF
--- a/src/Sonata/ProductBundle/Admin/ProductAdmin.php
+++ b/src/Sonata/ProductBundle/Admin/ProductAdmin.php
@@ -194,7 +194,10 @@ class ProductAdmin extends Admin
     {
         $list
             ->addIdentifier('name')
-            ->add('enabled', null, array('editable' => true))
+            ->add('enabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('price', 'currency', array('currency' => $this->currencyDetector->getCurrency()->getLabel()))
             ->add('productCategories', null, array('associated_tostring' => 'getCategory'))
             ->add('productCollections', null, array('associated_tostring' => 'getCollection'))


### PR DESCRIPTION
Added confirmation modal for product `enabled` field in administration list template.

Merge or the following PR is needed before: https://github.com/sonata-project/SonataAdminBundle/pull/1873
