### PR TITLE
Fix method setIsPriceIncludingVat() to setPriceIncludingVat()

### DIFF
--- a/src/Sonata/Component/Basket/BasketElement.php
+++ b/src/Sonata/Component/Basket/BasketElement.php
@@ -292,7 +292,7 @@ class BasketElement implements \Serializable, BasketElementInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsPriceIncludingVat($priceIncludingVat)
+    public function setPriceIncludingVat($priceIncludingVat)
     {
         $this->priceIncludingVat = $priceIncludingVat;
     }

--- a/src/Sonata/Component/Product/PriceComputableInterface.php
+++ b/src/Sonata/Component/Product/PriceComputableInterface.php
@@ -59,7 +59,7 @@ interface PriceComputableInterface
      *
      * @param boolean $priceIncludingVat
      */
-    public function setIsPriceIncludingVat($priceIncludingVat);
+    public function setPriceIncludingVat($priceIncludingVat);
 
     /**
      * Returns if price is including VAT

--- a/src/Sonata/Component/Transformer/InvoiceTransformer.php
+++ b/src/Sonata/Component/Transformer/InvoiceTransformer.php
@@ -128,7 +128,7 @@ class InvoiceTransformer extends BaseTransformer
         $invoice->setDesignation($orderElement->getDesignation());
         $invoice->setPrice($orderElement->getPrice(true));
         $invoice->setUnitPrice($orderElement->getUnitPrice(true));
-        $invoice->setIsPriceIncludingVat($orderElement->isPriceIncludingVat());
+        $invoice->setPriceIncludingVat($orderElement->isPriceIncludingVat());
         $invoice->setVatRate($orderElement->getVatRate());
         $invoice->setQuantity($orderElement->getQuantity());
         $invoice->setTotal($orderElement->getTotal(true));

--- a/src/Sonata/InvoiceBundle/Entity/BaseInvoiceElement.php
+++ b/src/Sonata/InvoiceBundle/Entity/BaseInvoiceElement.php
@@ -154,7 +154,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsPriceIncludingVat($priceIncludingVat)
+    public function setPriceIncludingVat($priceIncludingVat)
     {
         $this->priceIncludingVat = $priceIncludingVat;
     }

--- a/src/Sonata/OrderBundle/Entity/BaseOrderElement.php
+++ b/src/Sonata/OrderBundle/Entity/BaseOrderElement.php
@@ -180,7 +180,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsPriceIncludingVat($priceIncludingVat)
+    public function setPriceIncludingVat($priceIncludingVat)
     {
         $this->priceIncludingVat = $priceIncludingVat;
     }

--- a/src/Sonata/ProductBundle/Entity/BaseProduct.php
+++ b/src/Sonata/ProductBundle/Entity/BaseProduct.php
@@ -836,7 +836,7 @@ abstract class BaseProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsPriceIncludingVat($priceIncludingVat)
+    public function setPriceIncludingVat($priceIncludingVat)
     {
         $this->priceIncludingVat = $priceIncludingVat;
     }

--- a/src/Sonata/ProductBundle/Model/BaseProductProvider.php
+++ b/src/Sonata/ProductBundle/Model/BaseProductProvider.php
@@ -204,7 +204,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
         $orderElement->setQuantity($basketElement->getQuantity());
         $orderElement->setUnitPrice($basketElement->getUnitPrice(true));
         $orderElement->setPrice($basketElement->getPrice(true));
-        $orderElement->setIsPriceIncludingVat($basketElement->isPriceIncludingVat());
+        $orderElement->setPriceIncludingVat($basketElement->isPriceIncludingVat());
         $orderElement->setVatRate($basketElement->getVatRate());
         $orderElement->setDesignation($basketElement->getName());
         $orderElement->setProductType($this->getCode());
@@ -938,7 +938,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
 
         $basketElement->setUnitPrice($unitPrice);
         $basketElement->setPrice($price);
-        $basketElement->setIsPriceIncludingVat($product->isPriceIncludingVat());
+        $basketElement->setPriceIncludingVat($product->isPriceIncludingVat());
         $basketElement->setVatRate($product->getVatRate());
     }
 


### PR DESCRIPTION
I've fixed method name because I had the following error on admin:

```
Neither the property "priceIncludingVat" nor one of the methods "setPriceIncludingVat()", "__set()" or "__call()" exist and have public access in class
```
