### PR TITLE
SONATA-418 - Add a custom variations form fields label to allow translation

### DIFF
--- a/src/Sonata/Component/Form/Type/VariationChoiceType.php
+++ b/src/Sonata/Component/Form/Type/VariationChoiceType.php
@@ -51,7 +51,10 @@ class VariationChoiceType extends AbstractType
             $builder->add($choiceTitle, 'choice', array_merge(
                     array('translation_domain' => 'SonataProductBundle'),
                     $options['field_options'],
-                    array('choices' => $choiceValues,)
+                    array(
+                        'label'   => sprintf('form_%s', $choiceTitle),
+                        'choices' => $choiceValues,
+                    )
                 )
             );
         }


### PR DESCRIPTION
I've added a `form_<field>` label to allow form labels translation
