### PR TITLE
Fix breadcrumb to be well-aligned on product sheet

### DIFF
--- a/src/Sonata/ProductBundle/Resources/views/Product/view.html.twig
+++ b/src/Sonata/ProductBundle/Resources/views/Product/view.html.twig
@@ -30,7 +30,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block breadcrumb %}
-    <div class="row clearfix">
+    <div class="clearfix">
         {{ sonata_block_render_event('breadcrumb', { 'context': 'catalog', 'product': product, 'current_uri': app.request.requestUri }) }}
     </div>
 {% endblock %}


### PR DESCRIPTION
I've fixed breadcrumb alignment on product sheet to be well-aligned:

![capture decran 2014-01-22 a 11 37 59](https://f.cloud.github.com/assets/103900/1972974/6ed8e2bc-8351-11e3-877d-be2fe1070200.png)
