### PR TITLE
SONATA-447 - Add VAT amounts display in basket, order and invoice tables

### DIFF
--- a/src/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
+++ b/src/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
@@ -278,6 +278,10 @@
                 <source>header_basket_total</source>
                 <target>Total</target>
             </trans-unit>
+            <trans-unit id="footer_basket_vat">
+                <source>footer_basket_vat</source>
+                <target>VAT</target>
+            </trans-unit>
             <trans-unit id="footer_basket_total_excl">
                 <source>footer_basket_total_excl</source>
                 <target>Total excl. VAT</target>

--- a/src/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
+++ b/src/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
@@ -278,6 +278,10 @@
                 <source>header_basket_total</source>
                 <target>Total</target>
             </trans-unit>
+            <trans-unit id="footer_basket_vat">
+                <source>footer_basket_vat</source>
+                <target>TVA</target>
+            </trans-unit>
             <trans-unit id="footer_basket_total_excl">
                 <source>footer_basket_total_excl</source>
                 <target>Total HT</target>

--- a/src/BasketBundle/Resources/views/Basket/final_review_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/final_review_step.html.twig
@@ -43,7 +43,7 @@ file that was distributed with this source code.
 
     <tfoot>
         <tr>
-            <td colspan="2" rowspan="3"></td>
+            <td colspan="2" rowspan="{{ 3 + basket.getVatAmounts|length }}"></td>
             <th style="text-align: right">{{ 'sonata.basket.total_wo_vat'|trans({}, 'SonataBasketBundle') }}</th>
             <td class="number"><b>{{ basket.getTotal(false)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></td>
         </tr>
@@ -51,6 +51,12 @@ file that was distributed with this source code.
             <th style="text-align: right">{{ 'sonata.basket.total_vat'|trans({}, 'SonataBasketBundle') }}</th>
             <td class="number"><b>{{ basket.getVatAmount()|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></td>
         </tr>
+        {% for item in basket.getVatAmounts %}
+            <tr>
+                <th style="text-align: right"><small>{{ 'footer_basket_vat'|trans({}, 'SonataBasketBundle') }} {{ item.rate }}%</small></th>
+                <td class="number"><small><b>{{ item.amount|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></small></td>
+            </tr>
+        {% endfor %}
         <tr>
             <th style="text-align: right">{{ 'sonata.basket.total_w_vat'|trans({}, 'SonataBasketBundle') }}</th>
             <td class="number"><b>{{ basket.getTotal(true)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></td>

--- a/src/BasketBundle/Resources/views/Basket/index.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/index.html.twig
@@ -50,7 +50,7 @@ file that was distributed with this source code.
             </tbody>
             <tfoot>
                 <tr>
-                    <td colspan="3" rowspan="3"></td>
+                    <td colspan="3" rowspan="{{ 3 + basket.getVatAmounts|length }}"></td>
                     <th style="text-align: right">{% trans from 'SonataBasketBundle'%}footer_basket_total_excl{% endtrans %}</th>
                     <td colspan="2" class="number"><b>{{ basket.getTotal(false)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></td>
                 </tr>
@@ -58,6 +58,12 @@ file that was distributed with this source code.
                     <th style="text-align: right">{% trans from 'SonataBasketBundle'%}footer_basket_total_vat{% endtrans %}</th>
                     <td colspan="2" class="number"><b>{{ basket.getVatAmount()|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></td>
                 </tr>
+                {% for item in basket.getVatAmounts %}
+                    <tr>
+                        <th style="text-align: right"><small>{{ 'footer_basket_vat'|trans({}, 'SonataBasketBundle') }} {{ item.rate }}%</small></th>
+                        <td colspan="2" class="number"><small><b>{{ item.amount|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></small></td>
+                    </tr>
+                {% endfor %}
                 <tr>
                     <th style="text-align: right">{% trans from 'SonataBasketBundle'%}footer_basket_total_inc{% endtrans %}</th>
                     <td colspan="2" class="number"><b>{{ basket.getTotal(true)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}</b></td>

--- a/src/Component/Basket/Basket.php
+++ b/src/Component/Basket/Basket.php
@@ -461,6 +461,29 @@ class Basket implements \Serializable, BasketInterface
     /**
      * {@inheritdoc}
      */
+    public function getVatAmounts()
+    {
+        $amounts = array();
+
+        foreach ($this->getBasketElements() as $basketElement) {
+            $rate = $basketElement->getVatRate();
+
+            if (isset($amounts[$rate])) {
+                $amounts[$rate]['amount'] = bcadd($amounts[$rate]['amount'], $basketElement->getVatAmount());
+            } else {
+                $amounts[$rate] = array(
+                    'rate' => $rate,
+                    'amount' => $basketElement->getVatAmount()
+                );
+            }
+        }
+
+        return $amounts;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDeliveryPrice($vat = false)
     {
         $method = $this->getDeliveryMethod();

--- a/src/Component/Basket/BasketInterface.php
+++ b/src/Component/Basket/BasketInterface.php
@@ -208,11 +208,18 @@ interface BasketInterface
     public function getTotal($vat = false, $recurrentOnly = null);
 
     /**
-     * return the VAT of the current basket
+     * Returns the VAT of the current basket
      *
      * @return float
      */
     public function getVatAmount();
+
+    /**
+     * Returns an array with all VAT amounts of the current basket
+     *
+     * @return array
+     */
+    public function getVatAmounts();
 
     /**
      * return the Delivery price

--- a/src/Component/Transformer/InvoiceTransformer.php
+++ b/src/Component/Transformer/InvoiceTransformer.php
@@ -126,12 +126,12 @@ class InvoiceTransformer extends BaseTransformer
         $invoice->setOrderElement($orderElement);
         $invoice->setDescription($orderElement->getDescription());
         $invoice->setDesignation($orderElement->getDesignation());
-        $invoice->setPrice($orderElement->getPrice(true));
-        $invoice->setUnitPrice($orderElement->getUnitPrice(true));
-        $invoice->setPriceIncludingVat($orderElement->isPriceIncludingVat());
+        $invoice->setPrice($orderElement->getPrice(false));
+        $invoice->setUnitPrice($orderElement->getUnitPrice(false));
+        $invoice->setPriceIncludingVat(false);
         $invoice->setVatRate($orderElement->getVatRate());
         $invoice->setQuantity($orderElement->getQuantity());
-        $invoice->setTotal($orderElement->getTotal(true));
+        $invoice->setTotal($orderElement->getTotal(false));
 
         return $invoice;
     }

--- a/src/InvoiceBundle/Entity/BaseInvoice.php
+++ b/src/InvoiceBundle/Entity/BaseInvoice.php
@@ -321,6 +321,31 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
+     * Returns all VAT amounts contained in elements
+     *
+     * @return array
+     */
+    public function getVatAmounts()
+    {
+        $amounts = array();
+
+        foreach ($this->getInvoiceElements() as $invoiceElement) {
+            $rate = $invoiceElement->getVatRate();
+
+            if (isset($amounts[$rate])) {
+                $amounts[$rate]['amount'] = bcadd($amounts[$rate]['amount'], $invoiceElement->getVatAmount());
+            } else {
+                $amounts[$rate] = array(
+                    'rate' => $rate,
+                    'amount' => $invoiceElement->getVatAmount()
+                );
+            }
+        }
+
+        return $amounts;
+    }
+
+    /**
      * Set name
      *
      * @param string $name

--- a/src/InvoiceBundle/Entity/BaseInvoiceElement.php
+++ b/src/InvoiceBundle/Entity/BaseInvoiceElement.php
@@ -238,6 +238,16 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
+     * Returns VAT element amount
+     *
+     * @return float
+     */
+    public function getVatAmount()
+    {
+        return bcsub($this->getTotal(true), $this->getTotal(false));
+    }
+
+    /**
      * Set designation
      *
      * @param string $designation

--- a/src/InvoiceBundle/Resources/config/doctrine/BaseInvoiceElement.orm.xml
+++ b/src/InvoiceBundle/Resources/config/doctrine/BaseInvoiceElement.orm.xml
@@ -5,6 +5,7 @@
         <field name="quantity"          type="integer"  column="quantity"/>
         <field name="unitPrice"         type="decimal"  column="unit_price"         scale="4"/>
         <field name="price"             type="decimal"  column="price"              scale="4"/>
+        <field name="priceIncludingVat" type="boolean"  column="price_inc_vat" />
         <field name="vatRate"           type="decimal"  column="vat_rate"           scale="4"/>
         <field name="total"             type="decimal"  column="total"              scale="4"/>
         <field name="designation"       type="string"   column="designation"        length="255"/>

--- a/src/InvoiceBundle/Resources/translations/SonataInvoiceBundle.en.xliff
+++ b/src/InvoiceBundle/Resources/translations/SonataInvoiceBundle.en.xliff
@@ -209,6 +209,10 @@
                 <source>sonata.invoice.total_inc_vat</source>
                 <target>Total incl. VAT</target>
             </trans-unit>
+            <trans-unit id="sonata_invoice_view_vat">
+                <source>sonata_invoice_view_vat</source>
+                <target>VAT</target>
+            </trans-unit>
             <!-- End - Invoice View -->
             <!-- Begin - Invoice page titles translations -->
             <trans-unit id="invoice_view_title">

--- a/src/InvoiceBundle/Resources/translations/SonataInvoiceBundle.fr.xliff
+++ b/src/InvoiceBundle/Resources/translations/SonataInvoiceBundle.fr.xliff
@@ -205,6 +205,10 @@
                 <source>sonata.invoice.vat</source>
                 <target>Total TVA</target>
             </trans-unit>
+            <trans-unit id="sonata_invoice_view_vat">
+                <source>sonata_invoice_view_vat</source>
+                <target>TVA</target>
+            </trans-unit>
             <trans-unit id="sonata.invoice.total_inc_vat">
                 <source>sonata.invoice.total_inc_vat</source>
                 <target>Total TTC</target>

--- a/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
@@ -101,7 +101,7 @@ file that was distributed with this source code.
 
                     {% block sonata_invoice_elements_sumup %}
                     <tr>
-                        <td colspan="2" rowspan="4">&nbsp;</td>
+                        <td colspan="2" rowspan="{{ 4 + invoice.getVatAmounts|length }}">&nbsp;</td>
                         <th style="text-align: right">{% trans from 'SonataOrderBundle' %}sonata.order.view.delivery{% endtrans %}</th>
                         <td class="number">{{ order.deliveryCost|number_format_currency(order.currency.label, {}, {}, invoice.locale) }}</td>
                     </tr>
@@ -115,6 +115,13 @@ file that was distributed with this source code.
                         <th style="text-align: right">{% trans from 'SonataInvoiceBundle' %}sonata.invoice.vat{% endtrans %}</th>
                         <td class="number">{{ (invoice.totalInc - invoice.totalExcl)|number_format_currency(invoice.currency, {}, {}, invoice.locale) }}</td>
                     </tr>
+
+                    {% for item in invoice.getVatAmounts %}
+                        <tr>
+                            <th style="text-align: right"><small>{% trans from 'SonataInvoiceBundle' %}sonata_invoice_view_vat{% endtrans %} {{ item.rate|number_format(2) }}%</small></th>
+                            <td class="number"><small><b>{{ item.amount|number_format_currency(invoice.currency.label, {}, {}, invoice.locale) }}</b></small></td>
+                        </tr>
+                    {% endfor %}
 
                     <tr>
                         <th style="text-align: right">{% trans from 'SonataInvoiceBundle' %}sonata.invoice.total_inc_vat{% endtrans %}</th>

--- a/src/OrderBundle/Entity/BaseOrder.php
+++ b/src/OrderBundle/Entity/BaseOrder.php
@@ -1047,4 +1047,29 @@ abstract class BaseOrder implements OrderInterface
     {
         return bcsub($this->totalInc, $this->totalExcl);
     }
+
+    /**
+     * Returns all VAT amounts contained in elements
+     *
+     * @return array
+     */
+    public function getVatAmounts()
+    {
+        $amounts = array();
+
+        foreach ($this->getOrderElements() as $orderElement) {
+            $rate = $orderElement->getVatRate();
+
+            if (isset($amounts[$rate])) {
+                $amounts[$rate]['amount'] = bcadd($amounts[$rate]['amount'], $orderElement->getVatAmount());
+            } else {
+                $amounts[$rate] = array(
+                    'rate' => $rate,
+                    'amount' => $orderElement->getVatAmount()
+                );
+            }
+        }
+
+        return $amounts;
+    }
 }

--- a/src/OrderBundle/Entity/BaseOrderElement.php
+++ b/src/OrderBundle/Entity/BaseOrderElement.php
@@ -210,6 +210,16 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
+     * Returns VAT element amount
+     *
+     * @return float
+     */
+    public function getVatAmount()
+    {
+        return bcsub($this->getTotal(true), $this->getTotal(false));
+    }
+
+    /**
      * Set designation
      *
      * @param string $designation

--- a/src/OrderBundle/Resources/config/doctrine/BaseOrderElement.orm.xml
+++ b/src/OrderBundle/Resources/config/doctrine/BaseOrderElement.orm.xml
@@ -8,6 +8,7 @@
         <field name="quantity"          type="integer"      column="quantity"/>
         <field name="unitPrice"         type="decimal"      column="unit_price"     scale="4"/>
         <field name="price"             type="decimal"      column="price"          scale="4"/>
+        <field name="priceIncludingVat" type="boolean"      column="price_inc_vat" />
         <field name="vatRate"           type="decimal"      column="vat_rate"       scale="4"/>
         <field name="designation"       type="string"       column="designation"    length="255"/>
         <field name="description"       type="text"         column="description"    />

--- a/src/OrderBundle/Resources/translations/SonataOrderBundle.en.xliff
+++ b/src/OrderBundle/Resources/translations/SonataOrderBundle.en.xliff
@@ -479,6 +479,10 @@
                 <source>sonata.order.view.total_inc</source>
                 <target>Total inc. VAT</target>
             </trans-unit>
+            <trans-unit id="sonata_order_view_vat">
+                <source>sonata_order_view_vat</source>
+                <target>VAT</target>
+            </trans-unit>
             <trans-unit id="sonata.order.view_invoice">
                 <source>sonata.order.view_invoice</source>
                 <target>Your invoice</target>

--- a/src/OrderBundle/Resources/translations/SonataOrderBundle.fr.xliff
+++ b/src/OrderBundle/Resources/translations/SonataOrderBundle.fr.xliff
@@ -475,6 +475,10 @@
                 <source>sonata.order.view.total_vat</source>
                 <target>Total TVA</target>
             </trans-unit>
+            <trans-unit id="sonata_order_view_vat">
+                <source>sonata_order_view_vat</source>
+                <target>TVA</target>
+            </trans-unit>
             <trans-unit id="sonata.order.view.total_inc">
                 <source>sonata.order.view.total_inc</source>
                 <target>Total TTC</target>

--- a/src/OrderBundle/Resources/views/Order/view.html.twig
+++ b/src/OrderBundle/Resources/views/Order/view.html.twig
@@ -158,7 +158,7 @@ file that was distributed with this source code.
                     {% endfor %}
                     {% block sonata_order_elements_sumup %}
                         <tr>
-                            <td colspan="2" rowspan="4">&nbsp;</td>
+                            <td colspan="2" rowspan="{{ 4 + order.getVatAmounts|length }}">&nbsp;</td>
                             <th>{% trans from 'SonataOrderBundle' %}sonata.order.view.delivery{% endtrans %}</th>
                             <td class="number">{{ order.deliveryCost|number_format_currency(order.currency.label, {}, {}, order.locale) }}</td>
                         </tr>
@@ -170,6 +170,12 @@ file that was distributed with this source code.
                             <th>{% trans from 'SonataOrderBundle' %}sonata.order.view.total_vat{% endtrans %}</th>
                             <td class="number">{{ order.vat|number_format_currency(order.currency.label, {}, {}, order.locale) }}</td>
                         </tr>
+                        {% for item in order.getVatAmounts %}
+                            <tr>
+                                <th><small>{% trans from 'SonataOrderBundle' %}sonata_order_view_vat{% endtrans %} {{ item.rate|number_format(2) }}%</small></th>
+                                <td class="number"><small><b>{{ item.amount|number_format_currency(order.currency.label, {}, {}, order.locale) }}</b></small></td>
+                            </tr>
+                        {% endfor %}
                         <tr>
                             <th>{% trans from 'SonataOrderBundle' %}sonata.order.view.total_inc{% endtrans %}</th>
                             <td class="number">{{ order.totalInc|number_format_currency(order.currency.label, {}, {}, order.locale) }}</td>

--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -202,9 +202,9 @@ abstract class BaseProductProvider implements ProductProviderInterface
     {
         $orderElement = new $this->orderElementClassName;
         $orderElement->setQuantity($basketElement->getQuantity());
-        $orderElement->setUnitPrice($basketElement->getUnitPrice(true));
-        $orderElement->setPrice($basketElement->getPrice(true));
-        $orderElement->setPriceIncludingVat($basketElement->isPriceIncludingVat());
+        $orderElement->setUnitPrice($basketElement->getUnitPrice(false));
+        $orderElement->setPrice($basketElement->getPrice(false));
+        $orderElement->setPriceIncludingVat(false);
         $orderElement->setVatRate($basketElement->getVatRate());
         $orderElement->setDesignation($basketElement->getName());
         $orderElement->setProductType($this->getCode());

--- a/tests/BasketBundle/Entity/BaseBasketTest.php
+++ b/tests/BasketBundle/Entity/BaseBasketTest.php
@@ -76,4 +76,43 @@ class BaseBasketTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($basket->getBasketElements()));
         $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $basket->getBasketElements());
     }
+
+    public function testBasketElementsVatAmounts()
+    {
+        $basket = new BasketTest();
+
+        $pool = $this->getMockBuilder('Sonata\Component\Product\Pool')->disableOriginalConstructor()->getMock();
+        $pool->expects($this->any())->method('getProvider')->will($this->returnValue($this->getMock('Sonata\Component\Product\ProductProviderInterface')));
+
+        $basket->setProductPool($pool);
+
+        $element1 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
+        $element1->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element1->expects($this->any())->method('getVatRate')->will($this->returnValue(20));
+        $element1->expects($this->any())->method('getVatAmount')->will($this->returnValue(3));
+
+        $element2 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
+        $element2->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element2->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
+        $element2->expects($this->any())->method('getVatAmount')->will($this->returnValue(2));
+
+        $element3 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
+        $element3->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element3->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
+        $element3->expects($this->any())->method('getVatAmount')->will($this->returnValue(5));
+
+        $basket->setBasketElements(array($element1, $element2, $element3));
+
+        $items = $basket->getVatAmounts();
+
+        $this->assertTrue(is_array($items), 'Should return an array');
+
+        foreach ($items as $item) {
+            $this->assertArrayHasKey('rate', $item, 'Array items should contains a "rate" key');
+            $this->assertArrayHasKey('amount', $item, 'Array items should contains a "amount" key');
+
+            $this->assertTrue(in_array($item['rate'], array(10, 20)));
+            $this->assertTrue(in_array($item['amount'], array(7, 3)));
+        }
+    }
 }

--- a/tests/InvoiceBundle/Entity/BaseInvoiceTest.php
+++ b/tests/InvoiceBundle/Entity/BaseInvoiceTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Tests\InvoiceBundle\Entity;
+
+use Sonata\InvoiceBundle\Entity\BaseInvoice;
+
+class InvoiceTest extends BaseInvoice
+{
+    protected $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}
+
+/**
+ * Class BaseInvoiceTest
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BaseInvoiceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInvoiceElementsVatAmounts()
+    {
+        $invoice = new InvoiceTest();
+
+        $element1 = $this->getMockBuilder('Sonata\InvoiceBundle\Entity\BaseInvoiceElement')->getMock();
+        $element1->expects($this->any())->method('getVatRate')->will($this->returnValue(20));
+        $element1->expects($this->any())->method('getVatAmount')->will($this->returnValue(3));
+
+        $element2 = $this->getMockBuilder('Sonata\InvoiceBundle\Entity\BaseInvoiceElement')->getMock();
+        $element2->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
+        $element2->expects($this->any())->method('getVatAmount')->will($this->returnValue(2));
+
+        $element3 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
+        $element3->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element3->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
+        $element3->expects($this->any())->method('getVatAmount')->will($this->returnValue(5));
+
+        $invoice->setInvoiceElements(array($element1, $element2, $element3));
+
+        $items = $invoice->getVatAmounts();
+
+        $this->assertTrue(is_array($items), 'Should return an array');
+
+        foreach ($items as $item) {
+            $this->assertArrayHasKey('rate', $item, 'Array items should contains a "rate" key');
+            $this->assertArrayHasKey('amount', $item, 'Array items should contains a "amount" key');
+
+            $this->assertTrue(in_array($item['rate'], array(10, 20)));
+            $this->assertTrue(in_array($item['amount'], array(7, 3)));
+        }
+    }
+}

--- a/tests/OrderBundle/Entity/BaseOrderTest.php
+++ b/tests/OrderBundle/Entity/BaseOrderTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Tests\OrderBundle\Entity;
+
+use Sonata\OrderBundle\Entity\BaseOrder;
+
+class OrderTest extends BaseOrder
+{
+    protected $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}
+
+/**
+ * Class BaseOrderTest
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BaseOrderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOrderElementsVatAmounts()
+    {
+        $order = new OrderTest();
+
+        $element1 = $this->getMockBuilder('Sonata\OrderBundle\Entity\BaseOrderElement')->getMock();
+        $element1->expects($this->any())->method('getVatRate')->will($this->returnValue(20));
+        $element1->expects($this->any())->method('getVatAmount')->will($this->returnValue(3));
+
+        $element2 = $this->getMockBuilder('Sonata\OrderBundle\Entity\BaseOrderElement')->getMock();
+        $element2->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
+        $element2->expects($this->any())->method('getVatAmount')->will($this->returnValue(2));
+
+        $element3 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
+        $element3->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element3->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
+        $element3->expects($this->any())->method('getVatAmount')->will($this->returnValue(5));
+
+        $order->setOrderElements(array($element1, $element2, $element3));
+
+        $items = $order->getVatAmounts();
+
+        $this->assertTrue(is_array($items), 'Should return an array');
+
+        foreach ($items as $item) {
+            $this->assertArrayHasKey('rate', $item, 'Array items should contains a "rate" key');
+            $this->assertArrayHasKey('amount', $item, 'Array items should contains a "amount" key');
+
+            $this->assertTrue(in_array($item['rate'], array(10, 20)));
+            $this->assertTrue(in_array($item['amount'], array(7, 3)));
+        }
+    }
+}


### PR DESCRIPTION
I've added the display of different VAT rates and amount in basket, order and invoice views.

Here it how it looks like:

![capture-decran-2014-02-20-a-14 58 21](https://f.cloud.github.com/assets/103900/2219055/8dd455ca-9a3a-11e3-8657-fe9d9e96092d.png)
