### PR TITLE
SONATA-384 - Improve header basket block

### DIFF
--- a/src/Sonata/BasketBundle/Resources/views/Block/block_basket_items.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Block/block_basket_items.html.twig
@@ -1,7 +1,7 @@
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="row pull-right">
+    <div style="display:inline; margin-left:10px;">
         <span class="glyphicon glyphicon-shopping-cart"></span>
         <a href="{{ path('sonata_basket_index') }}">
             {{ 'sonata.basket.title_basket'|trans({}, 'SonataBasketBundle') }} ({{ sonata_basket.basket.countBasketElements }})


### PR DESCRIPTION
I've improved this block located in header for the following PR: https://github.com/sonata-project/sandbox/pull/177
