### PR TITLE
Remove priceIncludingVat attribute methods already defined in PriceCompu...

### DIFF
--- a/src/Sonata/Component/Product/ProductInterface.php
+++ b/src/Sonata/Component/Product/ProductInterface.php
@@ -111,20 +111,6 @@ interface ProductInterface extends PriceComputableInterface
     public function getDescriptionFormatter();
 
     /**
-     * Sets if price is including VAT.
-     *
-     * @param boolean $priceIncludingVat
-     */
-    public function setIsPriceIncludingVat($priceIncludingVat);
-
-    /**
-     * Gets if price is including vat boolean.
-     *
-     * @return boolean
-     */
-    public function isPriceIncludingVat();
-
-    /**
      * Set stock.
      *
      * @param integer $stock


### PR DESCRIPTION
...tableInterface

I've removed those two methods are already defined in `ProductComputableInterface` which is extending this interface.

See: https://github.com/sonata-project/ecommerce/blob/develop/src/Sonata/Component/Product/PriceComputableInterface.php#L62
