### PR TITLE
Fix ecommerce installation documentation

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -170,6 +170,14 @@ You can use these bundles to extend entities or template files.
 ::
 
         # sonata front controller
+        sonata_basket:
+            resource: @SonataBasketBundle/Resources/config/routing/basket.xml
+            prefix: /shop/basket
+
+        sonata_customer:
+            resource: @SonataCustomerBundle/Resources/config/routing/customer.xml
+            prefix: /shop/user
+
         sonata_user:
             resource: @SonataUserBundle/Resources/config/routing/user.xml
             prefix: /shop/user


### PR DESCRIPTION
I've added 2 missing e-commerce routing resources in installation documentation
