### PR TITLE
Add product short description to modal

### DIFF
--- a/src/Sonata/BasketBundle/Resources/views/Basket/add_product_popin.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/add_product_popin.html.twig
@@ -41,6 +41,10 @@
                         </dl>
                     </div>
                 </div>
+
+                <div class="col-md-12">
+                    <p>{{ product.rawShortDescription|raw }}</p>
+                </div>
             {% endblock %}
         </div>
         <div class="modal-footer">

--- a/src/Sonata/ProductBundle/Resources/skeleton/product/Resources/views/Entity/view.html.twig
+++ b/src/Sonata/ProductBundle/Resources/skeleton/product/Resources/views/Entity/view.html.twig
@@ -25,15 +25,3 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block product_gallery %}Product gallery{% endblock %}
-
-{% block product_basket %}
-
-    <form action="{{ url('sonata_basket_add_product') }}" method="POST">
-        {% trans from 'SonataProductBundle' %}sonata.product.label_quantity{% endtrans %} {{ form_widget(form.quantity) }}
-
-        <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-shopping-cart"></i> {% trans from 'SonataProductBundle' %}sonata.product.btn_add_to_basket{% endtrans %}</button>
-
-        {{ form_rest(form) }}
-    </form>
-
-{% endblock %}


### PR DESCRIPTION
I've added product short description to "add to basket" modal and also updated product generation skeleton template to remove `basket_product` product block override.

Preview:

![capture decran 2014-01-24 a 14 49 03](https://f.cloud.github.com/assets/103900/1995209/1f0fbd40-8500-11e3-8bfa-9019c19efe37.png)
