### PR TITLE
SONATA-427 - Add checkout process stepper + fix final review template

### DIFF
--- a/src/Sonata/BasketBundle/Resources/public/css/stepper.css
+++ b/src/Sonata/BasketBundle/Resources/public/css/stepper.css
@@ -1,0 +1,60 @@
+/*
+ * Basket stepper
+ */
+
+ul.stepper {
+    list-style: none;
+    width: 100%;
+    height: 70px;
+    text-align: center;
+    color: #3a87ad;
+}
+
+ul.stepper li {
+    display: inline-block;
+    width: 135px;
+    height: 60px;
+}
+
+ul.stepper li hr {
+    margin: -53px 0px 0px 102px;
+    width: 70px;
+    border-top: 1px solid #3a87ad;
+}
+
+ul.stepper li div.img-circle {
+    background: #d9edf7;
+    width: 45px;
+    height: 45px;
+    margin: auto;
+    padding-top: 3px;
+    font-size: 2em;
+}
+
+ul.stepper li.active {
+    color: #3c763d;
+}
+
+ul.stepper li.active div.img-circle {
+    background: #dff0d8;
+}
+
+ul.stepper li.active hr {
+    border-top: 1px solid #cccccc;
+}
+
+ul.stepper li.active ~ li hr {
+    border-top: 1px solid #cccccc;
+}
+
+ul.stepper li.active ~ li {
+    color: #b0b0b0;
+}
+
+ul.stepper li.active ~ li div.img-circle {
+    background: #eeeeee;
+}
+
+ul.stepper li:last-child hr {
+    display: none;
+}

--- a/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
+++ b/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
@@ -311,6 +311,26 @@
                 <source>basket_review_title</source>
                 <target>Review your order</target>
             </trans-unit>
+            <trans-unit id="basket_stepper_basket_title">
+                <source>basket_stepper_basket_title</source>
+                <target>Your basket</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_identification_title">
+                <source>basket_stepper_identification_title</source>
+                <target>Identification</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_delivery_title">
+                <source>basket_stepper_delivery_title</source>
+                <target>Delivery</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_billing_title">
+                <source>basket_stepper_billing_title</source>
+                <target>Billing</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_checkout_title">
+                <source>basket_stepper_checkout_title</source>
+                <target>Checkout</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
+++ b/src/Sonata/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
@@ -311,6 +311,26 @@
                 <source>basket_review_title</source>
                 <target>Votre commande</target>
             </trans-unit>
+            <trans-unit id="basket_stepper_basket_title">
+                <source>basket_stepper_basket_title</source>
+                <target>Votre panier</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_identification_title">
+                <source>basket_stepper_identification_title</source>
+                <target>Identification</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_delivery_title">
+                <source>basket_stepper_delivery_title</source>
+                <target>Livraison</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_billing_title">
+                <source>basket_stepper_billing_title</source>
+                <target>Paiement</target>
+            </trans-unit>
+            <trans-unit id="basket_stepper_checkout_title">
+                <source>basket_stepper_checkout_title</source>
+                <target>Finalisation</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sonata/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
     {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
 {% endblock %}
 
-<h1>{{ 'sonata.basket.title_delivery_step_basket'|trans({}, 'SonataBasketBundle') }}</h1>
+{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'delivery'} %}
 
 {% form_theme form 'SonataBasketBundle:Form:label.html.twig' %}
 

--- a/src/Sonata/BasketBundle/Resources/views/Basket/delivery_step.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/delivery_step.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% sonata_template_box 'This is the basket delivery address template. Feel free to override it.' %}
 
-<h1>{{ 'sonata.basket.title_delivery_step_basket'|trans({}, 'SonataBasketBundle') }}</h1>
+{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'delivery'} %}
 
 <form action="{{ url('sonata_basket_delivery') }}" method="POST" >
 <div class="row">

--- a/src/Sonata/BasketBundle/Resources/views/Basket/final_review_step.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/final_review_step.html.twig
@@ -11,18 +11,36 @@ file that was distributed with this source code.
 
 {% sonata_template_box 'This is the basket final review template. Feel free to override it.' %}
 
-<h1>{{ 'sonata.basket.title_basket'|trans({}, 'SonataBasketBundle') }}</h1>
+{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'checkout'} %}
 
-<table class="table table-bordered">
+<table class="table basket">
 
     <thead>
         <tr>
-            <th>{{ 'header_basket_information'|trans({}, 'SonataBasketBundle') }}</th>
-            <th>{{ 'header_basket_price'|trans({}, 'SonataBasketBundle') }}</th>
-            <th>{{ 'header_basket_quantity'|trans({}, 'SonataBasketBundle') }}</th>
-            <th>{{ 'header_basket_total'|trans({}, 'SonataBasketBundle') }}</th>
+            <th class="col-sm-6">{% trans from 'SonataBasketBundle'%}header_basket_information{% endtrans %}</th>
+            <th class="col-sm-2">{% trans from 'SonataBasketBundle'%}header_basket_unit_price{% endtrans %}</th>
+            <th class="col-sm-2">{% trans from 'SonataBasketBundle'%}header_basket_quantity{% endtrans %}</th>
+            <th>{% trans from 'SonataBasketBundle'%}header_basket_total_inc{% endtrans %}</th>
         </tr>
     </thead>
+
+    <tbody>
+        {# call each product controller to render its own view #}
+        {% for basketElement in basket.BasketElements %}
+            {% render controller('SonataProductBundle:Product:renderFinalReviewBasketElement', {
+            'basketElement' : basketElement,
+            'basket': basket
+            }) %}
+        {% endfor %}
+
+        <tr>
+            <td>{{ 'sonata.basket.label_delivery_charge'|trans({}, 'SonataBasketBundle') }}</td>
+            <td class="number">{{ basket.getDeliveryPrice(false)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</td>
+            <td></td>
+            <td class="number">{{ basket.getDeliveryPrice(true)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</td>
+        </tr>
+    </tbody>
+
     <tfoot>
         <tr>
             <td colspan="2" rowspan="3"></td>
@@ -39,31 +57,15 @@ file that was distributed with this source code.
         </tr>
     </tfoot>
 
-    <tbody>
-        {# call each product controller to render its own view #}
-        {% for basketElement in basket.BasketElements %}
-            {% render controller('SonataProductBundle:Product:renderFinalReviewBasketElement', {
-                'basketElement' : basketElement,
-                'basket': basket
-            }) %}
-        {% endfor %}
-
-        <tr>
-            <td>{{ 'sonata.basket.label_delivery_charge'|trans({}, 'SonataBasketBundle') }}</td>
-            <td class="number">{{ basket.getDeliveryPrice(false)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</td>
-            <td></td>
-            <td class="number">{{ basket.getDeliveryPrice(true)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</td>
-        </tr>
-    </tbody>
 </table>
 
 <div class="row">
-    <!-- Delivery information -->
-    <div class="col-lg-6">
-        <div class="panel panel-info">
+    <!-- Delivery address -->
+    <div class="col-sm-6">
+        <div class="panel panel-primary">
             <div class="panel-heading">
                 <div class="panel-title">
-                    <h3>{{ 'sonata.basket.title_delivery'|trans({}, 'SonataBasketBundle') }}</h3>
+                    {{ 'sonata.basket.title_address_delivery_step_basket'|trans({}, 'SonataBasketBundle') }}
                 </div>
             </div>
             <div class="panel-body">
@@ -76,18 +78,15 @@ file that was distributed with this source code.
                     <i>{{ 'sonata.basket.title_delivery_address_not_required'|trans({}, 'SonataBasketBundle') }}</i>
                 {% endif %}
             </div>
-            <div class="panel-footer">
-                {{ basket.deliverymethod.name }}
-            </div>
         </div>
     </div>
 
-    <!-- Payment information -->
-    <div class="col-lg-6">
-        <div class="panel panel-success">
+    <!-- Payment address -->
+    <div class="col-sm-6">
+        <div class="panel panel-primary">
             <div class="panel-heading">
                 <div class="panel-title">
-                    <h3>{{ 'sonata.basket.title_billing'|trans({}, 'SonataBasketBundle') }}</h3>
+                    {{ 'sonata.basket.title_address_billing_step_basket'|trans({}, 'SonataBasketBundle') }}
                 </div>
             </div>
             <div class="panel-body">
@@ -96,28 +95,53 @@ file that was distributed with this source code.
                     {{  basket.billingaddress.getFullAddress("<br />")|raw }}
                 </address>
             </div>
-            <div class="panel-footer">
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <!-- Delivery information -->
+    <div class="col-sm-6">
+        <div class="panel panel-primary">
+            <div class="panel-heading">
+                <div class="panel-title">
+                    {{ 'sonata.basket.title_delivery_method'|trans({}, 'SonataBasketBundle') }}
+                </div>
+            </div>
+            <div class="panel-body">
+                {{ basket.deliverymethod.name }}
+            </div>
+        </div>
+    </div>
+
+    <!-- Payment information -->
+    <div class="col-sm-6">
+        <div class="panel panel-primary">
+            <div class="panel-heading">
+                <div class="panel-title">
+                    {{ 'sonata.basket.title_payment_method'|trans({}, 'SonataBasketBundle') }}
+                </div>
+            </div>
+            <div class="panel-body">
                 {{ basket.paymentmethod.name }}
             </div>
         </div>
     </div>
 </div>
 
-<div class="basket_tac well pagination-centered text-center">
-    <h3>{{ 'sonata.basket.order_terms_and_conditions_title'|trans({}, 'SonataBasketBundle') }}</h3>
-    <form action="{{ url('sonata_basket_final') }}" method="POST" onsubmit="ctrlForm(this)">
-
+<form action="{{ url('sonata_basket_final') }}" method="POST" onsubmit="ctrlForm(this)">
+    <div class="alert alert-info">
         <label for="basket_tac">
             <input type="checkbox" name="tac" id="basket_tac"/>
-            <strong>{{ 'sonata.basket.label_terms_and_condition'|trans({}, 'SonataBasketBundle') }}</strong> <br />
-            <i><a href="{{ path('sonata_payment_terms') }}" target="_blank">{{ 'sonata.basket.link_terms_and_condition'|trans({}, 'SonataBasketBundle') }}</a></i>
+            {{ 'sonata.basket.label_terms_and_condition'|trans({}, 'SonataBasketBundle') }}
+            (<i><a href="{{ path('sonata_payment_terms') }}" target="_blank">{{ 'sonata.basket.link_terms_and_condition'|trans({}, 'SonataBasketBundle') }}</a></i>)
         </label>
+    </div>
 
-        <br />
-        <br />
-        <input type="submit" value="{{ 'sonata.basket.label_process_to_payment'|trans({}, 'SonataBasketBundle') }}" class="btn btn-lg btn-primary" />
-    </form>
-</div>
+    <div class="form-actions">
+        <input type="submit" value="{{ 'sonata.basket.label_process_to_payment'|trans({}, 'SonataBasketBundle') }}" class="btn btn-primary pull-right" />
+    </div>
+</form>
 
 <script>
     function ctrlForm(form) {

--- a/src/Sonata/BasketBundle/Resources/views/Basket/index.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/index.html.twig
@@ -9,13 +9,13 @@ file that was distributed with this source code.
 
 #}
 
-<h1>{% trans from 'SonataBasketBundle' %}sonata.basket.title_basket{% endtrans %}</h1>
-
 {% block sonata_flash_messages %}
     {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
 {% endblock %}
 
 {% sonata_template_box 'This is the basket page template. Feel free to override it.' %}
+
+{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'basket'} %}
 
 {% if basket.hasBasketElements %}
 

--- a/src/Sonata/BasketBundle/Resources/views/Basket/payment_address_step.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/payment_address_step.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
     {% include 'SonataCoreBundle:FlashMessage:render.html.twig' with {domain: 'SonataCustomerBundle'} %}
 {% endblock %}
 
-<h1>{{ 'sonata.basket.title_payment_step_basket'|trans({}, 'SonataBasketBundle') }}</h1>
+{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'billing'} %}
 
 {% form_theme form 'SonataBasketBundle:Form:label.html.twig' %}
 

--- a/src/Sonata/BasketBundle/Resources/views/Basket/payment_step.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/payment_step.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% sonata_template_box 'This is the basket billing step template. Feel free to override it.' %}
 
-<h1>{{ 'sonata.basket.title_payment_step_basket'|trans({}, 'SonataBasketBundle') }}</h1>
+{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'billing'} %}
 
 <form action="{{ url('sonata_basket_payment') }}" method="POST" >
     <div class="row">

--- a/src/Sonata/BasketBundle/Resources/views/Basket/stepper.html.twig
+++ b/src/Sonata/BasketBundle/Resources/views/Basket/stepper.html.twig
@@ -1,0 +1,37 @@
+{% block stepper_stylesheet %}
+    <link rel="stylesheet" href="{{ asset('bundles/sonatabasket/css/stepper.css') }}" type="text/css" media="all" />
+{% endblock %}
+
+{% block stepper_content %}
+    <ul class="stepper hidden-xs">
+        <li{% if 'basket' == step %} class="active"{% endif %}>
+            <div class="img-circle">1</div>
+            <p>{{ 'basket_stepper_basket_title'|trans({}, 'SonataBasketBundle') }}</p>
+            <hr />
+        </li>
+
+        <li{% if 'identification' == step %} class="active"{% endif %}>
+            <div class="img-circle">2</div>
+            <p>{{ 'basket_stepper_identification_title'|trans({}, 'SonataBasketBundle') }}</p>
+            <hr />
+        </li>
+
+        <li{% if 'delivery' == step %} class="active"{% endif %}>
+            <div class="img-circle">3</div>
+            <p>{{ 'basket_stepper_delivery_title'|trans({}, 'SonataBasketBundle') }}</p>
+            <hr />
+        </li>
+
+        <li{% if 'billing' == step %} class="active"{% endif %}>
+            <div class="img-circle">4</div>
+            <p>{{ 'basket_stepper_billing_title'|trans({}, 'SonataBasketBundle') }}</p>
+            <hr />
+        </li>
+
+        <li{% if 'checkout' == step %} class="active"{% endif %}>
+            <div class="img-circle">5</div>
+            <p>{{ 'basket_stepper_checkout_title'|trans({}, 'SonataBasketBundle') }}</p>
+            <hr />
+        </li>
+    </ul>
+{% endblock %}

--- a/src/Sonata/ProductBundle/Resources/views/Product/final_review_basket_element.html.twig
+++ b/src/Sonata/ProductBundle/Resources/views/Product/final_review_basket_element.html.twig
@@ -11,10 +11,21 @@ file that was distributed with this source code.
 
 <tr>
     <td>
-        {% block product_description %}
-            <b>{{ basketElement.name }}</b> <br />
-            {{ basketElement.product.description|raw }}
-        {% endblock %}
+        <div class="col-sm-4 hidden-xs">
+            {% block product_thumbnail %}
+                {% thumbnail basketElement.product.image, 'preview' with {'itemprop':'image', 'class': 'img-rounded img-responsive'} %}
+            {% endblock %}
+        </div>
+        <div class="col-sm-8">
+            {% block product_name %}
+                <strong><a href="{{ url('sonata_product_view', {'productId': basketElement.product.id, 'slug': basketElement.product.slug}) }}">{{ basketElement.name }}</a></strong>
+            {% endblock %}
+            {% block product_sku %}
+                <p>{{ 'sonata.product.sku'|trans([], 'SonataProductBundle') }}: {{ basketElement.product.sku }}</p>
+            {% endblock %}
+            {% block product_description %}{% endblock %}
+            {% block product_variations %}{% endblock %}
+        </div>
     </td>
     <td class="number">
         {% block product_unit_price %}


### PR DESCRIPTION
I have added a checkout stepper and updated final review template page.

Stepper looks this like:

![capture decran 2014-02-05 a 13 58 42](https://f.cloud.github.com/assets/103900/2087122/a1dd80e0-8e65-11e3-98ca-64b55f5b2f79.png)

New final review template looks like this:

![capture decran 2014-02-05 a 13 59 47](https://f.cloud.github.com/assets/103900/2087124/aa5c18bc-8e65-11e3-8fcf-bca67599c832.png)
