### PR TITLE
Add POST, PUT and DELETE methods for customers

### DIFF
--- a/src/CustomerBundle/Controller/Api/AddressController.php
+++ b/src/CustomerBundle/Controller/Api/AddressController.php
@@ -1,0 +1,186 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Sonata\CustomerBundle\Controller\Api;
+
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\Controller\Annotations\QueryParam;
+use FOS\RestBundle\Controller\Annotations\View;
+
+use JMS\Serializer\SerializationContext;
+
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Customer\AddressManagerInterface;
+use Sonata\Component\Customer\CustomerElementInterface;
+
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class AddressController
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class AddressController
+{
+    /**
+     * @var AddressManagerInterface
+     */
+    protected $addressManager;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * Constructor
+     *
+     * @param AddressManagerInterface  $addressManager
+     * @param FormFactoryInterface     $formFactory
+     */
+    public function __construct(AddressManagerInterface $addressManager, FormFactoryInterface $formFactory)
+    {
+        $this->addressManager  = $addressManager;
+        $this->formFactory     = $formFactory;
+    }
+
+    /**
+     * Retrieves a specific address
+     *
+     * @ApiDoc(
+     *  resource=true,
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="address id"}
+     *  },
+     *  output={"class"="Sonata\Component\Customer\AddressInterface", "groups"="sonata_api_read"},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      404="Returned when address is not found"
+     *  }
+     * )
+     *
+     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     *
+     * @param $id
+     *
+     * @return AddressInterface
+     */
+    public function getAddressAction($id)
+    {
+        return $this->getAddress($id);
+    }
+
+    /**
+     * Updates an address
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="address id"}
+     *  },
+     *  input={"class"="sonata_customer_api_form_address", "name"="", "groups"={"sonata_api_write"}},
+     *  output={"class"="Sonata\CustomerBundle\Model\Address", "groups"={"sonata_api_read"}},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      400="Returned when an error has occurred while address creation",
+     *  }
+     * )
+     *
+     * @param integer $id      An Address identifier
+     * @param Request $request A Symfony request
+     *
+     * @return Address
+     *
+     * @throws NotFoundHttpException
+     */
+    public function putAddressAction($id, Request $request)
+    {
+        $address = $this->getAddress($id);
+
+        $form = $this->formFactory->createNamed(null, 'sonata_customer_api_form_address', $address, array(
+            'csrf_protection' => false
+        ));
+
+        $form->bind($request);
+
+        if ($form->isValid()) {
+            $address = $form->getData();
+
+            $this->addressManager->save($address);
+
+            $view = \FOS\RestBundle\View\View::create($address);
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups(array('sonata_api_read'));
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+
+            return $view;
+        }
+
+        return $form;
+    }
+
+    /**
+     * Deletes an address
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="address identifier"}
+     *  },
+     *  statusCodes={
+     *      200="Returned when customer is successfully deleted",
+     *      400="Returned when an error has occurred while address deletion",
+     *      404="Returned when unable to find address"
+     *  }
+     * )
+     *
+     * @param integer $id An Address identifier
+     *
+     * @return \FOS\RestBundle\View\View
+     *
+     * @throws NotFoundHttpException
+     */
+    public function deleteAddressAction($id)
+    {
+        $address = $this->getAddress($id);
+
+        try {
+            $this->addressManager->delete($address);
+        } catch (\Exception $e) {
+            return \FOS\RestBundle\View\View::create(array('error' => $e->getMessage()), 400);
+        }
+
+        return array('deleted' => true);
+    }
+
+    /**
+     * Retrieves address with id $id or throws an exception if it doesn't exist
+     *
+     * @param integer $id
+     *
+     * @return AddressInterface
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    protected function getAddress($id)
+    {
+        $address = $this->addressManager->findOneBy(array('id' => $id));
+
+        if (null === $address) {
+            throw new NotFoundHttpException(sprintf('Address (%d) not found', $id));
+        }
+
+        return $address;
+    }
+}

--- a/src/CustomerBundle/Controller/Api/CustomerController.php
+++ b/src/CustomerBundle/Controller/Api/CustomerController.php
@@ -11,19 +11,25 @@
 
 namespace Sonata\CustomerBundle\Controller\Api;
 
-use Sonata\Component\Customer\AddressInterface;
-use Sonata\Component\Customer\CustomerElementInterface;
-use Sonata\Component\Customer\CustomerInterface;
-use Sonata\Component\Customer\CustomerManagerInterface;
-
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
+
+use JMS\Serializer\SerializationContext;
+
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Customer\AddressManagerInterface;
+use Sonata\Component\Customer\CustomerElementInterface;
+use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Customer\CustomerManagerInterface;
 use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Order\OrderManagerInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class CustomerController
@@ -35,6 +41,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class CustomerController
 {
     /**
+     * @var AddressManagerInterface
+     */
+    protected $addressManager;
+
+    /**
      * @var \Sonata\Component\Customer\CustomerManagerInterface
      */
     protected $customerManager;
@@ -45,15 +56,24 @@ class CustomerController
     protected $orderManager;
 
     /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
      * Constructor
      *
      * @param CustomerManagerInterface $customerManager
      * @param OrderManagerInterface    $orderManager
+     * @param AddressManagerInterface  $addressManager
+     * @param FormFactoryInterface     $formFactory
      */
-    public function __construct(CustomerManagerInterface $customerManager, OrderManagerInterface $orderManager)
+    public function __construct(CustomerManagerInterface $customerManager, OrderManagerInterface $orderManager, AddressManagerInterface $addressManager, FormFactoryInterface $formFactory)
     {
         $this->customerManager = $customerManager;
         $this->orderManager    = $orderManager;
+        $this->addressManager  = $addressManager;
+        $this->formFactory     = $formFactory;
     }
 
     /**
@@ -120,6 +140,124 @@ class CustomerController
     }
 
     /**
+     * Adds a customer
+     *
+     * @ApiDoc(
+     *  input={"class"="sonata_customer_api_form_customer", "name"="", "groups"={"sonata_api_write"}},
+     *  output={"class"="Sonata\CustomerBundle\Model\Customer", "groups"={"sonata_api_read"}},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      400="Returned when an error has occurred while customer creation",
+     *  }
+     * )
+     *
+     * @param Request $request A Symfony request
+     *
+     * @return Customer
+     *
+     * @throws NotFoundHttpException
+     */
+    public function postCustomerAction(Request $request)
+    {
+        return $this->handleWriteCustomer($request);
+    }
+
+    /**
+     * Updates a customer
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="customer identifier"}
+     *  },
+     *  input={"class"="sonata_customer_api_form_customer", "name"="", "groups"={"sonata_api_write"}},
+     *  output={"class"="Sonata\CustomerBundle\Model\Customer", "groups"={"sonata_api_read"}},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      400="Returned when an error has occurred while customer update",
+     *      404="Returned when unable to find customer"
+     *  }
+     * )
+     *
+     * @param integer $id      A Customer identifier
+     * @param Request $request A Symfony request
+     *
+     * @return Customer
+     *
+     * @throws NotFoundHttpException
+     */
+    public function putCustomerAction($id, Request $request)
+    {
+        return $this->handleWriteCustomer($request, $id);
+    }
+
+    /**
+     * Write a customer, this method is used by both POST and PUT action methods
+     *
+     * @param Request      $request Symfony request
+     * @param integer|null $id      A customer identifier
+     *
+     * @return \FOS\RestBundle\View\View|FormInterface
+     */
+    protected function handleWriteCustomer($request, $id = null)
+    {
+        $customer = $id ? $this->getCustomer($id) : null;
+
+        $form = $this->formFactory->createNamed(null, 'sonata_customer_api_form_customer', $customer, array(
+            'csrf_protection' => false
+        ));
+
+        $form->bind($request);
+
+        if ($form->isValid()) {
+            $customer = $form->getData();
+            $this->customerManager->save($customer);
+
+            $view = \FOS\RestBundle\View\View::create($customer);
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups(array('sonata_api_read'));
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+
+            return $view;
+        }
+
+        return $form;
+    }
+
+    /**
+     * Deletes a customer
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="customer identifier"}
+     *  },
+     *  statusCodes={
+     *      200="Returned when customer is successfully deleted",
+     *      400="Returned when an error has occurred while customer deletion",
+     *      404="Returned when unable to find customer"
+     *  }
+     * )
+     *
+     * @param integer $id A Customer identifier
+     *
+     * @return \FOS\RestBundle\View\View
+     *
+     * @throws NotFoundHttpException
+     */
+    public function deleteCustomerAction($id)
+    {
+        $customer = $this->getCustomer($id);
+
+        try {
+            $this->customerManager->delete($customer);
+        } catch (\Exception $e) {
+            return \FOS\RestBundle\View\View::create(array('error' => $e->getMessage()), 400);
+        }
+
+        return array('deleted' => true);
+    }
+
+    /**
      * Retrieves a specific customer's orders
      *
      * @ApiDoc(
@@ -168,6 +306,56 @@ class CustomerController
     public function getCustomerAddressesAction($id)
     {
         return $this->getCustomer($id)->getAddresses();
+    }
+
+    /**
+     * Adds a customer address
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="customer id"}
+     *  },
+     *  input={"class"="sonata_customer_api_form_address", "name"="", "groups"={"sonata_api_write"}},
+     *  output={"class"="Sonata\CustomerBundle\Model\Address", "groups"={"sonata_api_read"}},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      400="Returned when an error has occurred while address creation",
+     *  }
+     * )
+     *
+     * @param integer $id      A Customer identifier
+     * @param Request $request A Symfony request
+     *
+     * @return Address
+     *
+     * @throws NotFoundHttpException
+     */
+    public function postCustomerAddressAction($id, Request $request)
+    {
+        $customer = $id ? $this->getCustomer($id) : null;
+
+        $form = $this->formFactory->createNamed(null, 'sonata_customer_api_form_address', null, array(
+            'csrf_protection' => false
+        ));
+
+        $form->bind($request);
+
+        if ($form->isValid()) {
+            $address = $form->getData();
+            $address->setCustomer($customer);
+
+            $this->addressManager->save($address);
+
+            $view = \FOS\RestBundle\View\View::create($address);
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups(array('sonata_api_read'));
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+
+            return $view;
+        }
+
+        return $form;
     }
 
     /**

--- a/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
+++ b/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
@@ -48,6 +48,7 @@ class SonataCustomerExtension extends Extension
 
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_controllers.xml');
+            $loader->load('api_form.xml');
             $loader->load('serializer.xml');
         }
 

--- a/src/CustomerBundle/Resources/config/api_controllers.xml
+++ b/src/CustomerBundle/Resources/config/api_controllers.xml
@@ -5,9 +5,16 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="sonata.customer.controller.api.address" class="Sonata\CustomerBundle\Controller\Api\AddressController">
+            <argument type="service" id="sonata.address.manager" />
+            <argument type="service" id="form.factory" />
+        </service>
+
         <service id="sonata.customer.controller.api.customer" class="Sonata\CustomerBundle\Controller\Api\CustomerController">
             <argument type="service" id="sonata.customer.manager" />
             <argument type="service" id="sonata.order.manager" />
+            <argument type="service" id="sonata.address.manager" />
+            <argument type="service" id="form.factory" />
         </service>
     </services>
 </container>

--- a/src/CustomerBundle/Resources/config/api_form.xml
+++ b/src/CustomerBundle/Resources/config/api_form.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sonata.customer.api.form.type.customer" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+            <tag name="form.type" alias="sonata_customer_api_form_customer" />
+
+            <argument type="service" id="jms_serializer.metadata_factory" />
+            <argument type="service" id="doctrine" />
+            <argument>sonata_customer_api_form_customer</argument>
+            <argument>%sonata.customer.admin.customer.entity%</argument>
+            <argument>sonata_api_write</argument>
+        </service>
+
+        <service id="sonata.customer.api.form.type.address" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+            <tag name="form.type" alias="sonata_customer_api_form_address" />
+
+            <argument type="service" id="jms_serializer.metadata_factory" />
+            <argument type="service" id="doctrine" />
+            <argument>sonata_customer_api_form_address</argument>
+            <argument>%sonata.customer.admin.address.entity%</argument>
+            <argument>sonata_api_write</argument>
+        </service>
+    </services>
+</container>

--- a/src/CustomerBundle/Resources/config/routing/api.xml
+++ b/src/CustomerBundle/Resources/config/routing/api.xml
@@ -4,6 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
 
+    <import type="rest" resource="sonata.customer.controller.api.address" name-prefix="sonata_api_ecommerce_address_" />
     <import type="rest" resource="sonata.customer.controller.api.customer" name-prefix="sonata_api_ecommerce_customer_" />
 
 </routes>

--- a/tests/CustomerBundle/Controller/Api/AddressControllerTest.php
+++ b/tests/CustomerBundle/Controller/Api/AddressControllerTest.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Test\CustomerBundle\Controller\Api;
+
+use Sonata\CustomerBundle\Controller\Api\AddressController;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class AddressControllerTest
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class AddressControllerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetAddressAction()
+    {
+        $address = $this->getMock('Sonata\Component\Customer\AddressInterface');
+
+        $this->assertEquals($address, $this->createAddressController($address)->getAddressAction(1));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage Address (42) not found
+     */
+    public function testGetAddressActionNotFoundException()
+    {
+        $this->createAddressController()->getAddressAction(42);
+    }
+
+    public function testPutAddressAction()
+    {
+        $address = $this->getMock('Sonata\CustomerBundle\Model\AddressInterface');
+
+        $addressManager = $this->getMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
+        $addressManager->expects($this->once())->method('save')->will($this->returnValue($address));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($address));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createAddressController($address, $addressManager, $formFactory)->putAddressAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPutAddressInvalidAction()
+    {
+        $address = $this->getMock('Sonata\CustomerBundle\Model\AddressInterface');
+
+        $addressManager = $this->getMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
+        $addressManager->expects($this->never())->method('save')->will($this->returnValue($address));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createAddressController($address, $addressManager, $formFactory)->putAddressAction(1, new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testDeleteAddressAction()
+    {
+        $address = $this->getMock('Sonata\CustomerBundle\Model\AddressInterface');
+
+        $addressManager = $this->getMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
+        $addressManager->expects($this->once())->method('delete');
+
+        $view = $this->createAddressController($address, $addressManager)->deleteAddressAction(1);
+
+        $this->assertEquals(array('deleted' => true), $view);
+    }
+
+    public function testDeleteAddressInvalidAction()
+    {
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $addressManager = $this->getMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue(null));
+        $addressManager->expects($this->never())->method('delete');
+
+        $this->createAddressController(null, $addressManager)->deleteAddressAction(1);
+    }
+
+    /**
+     * Returns address controller
+     *
+     * @param \Sonata\Component\Customer\AddressInterface        $address
+     * @param \Sonata\Component\Customer\AddressManagerInterface $addressManager
+     * @param \Symfony\Component\Form\FormFactory                $formFactory
+     *
+     * @return AddressController
+     */
+    public function createAddressController($address = null, $addressManager = null, $formFactory = null)
+    {
+        if (null === $addressManager) {
+            $addressManager = $this->getMock('Sonata\Component\Customer\AddressManagerInterface');
+
+            if ($address) {
+                $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
+            }
+        }
+
+        if (null === $formFactory) {
+            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        }
+
+        return new AddressController($addressManager, $formFactory);
+    }
+}

--- a/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
+++ b/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\Test\CustomerBundle\Controller\Api;
 
 use Sonata\CustomerBundle\Controller\Api\CustomerController;
 
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class CustomerControllerTest
@@ -56,7 +57,7 @@ class CustomerControllerTest extends \PHPUnit_Framework_TestCase
         $customer = $this->getMock('Sonata\Component\Customer\CustomerInterface');
         $order    = $this->getMock('Sonata\Component\Order\OrderInterface');
 
-        $this->assertEquals(array($order), $this->createCustomerController($customer, null, $order)->getCustomerOrdersAction(1));
+        $this->assertEquals(array($order), $this->createCustomerController($customer, null, null, null, $order)->getCustomerOrdersAction(1));
     }
 
     public function testGetCustomerAddressesAction()
@@ -68,15 +69,164 @@ class CustomerControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($address), $this->createCustomerController($customer)->getCustomerAddressesAction(1));
     }
 
+    public function testPostCustomerAction()
+    {
+        $customer = $this->getMock('Sonata\CustomerBundle\Model\CustomerInterface');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager->expects($this->once())->method('save')->will($this->returnValue($customer));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($customer));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCustomerController(null, $customerManager, null, $formFactory)->postCustomerAction(new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPostCustomerInvalidAction()
+    {
+        $customer = $this->getMock('Sonata\CustomerBundle\Model\CustomerInterface');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager->expects($this->never())->method('save')->will($this->returnValue($customer));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCustomerController(null, $customerManager, null, $formFactory)->postCustomerAction(new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testPostCustomerAddressAction()
+    {
+        $customer = $this->getMock('Sonata\Component\Customer\CustomerInterface');
+        $address = $this->getMock('Sonata\Component\Customer\AddressInterface');
+        $address->expects($this->once())->method('setCustomer');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+
+        $addressManager = $this->getMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager->expects($this->once())->method('save')->will($this->returnValue($address));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($address));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCustomerController($customer, $customerManager, $addressManager, $formFactory)->postCustomerAddressAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPostCustomerAddressInvalidAction()
+    {
+        $customer = $this->getMock('Sonata\CustomerBundle\Model\CustomerInterface');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager->expects($this->never())->method('save')->will($this->returnValue($customer));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCustomerController(null, $customerManager, null, $formFactory)->postCustomerAction(new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testPutCustomerAction()
+    {
+        $customer = $this->getMock('Sonata\CustomerBundle\Model\CustomerInterface');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
+        $customerManager->expects($this->once())->method('save')->will($this->returnValue($customer));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($customer));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCustomerController($customer, $customerManager, null, $formFactory)->putCustomerAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPutCustomerInvalidAction()
+    {
+        $customer = $this->getMock('Sonata\CustomerBundle\Model\CustomerInterface');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
+        $customerManager->expects($this->never())->method('save')->will($this->returnValue($customer));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCustomerController($customer, $customerManager, null, $formFactory)->putCustomerAction(1, new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testDeleteCustomerAction()
+    {
+        $customer = $this->getMock('Sonata\CustomerBundle\Model\CustomerInterface');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
+        $customerManager->expects($this->once())->method('delete');
+
+        $view = $this->createCustomerController($customer, $customerManager)->deleteCustomerAction(1);
+
+        $this->assertEquals(array('deleted' => true), $view);
+    }
+
+    public function testDeleteCustomerInvalidAction()
+    {
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue(null));
+        $customerManager->expects($this->never())->method('delete');
+
+        $this->createCustomerController(null, $customerManager)->deleteCustomerAction(1);
+    }
+
     /**
      * @param $customer
      * @param $customerManager
+     * @param $addressManager
+     * @param $formFactory
      * @param $order
      * @param $orderManager
      *
      * @return CustomerController
      */
-    public function createCustomerController($customer = null, $customerManager = null, $order = null, $orderManager = null)
+    public function createCustomerController($customer = null, $customerManager = null, $addressManager = null, $formFactory = null, $order = null, $orderManager = null)
     {
         if (null === $customerManager) {
             $customerManager = $this->getMock('Sonata\Component\Customer\CustomerManagerInterface');
@@ -84,14 +234,19 @@ class CustomerControllerTest extends \PHPUnit_Framework_TestCase
         if (null !== $customer) {
             $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
         }
-
         if (null === $orderManager) {
             $orderManager = $this->getMock('Sonata\Component\Order\OrderManagerInterface');
+        }
+        if (null === $addressManager) {
+            $addressManager = $this->getMock('Sonata\Component\Customer\AddressManagerInterface');
         }
         if (null !== $order) {
             $orderManager->expects($this->once())->method('findBy')->will($this->returnValue(array($order)));
         }
+        if (null === $formFactory) {
+            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        }
 
-        return new CustomerController($customerManager, $orderManager);
+        return new CustomerController($customerManager, $orderManager, $addressManager, $formFactory);
     }
 }


### PR DESCRIPTION
I've added a `POST`, `PUT` and a `DELETE` method for customers

![capture decran 2014-03-17 a 12 31 50](https://f.cloud.github.com/assets/103900/2435468/b8cfcc46-adc7-11e3-809b-54d48dfa5407.png)

I've also added customer addresses methods:

![capture decran 2014-03-17 a 12 31 38](https://f.cloud.github.com/assets/103900/2435471/c11afdbc-adc7-11e3-9841-581562db284c.png)
