### PR TITLE
SONATA-334 - Remove product name truncation on recent products block

### DIFF
--- a/src/Sonata/ProductBundle/Resources/translations/SonataProductBundle.en.xliff
+++ b/src/Sonata/ProductBundle/Resources/translations/SonataProductBundle.en.xliff
@@ -345,7 +345,7 @@
             </trans-unit>
             <trans-unit id="view_all_products">
                 <source>view_all_products</source>
-                <target>View products</target>
+                <target>View all products</target>
             </trans-unit>
             <trans-unit id="catalog_root_title">
                 <source>catalog_root_title</source>

--- a/src/Sonata/ProductBundle/Resources/views/Product/view_thumbnail.html.twig
+++ b/src/Sonata/ProductBundle/Resources/views/Product/view_thumbnail.html.twig
@@ -23,7 +23,7 @@ file that was distributed with this source code.
             {% endif %}
         </div>
 
-        <h5 itemprop="name"><a href="{{ link }}">{{ product.name|truncate(30, false, '…') }}</a></h5>
+        <h5 itemprop="name"><a href="{{ link }}">{{ product.name }}</a></h5>
 
         <p>
             <span itemprop="price">


### PR DESCRIPTION
I've also renamed homepage button "View products" to "View all products"
