### PR TITLE
Add "sku" to variation fields

### DIFF
--- a/src/Sonata/ProductBundle/Model/BaseProductProvider.php
+++ b/src/Sonata/ProductBundle/Model/BaseProductProvider.php
@@ -588,7 +588,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
      */
     public function synchronizeVariationsProduct(ProductInterface $product, ArrayCollection $variations = null)
     {
-        $variationFields = array_merge(array('id', 'parent'), $this->getVariationFields());
+        $variationFields = array_merge(array('id', 'parent', 'sku'), $this->getVariationFields());
 
         $values = $product->toArray();
 


### PR DESCRIPTION
I've added `sku` fields to basic variation fields because it needs to be unique
