### PR TITLE
Allows to add to basket a product directly from thumbnails blocks

### DIFF
--- a/src/BasketBundle/Resources/views/Basket/add_product_form.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/add_product_form.html.twig
@@ -17,44 +17,47 @@ file that was distributed with this source code.
     {% block product_add_basket_modal %}
     <div class="row">
         <div class="col-lg-12">
-            <div id="add_basket_modal" class="modal fade"></div>
+            <div id="add_basket_modal_{{ product.id }}" class="modal fade"></div>
         </div>
     </div>
     {% endblock %}
 {% endif %}
 
-<div class="row">
-    <div class="col-lg-12">
-        <form id="form_add_basket" class="form-horizontal" action="{{ url('sonata_basket_add_product') }}" method="POST"{% if provider.getOption('product_add_modal') %} data-target="#add_basket_modal"{% endif %}>
 
-            {% if sonata_product_stock(product) == 0 %}
-                {% set quantityAttrs = {'min': 1, 'disabled': true} %}
-            {% else %}
-                {% set quantityAttrs = {'min': 1} %}
-            {% endif %}
+{% block add_product_form_content %}
+    <div class="row">
+        <div class="col-lg-12">
+            <form id="form_add_basket" class="form-horizontal" action="{{ url('sonata_basket_add_product') }}" method="POST"{% if provider.getOption('product_add_modal') %} data-target="#add_basket_modal_{{ product.id }}"{% endif %}>
 
-            {{ form_row(form.quantity, {'label': 'form_label_quantity'|trans({}, 'SonataBasketBundle'), 'attr': quantityAttrs, 'horizontal_input_wrapper_class': 'col-lg-4', 'horizontal_label_class': 'control-label col-lg-8', 'render_required_asterisk': false}) }}
+                {% if sonata_product_stock(product) == 0 %}
+                    {% set quantityAttrs = {'min': 1, 'disabled': true} %}
+                {% else %}
+                    {% set quantityAttrs = {'min': 1} %}
+                {% endif %}
 
-            <div class="form-group">
-                <div class="col-lg-6 col-xs-6">
-                    <span id="sonata_product_price" class="lead">
-                        {% block product_price_price %}
-                            {% if provider.hasEnabledVariations(product) %}
-                                {{ cheapest_variation.price|number_format_currency(currency) }}
-                            {% else %}
-                                {{ sonata_product_price(product, currency, true)|number_format_currency(currency) }}
-                            {% endif %}
-                        {% endblock %}
-                    </span>
+                {{ form_row(form.quantity, {'label': 'form_label_quantity'|trans({}, 'SonataBasketBundle'), 'attr': quantityAttrs, 'horizontal_input_wrapper_class': 'col-lg-4', 'horizontal_label_class': 'control-label col-lg-8', 'render_required_asterisk': false}) }}
+
+                <div class="form-group">
+                    <div class="col-lg-6 col-xs-6">
+                        <span id="sonata_product_price" class="lead">
+                            {% block product_price_price %}
+                                {% if provider.hasEnabledVariations(product) %}
+                                    {{ cheapest_variation.price|number_format_currency(currency) }}
+                                {% else %}
+                                    {{ sonata_product_price(product, currency, true)|number_format_currency(currency) }}
+                                {% endif %}
+                            {% endblock %}
+                        </span>
+                    </div>
+                    <div class="col-lg-6 col-xs-6">
+                        <button type="submit" class="btn btn-primary btn-sm pull-right" id="sonata_add_basket_submit"{% if sonata_product_stock(product) == 0 %} disabled{% endif %}>
+                            <i class="glyphicon glyphicon-shopping-cart icon-white"></i> {% trans from 'SonataProductBundle' %}sonata.product.btn_add_to_basket{% endtrans %}
+                        </button>
+                    </div>
                 </div>
-                <div class="col-lg-6 col-xs-6">
-                    <button type="submit" class="btn btn-primary btn-sm pull-right" id="sonata_add_basket_submit"{% if sonata_product_stock(product) == 0 %} disabled{% endif %}>
-                        <i class="glyphicon glyphicon-shopping-cart icon-white"></i>{% trans from 'SonataProductBundle' %}sonata.product.btn_add_to_basket{% endtrans %}
-                    </button>
-                </div>
-            </div>
 
-            {{ form_rest(form) }}
-        </form>
+                {{ form_rest(form) }}
+            </form>
+        </div>
     </div>
-</div>
+{% endblock %}

--- a/src/BasketBundle/Resources/views/Basket/add_product_form_button.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/add_product_form_button.html.twig
@@ -1,0 +1,38 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% set provider = sonata_product_provider(product) %}
+
+{% extends 'SonataBasketBundle:Basket:add_product_form.html.twig' %}
+
+{% block add_product_form_content %}
+    {% if product.isVariation %}
+        <a class="btn btn-primary btn-sm pull-right" href="{{ url('sonata_product_view', {'productId': product.id, 'slug': product.slug}) }}">
+            <i class="glyphicon glyphicon-search icon-white"></i> {% trans from 'SonataProductBundle' %}sonata.product.btn_see{% endtrans %}
+        </a>
+    {% else %}
+        {% if sonata_product_stock(product) == 0 %}
+            <a class="btn btn-primary btn-sm pull-right" href="{{ url('sonata_product_view', {'productId': product.id, 'slug': product.slug}) }}">
+                <i class="glyphicon glyphicon-search icon-white"></i> {% trans from 'SonataProductBundle' %}sonata.product.btn_see{% endtrans %}
+            </a>
+        {% else %}
+            {% set form = sonata_product_form_add_basket(product) %}
+
+            <form id="form_add_basket" class="form-horizontal" action="{{ url('sonata_basket_add_product') }}" method="POST"{% if provider.getOption('product_add_modal') %} data-target="#add_basket_modal_{{ product.id }}"{% endif %}>
+                <button type="submit" class="btn btn-primary btn-sm pull-right" id="sonata_add_basket_submit"{% if sonata_product_stock(product) == 0 %} disabled{% endif %}>
+                    <i class="glyphicon glyphicon-shopping-cart icon-white"></i> {% trans from 'SonataProductBundle' %}sonata.product.btn_add{% endtrans %}
+                </button>
+
+                {{ form_rest(form) }}
+            </form>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/src/Component/Product/ProductProviderInterface.php
+++ b/src/Component/Product/ProductProviderInterface.php
@@ -60,11 +60,12 @@ interface ProductProviderInterface
     public function getBaseControllerName();
 
     /**
-     * @param \Sonata\Component\Product\ProductInterface $product
-     * @param \Symfony\Component\Form\FormBuilder        $formBuilder
-     * @param array                                      $options
+     * @param \Sonata\Component\Product\ProductInterface $product      A Sonata product instance
+     * @param \Symfony\Component\Form\FormBuilder        $formBuilder  Symfony form builder
+     * @param boolean                                    $showQuantity Specifies if quantity field will be displayed (default true)
+     * @param array                                      $options      An options array
      */
-    public function defineAddBasketForm(ProductInterface $product, FormBuilder $formBuilder, array $options = array());
+    public function defineAddBasketForm(ProductInterface $product, FormBuilder $formBuilder, $showQuantity = true, array $options = array());
 
     /**
      * @param \Sonata\Component\Basket\BasketElementInterface $basketElement

--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -796,20 +796,26 @@ abstract class BaseProductProvider implements ProductProviderInterface
     /**
      * This function return the form used in the product view page
      *
-     * @param  \Sonata\Component\Product\ProductInterface $product
-     * @param  \Symfony\Component\Form\FormBuilder        $formBuilder
-     * @param  array                                      $options
+     * @param  \Sonata\Component\Product\ProductInterface $product      A Sonata product instance
+     * @param  \Symfony\Component\Form\FormBuilder        $formBuilder  Symfony form builder
+     * @param  boolean                                    $showQuantity Specifies if quantity field will be displayed (default true)
+     * @param  array                                      $options      An options array
      * @return void
      */
-    public function defineAddBasketForm(ProductInterface $product, FormBuilder $formBuilder, array $options = array())
+    public function defineAddBasketForm(ProductInterface $product, FormBuilder $formBuilder, $showQuantity = true, array $options = array())
     {
         $basketElement = $this->createBasketElement($product);
 
         // create the product form
         $formBuilder
             ->setData($basketElement)
-            ->add('quantity', 'integer')
             ->add('productId', 'hidden');
+
+        if ($showQuantity) {
+            $formBuilder->add('quantity', 'integer');
+        } else {
+            $formBuilder->add('quantity', 'hidden', array('data' => 1));
+        }
     }
 
     /**

--- a/src/ProductBundle/Resources/config/twig.xml
+++ b/src/ProductBundle/Resources/config/twig.xml
@@ -7,6 +7,8 @@
     <services>
         <service id="sonata.product.provider.twig" class="Sonata\ProductBundle\Twig\Extension\ProductExtension" public="false">
             <argument type="service" id="sonata.product.pool" />
+            <argument type="service" id="form.factory" />
+            <argument>%sonata.basket.basket_element.class%</argument>
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/ProductBundle/Resources/translations/SonataProductBundle.en.xliff
+++ b/src/ProductBundle/Resources/translations/SonataProductBundle.en.xliff
@@ -16,6 +16,14 @@
                 <source>product_reference</source>
                 <target>Reference</target>
             </trans-unit>
+            <trans-unit id="sonata.product.btn_add">
+                <source>sonata.product.btn_add</source>
+                <target>Add</target>
+            </trans-unit>
+            <trans-unit id="sonata.product.btn_see">
+                <source>sonata.product.btn_see</source>
+                <target>See</target>
+            </trans-unit>
             <trans-unit id="sonata.product.btn_add_to_basket">
                 <source>sonata.product.btn_add_to_basket</source>
                 <target>Add to basket</target>

--- a/src/ProductBundle/Resources/translations/SonataProductBundle.fr.xliff
+++ b/src/ProductBundle/Resources/translations/SonataProductBundle.fr.xliff
@@ -16,6 +16,14 @@
                 <source>product_reference</source>
                 <target>Référence</target>
             </trans-unit>
+            <trans-unit id="sonata.product.btn_add">
+                <source>sonata.product.btn_add</source>
+                <target>Ajouter</target>
+            </trans-unit>
+            <trans-unit id="sonata.product.btn_see">
+                <source>sonata.product.btn_see</source>
+                <target>Voir</target>
+            </trans-unit>
             <trans-unit id="sonata.product.btn_add_to_basket">
                 <source>sonata.product.btn_add_to_basket</source>
                 <target>Ajouter au panier</target>

--- a/src/ProductBundle/Resources/views/Product/view_thumbnail.html.twig
+++ b/src/ProductBundle/Resources/views/Product/view_thumbnail.html.twig
@@ -24,8 +24,11 @@ file that was distributed with this source code.
                 {# default product picture goes here #}
             {% endif %}
         </div>
-        <div class="panel-footer text-right">
-            <span itemprop="price">
+        <div class="panel-footer">
+            <span class="text-left">
+                {% include "SonataBasketBundle:Basket:add_product_form_button.html.twig" %}
+            </span>
+            <span itemprop="price" class="text-right">
                 {% if not sonata_product_has_variations(product) %}
                     {{ sonata_product_price(product, currency, true)|number_format_currency(currency) }}
                 {% else %}


### PR DESCRIPTION
I've added this feature to add a product directly from thumbnails blocks:

![capture decran 2014-03-27 a 15 30 11](https://cloud.githubusercontent.com/assets/103900/2538369/d8608c06-b5bc-11e3-99ff-a3d743f7705b.png)

If product is a master product (has variations) or has no stock, then the "Add" button is transformed into a "See" button that redirect on the product page.
