### PR TITLE
Fix validation class names

### DIFF
--- a/src/Sonata/CustomerBundle/Resources/config/validation.xml
+++ b/src/Sonata/CustomerBundle/Resources/config/validation.xml
@@ -4,7 +4,7 @@
                     xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
         http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
 
-    <class name="Sonata\CustomerBundle\Entity\Customer">
+    <class name="Sonata\CustomerBundle\Entity\BaseCustomer">
         <getter property="firstname">
             <constraint name="NotNull" />
         </getter>
@@ -26,7 +26,7 @@
         </getter>
     </class>
 
-    <class name="Sonata\CustomerBundle\Entity\Address">
+    <class name="Sonata\CustomerBundle\Entity\BaseAddress">
         <getter property="name">
             <constraint name="NotNull" />
         </getter>


### PR DESCRIPTION
Address form validations when editing or even on process payment pages do not care about validation because entities class names are wrong.

I've fixed it:

`Sonata\CustomerBundle\Entity\Customer` was renamed to `Sonata\CustomerBundle\Entity\BaseCustomer`
`Sonata\CustomerBundle\Entity\Address` was renamed to `Sonata\CustomerBundle\Entity\BaseAddress`
