### PR TITLE
Fix order & invoice elements prices to be stored excluding & including V...

### DIFF
--- a/src/Component/Basket/BasketElementInterface.php
+++ b/src/Component/Basket/BasketElementInterface.php
@@ -78,6 +78,27 @@ interface BasketElementInterface extends PriceComputableInterface
     public function getVatAmount();
 
     /**
+     * Sets product unit price
+     *
+     * @param float $unitPrice
+     */
+    public function setUnitPrice($unitPrice);
+
+    /**
+     * Sets if current price is including VAT
+     *
+     * @param float $priceIncludingVat
+     */
+    public function setPriceIncludingVat($priceIncludingVat);
+
+    /**
+     * Returns if price is including VAT
+     *
+     * @return boolean
+     */
+    public function isPriceIncludingVat();
+
+    /**
      * Return the total (price * quantity)
      *
      * if $vat = true, return the price with vat

--- a/src/Component/Invoice/InvoiceElementInterface.php
+++ b/src/Component/Invoice/InvoiceElementInterface.php
@@ -16,6 +16,34 @@ use Sonata\Component\Product\PriceComputableInterface;
 interface InvoiceElementInterface extends PriceComputableInterface
 {
     /**
+     * Sets unit price excluding VAT
+     *
+     * @param float $unitPriceExcl
+     */
+    public function setUnitPriceExcl($unitPriceExcl);
+
+    /**
+     * Returns unit price excluding VAT
+     *
+     * @return float
+     */
+    public function getUnitPriceExcl();
+
+    /**
+     * Sets unit price including VAT
+     *
+     * @param float $unitPriceInc
+     */
+    public function setUnitPriceInc($unitPriceInc);
+
+    /**
+     * Returns unit price including VAT
+     *
+     * @return float
+     */
+    public function getUnitPriceInc();
+
+    /**
      * Set invoiceId
      *
      * @param InvoiceInterface $invoice

--- a/src/Component/Product/PriceComputableInterface.php
+++ b/src/Component/Product/PriceComputableInterface.php
@@ -21,13 +21,6 @@ namespace Sonata\Component\Product;
 interface PriceComputableInterface
 {
     /**
-     * Sets unit price
-     *
-     * @param float $unitPrice
-     */
-    public function setUnitPrice($unitPrice);
-
-    /**
      * Returns the unit price
      *
      * if $vat = true, returns the unit price with vat
@@ -53,20 +46,6 @@ interface PriceComputableInterface
      * @return float
      */
     public function getPrice($vat = false);
-
-    /**
-     * Sets if price is including VAT
-     *
-     * @param boolean $priceIncludingVat
-     */
-    public function setPriceIncludingVat($priceIncludingVat);
-
-    /**
-     * Returns if price is including VAT
-     *
-     * @return boolean
-     */
-    public function isPriceIncludingVat();
 
     /**
      * Sets VAT rate

--- a/src/Component/Product/ProductInterface.php
+++ b/src/Component/Product/ProductInterface.php
@@ -125,6 +125,20 @@ interface ProductInterface extends PriceComputableInterface
     public function getStock();
 
     /**
+     * Sets if current price is including VAT
+     *
+     * @param float $priceIncludingVat
+     */
+    public function setPriceIncludingVat($priceIncludingVat);
+
+    /**
+     * Returns if price is including VAT
+     *
+     * @return boolean
+     */
+    public function isPriceIncludingVat();
+
+    /**
      * Set enabled.
      *
      * @param boolean $enabled

--- a/src/Component/Transformer/InvoiceTransformer.php
+++ b/src/Component/Transformer/InvoiceTransformer.php
@@ -102,7 +102,8 @@ class InvoiceTransformer extends BaseTransformer
 
         $invoiceElement->setQuantity(1);
         $invoiceElement->setPrice($order->getDeliveryCost());
-        $invoiceElement->setUnitPrice($order->getDeliveryCost());
+        $invoiceElement->setUnitPriceExcl($order->getDeliveryCost());
+        $invoiceElement->setUnitPriceInc($order->getDeliveryCost());
         $invoiceElement->setTotal($order->getDeliveryCost());
         $invoiceElement->setVatRate(0);
 
@@ -126,12 +127,12 @@ class InvoiceTransformer extends BaseTransformer
         $invoice->setOrderElement($orderElement);
         $invoice->setDescription($orderElement->getDescription());
         $invoice->setDesignation($orderElement->getDesignation());
-        $invoice->setPrice($orderElement->getPrice(false));
-        $invoice->setUnitPrice($orderElement->getUnitPrice(false));
-        $invoice->setPriceIncludingVat(false);
+        $invoice->setPrice($orderElement->getPrice(true));
+        $invoice->setUnitPriceExcl($orderElement->getUnitPrice(false));
+        $invoice->setUnitPriceInc($orderElement->getUnitPrice(true));
         $invoice->setVatRate($orderElement->getVatRate());
         $invoice->setQuantity($orderElement->getQuantity());
-        $invoice->setTotal($orderElement->getTotal(false));
+        $invoice->setTotal($orderElement->getTotal(true));
 
         return $invoice;
     }

--- a/src/InvoiceBundle/Entity/BaseInvoiceElement.php
+++ b/src/InvoiceBundle/Entity/BaseInvoiceElement.php
@@ -40,14 +40,14 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     protected $price;
 
     /**
-     * @var float $unitPrice
+     * @var float $unitPriceExcl
      */
-    protected $unitPrice;
+    protected $unitPriceExcl;
 
     /**
-     * @var boolean
+     * @var float $unitPriceInc
      */
-    protected $priceIncludingVat;
+    protected $unitPriceInc;
 
     /**
      * @var float $vatRate
@@ -138,33 +138,13 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
      */
     public function getPrice($vat = false)
     {
-        $price = $this->price;
+        $unitPrice = $this->getUnitPriceExcl();
 
-        if (!$vat && true === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcsub(1, bcdiv($this->getVatRate(), 100)));
+        if ($vat) {
+            $unitPrice = $this->getUnitPriceInc();
         }
 
-        if ($vat && false === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcadd(1, bcdiv($this->getVatRate(), 100)));
-        }
-
-        return $price;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setPriceIncludingVat($priceIncludingVat)
-    {
-        $this->priceIncludingVat = $priceIncludingVat;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isPriceIncludingVat()
-    {
-        return $this->priceIncludingVat;
+        return bcmul($unitPrice, $this->getQuantity());
     }
 
     /**
@@ -196,9 +176,33 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     /**
      * {@inheritdoc}
      */
-    public function setUnitPrice($unitPrice)
+    public function setUnitPriceExcl($unitPriceExcl)
     {
-        $this->unitPrice = $unitPrice;
+        $this->unitPriceExcl = $unitPriceExcl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnitPriceExcl()
+    {
+        return $this->unitPriceExcl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUnitPriceInc($unitPriceInc)
+    {
+        $this->unitPriceInc = $unitPriceInc;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnitPriceInc()
+    {
+        return $this->unitPriceInc;
     }
 
     /**
@@ -206,17 +210,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
      */
     public function getUnitPrice($vat = false)
     {
-        $price = $this->unitPrice;
-
-        if (!$vat && true === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcsub(1, bcdiv($this->getVatRate(), 100)));
-        }
-
-        if ($vat && false === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcadd(1, bcdiv($this->getVatRate(), 100)));
-        }
-
-        return $price;
+        return $vat ? $this->getUnitPriceInc() : $this->getUnitPriceExcl();
     }
 
     /**
@@ -228,13 +222,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
      */
     public function getTotal($vat = true)
     {
-        $total = $this->total;
-
-        if (!$vat) {
-            $total = bcmul($total, bcsub(1, bcdiv($this->getVatRate(), 100)));
-        }
-
-        return $total;
+        return bcmul($this->getUnitPrice($vat), $this->getQuantity());
     }
 
     /**

--- a/src/InvoiceBundle/Resources/config/doctrine/BaseInvoiceElement.orm.xml
+++ b/src/InvoiceBundle/Resources/config/doctrine/BaseInvoiceElement.orm.xml
@@ -3,9 +3,9 @@
     <mapped-superclass name="Sonata\InvoiceBundle\Entity\BaseInvoiceElement">
 
         <field name="quantity"          type="integer"  column="quantity"/>
-        <field name="unitPrice"         type="decimal"  column="unit_price"         scale="4"/>
+        <field name="unitPriceExcl"     type="decimal"  column="unit_price_excl"    scale="4"/>
+        <field name="unitPriceInc"      type="decimal"  column="unit_price_inc"     scale="4"/>
         <field name="price"             type="decimal"  column="price"              scale="4"/>
-        <field name="priceIncludingVat" type="boolean"  column="price_inc_vat"      nullable="true" />
         <field name="vatRate"           type="decimal"  column="vat_rate"           scale="4"/>
         <field name="total"             type="decimal"  column="total"              scale="4"/>
         <field name="designation"       type="string"   column="designation"        length="255"/>

--- a/src/OrderBundle/Entity/BaseOrderElement.php
+++ b/src/OrderBundle/Entity/BaseOrderElement.php
@@ -30,14 +30,14 @@ abstract class BaseOrderElement implements OrderElementInterface
     protected $price;
 
     /**
-     * @var float $unitPrice
+     * @var float $unitPriceExcl
      */
-    protected $unitPrice;
+    protected $unitPriceExcl;
 
     /**
-     * @var boolean
+     * @var float $unitPriceInc
      */
-    protected $priceIncludingVat;
+    protected $unitPriceInc;
 
     /**
      * @var float $vatRate
@@ -164,33 +164,13 @@ abstract class BaseOrderElement implements OrderElementInterface
      */
     public function getPrice($vat = false)
     {
-        $price = $this->price;
+        $unitPrice = $this->getUnitPriceExcl();
 
-        if (!$vat && true === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcsub(1, bcdiv($this->getVatRate(), 100)));
+        if ($vat) {
+            $unitPrice = $this->getUnitPriceInc();
         }
 
-        if ($vat && false === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcadd(1, bcdiv($this->getVatRate(), 100)));
-        }
-
-        return $price;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setPriceIncludingVat($priceIncludingVat)
-    {
-        $this->priceIncludingVat = $priceIncludingVat;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isPriceIncludingVat()
-    {
-        return $this->priceIncludingVat;
+        return bcmul($unitPrice, $this->getQuantity());
     }
 
     /**
@@ -595,11 +575,43 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Sets unit price excluding VAT
+     *
+     * @param float $unitPriceExcl
      */
-    public function setUnitPrice($unitPrice)
+    public function setUnitPriceExcl($unitPriceExcl)
     {
-        $this->unitPrice = $unitPrice;
+        $this->unitPriceExcl = $unitPriceExcl;
+    }
+
+    /**
+     * Returns unit price including VAT
+     *
+     * @return float
+     */
+    public function getUnitPriceExcl()
+    {
+        return $this->unitPriceExcl;
+    }
+
+    /**
+     * Sets unit price including VAT
+     *
+     * @param float $unitPriceInc
+     */
+    public function setUnitPriceInc($unitPriceInc)
+    {
+        $this->unitPriceInc = $unitPriceInc;
+    }
+
+    /**
+     * Returns unit price including VAT
+     *
+     * @return float
+     */
+    public function getUnitPriceInc()
+    {
+        return $this->unitPriceInc;
     }
 
     /**
@@ -607,17 +619,7 @@ abstract class BaseOrderElement implements OrderElementInterface
      */
     public function getUnitPrice($vat = false)
     {
-        $price = $this->unitPrice;
-
-        if (!$vat && true === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcsub(1, bcdiv($this->getVatRate(), 100)));
-        }
-
-        if ($vat && false === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcadd(1, bcdiv($this->getVatRate(), 100)));
-        }
-
-        return $price;
+        return $vat ? $this->getUnitPriceInc() : $this->getUnitPriceExcl();
     }
 
     /**

--- a/src/OrderBundle/Resources/config/doctrine/BaseOrderElement.orm.xml
+++ b/src/OrderBundle/Resources/config/doctrine/BaseOrderElement.orm.xml
@@ -6,17 +6,17 @@
         <field name="productType"       type="string"       column="product_type"          length="255"/>
 
         <field name="quantity"          type="integer"      column="quantity"/>
-        <field name="unitPrice"         type="decimal"      column="unit_price"     scale="4"/>
-        <field name="price"             type="decimal"      column="price"          scale="4"/>
-        <field name="priceIncludingVat" type="boolean"      column="price_inc_vat"  nullable="true" />
-        <field name="vatRate"           type="decimal"      column="vat_rate"       scale="4"/>
-        <field name="designation"       type="string"       column="designation"    length="255"/>
+        <field name="unitPriceExcl"     type="decimal"      column="unit_price_excl" scale="4"/>
+        <field name="unitPriceInc"      type="decimal"      column="unit_price_inc"  scale="4"/>
+        <field name="price"             type="decimal"      column="price"           scale="4"/>
+        <field name="vatRate"           type="decimal"      column="vat_rate"        scale="4"/>
+        <field name="designation"       type="string"       column="designation"     length="255"/>
         <field name="description"       type="text"         column="description"    />
-        <field name="options"           type="json"         column="options"          nullable="true"/>
-        <field name="rawProduct"        type="json"         column="raw_product"      nullable="true"/>
+        <field name="options"           type="json"         column="options"         nullable="true"/>
+        <field name="rawProduct"        type="json"         column="raw_product"     nullable="true"/>
         <field name="status"            type="integer"      column="status"/>
         <field name="deliveryStatus"    type="integer"      column="delivery_status"/>
-        <field name="validatedAt"       type="datetime"     column="validated_at" nullable="true"/>
+        <field name="validatedAt"       type="datetime"     column="validated_at"    nullable="true"/>
 
         <field name="updatedAt"  nullable="true"  column="updated_at"     type="datetime" />
         <field name="createdAt"  nullable="true"  column="created_at"     type="datetime" />

--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -202,9 +202,9 @@ abstract class BaseProductProvider implements ProductProviderInterface
     {
         $orderElement = new $this->orderElementClassName;
         $orderElement->setQuantity($basketElement->getQuantity());
-        $orderElement->setUnitPrice($basketElement->getUnitPrice(false));
-        $orderElement->setPrice($basketElement->getPrice(false));
-        $orderElement->setPriceIncludingVat(false);
+        $orderElement->setUnitPriceExcl($basketElement->getUnitPrice(false));
+        $orderElement->setUnitPriceInc($basketElement->getUnitPrice(true));
+        $orderElement->setPrice($basketElement->getPrice(true));
         $orderElement->setVatRate($basketElement->getVatRate());
         $orderElement->setDesignation($basketElement->getName());
         $orderElement->setProductType($this->getCode());


### PR DESCRIPTION
I've updated order & invoice elements prices to be stored into two separated fields: `unitPriceExcl` and `unitPriceInc` whereas a simple `unitPrice` which we don't know explicitly if it stores unit price excluding or including VAT.
This will also avoid VAT calculations in orders & invoices as they are already done in basket prices computations.
