### PR TITLE
Allow selecting available delivery country addresses only

### DIFF
--- a/src/BasketBundle/Controller/BasketController.php
+++ b/src/BasketBundle/Controller/BasketController.php
@@ -328,7 +328,7 @@ class BasketController extends Controller
         $addresses = $customer->getAddressesByType(AddressInterface::TYPE_DELIVERY);
 
         // Show address creation / selection form
-        $form = $this->createForm('sonata_basket_address', null, array('addresses' => $addresses->toArray()));
+        $form = $this->createForm('sonata_basket_address', null, array('addresses' => $addresses));
         $template = 'SonataBasketBundle:Basket:delivery_address_step.html.twig';
 
         if ($this->get('request')->getMethod() == 'POST') {
@@ -364,7 +364,8 @@ class BasketController extends Controller
 
         return $this->render($template, array(
             'form'      => $form->createView(),
-            'addresses' => $addresses
+            'addresses' => $addresses,
+            'basket'    => $basket,
         ));
     }
 

--- a/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
@@ -33,11 +33,17 @@ file that was distributed with this source code.
                     </div>
                     <ul class="list-group">
                     {% for address in form.addresses %}
+                        {% set deliverable = sonata_address_deliverable(addresses.get(address.vars.value), basket) %}
+
                         <li class="list-group-item">
                             <div class="radio">
-                                <label for="{{ address.vars.id }}">
-                                    {{ form_widget(address, {'checked': (address.vars.value in (form.addresses.vars.preferred_choices|keys))}) }}
-                                    {{ sonata_address_render(address.vars.label, true, true) }}
+                                <label for="{{ address.vars.id }}"{% if false == deliverable %} class="disabled"{% endif %}>
+                                    {{ form_widget(address, {
+                                        'checked': (address.vars.value in (form.addresses.vars.preferred_choices|keys)),
+                                        'disabled': false == deliverable
+                                    }) }}
+
+                                    {{ sonata_address_render(address.vars.label, true, true, 'delivery') }}
                                 </label>
                             </div>
                         </li>

--- a/src/CustomerBundle/Controller/CustomerController.php
+++ b/src/CustomerBundle/Controller/CustomerController.php
@@ -151,8 +151,11 @@ class CustomerController extends Controller
             $address = $this->getAddressManager()->findOneBy(array('id' => $id));
             $this->checkAddress($address);
 
-            $form = $this->createForm('sonata_customer_address', $address);
+            $form = $this->createForm('sonata_customer_address', $address, array(
+                'context' => $this->getRequest()->query->get('context')
+            ));
         }
+
         $template = 'SonataCustomerBundle:Addresses:new.html.twig';
 
         if ($this->get('request')->getMethod() == 'POST') {

--- a/src/CustomerBundle/Entity/BaseCustomer.php
+++ b/src/CustomerBundle/Entity/BaseCustomer.php
@@ -391,7 +391,7 @@ abstract class BaseCustomer implements CustomerInterface
 
         foreach ($this->getAddresses() as $address) {
             if ($type == $address->getType()) {
-                $addresses->add($address);
+                $addresses->set($address->getId(), $address);
             }
         }
 

--- a/src/CustomerBundle/Resources/config/form.xml
+++ b/src/CustomerBundle/Resources/config/form.xml
@@ -9,6 +9,7 @@
             <argument>%sonata.customer.address.class%</argument>
             <argument>getTypesList</argument>
             <argument>sonata_customer_address</argument>
+            <argument type="service" id="sonata.basket" />
 
             <tag name="form.type" alias="sonata_customer_address" />
         </service>

--- a/src/CustomerBundle/Resources/config/twig.xml
+++ b/src/CustomerBundle/Resources/config/twig.xml
@@ -7,6 +7,8 @@
     <services>
         <service id="sonata.customer.twig.address" class="Sonata\CustomerBundle\Twig\Extension\AddressExtension" public="false">
             <tag name="twig.extension" />
+
+            <argument type="service" id="sonata.delivery.selector.default" />
         </service>
     </services>
 

--- a/src/CustomerBundle/Resources/views/Addresses/_address.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/_address.html.twig
@@ -14,7 +14,7 @@
         {% block sonata_address_edit %}
             {% if showEdit %}
                 <div class="col-sm-3">
-                    <a class="btn btn-primary btn-xs pull-right" href="{{ url('sonata_customer_address_edit', {'id' : address.id}) }}"><span class="glyphicon glyphicon-pencil">&nbsp;</span>{{ 'sonata_customer_address_edit'|trans({}, "SonataCustomerBundle") }}</a>
+                    <a class="btn btn-primary btn-xs pull-right" href="{{ url('sonata_customer_address_edit', {'id' : address.id, 'context': context}) }}"><span class="glyphicon glyphicon-pencil">&nbsp;</span>{{ 'sonata_customer_address_edit'|trans({}, "SonataCustomerBundle") }}</a>
                 </div>
             {% endif %}
         {% endblock %}


### PR DESCRIPTION
During checkout process, customer have to select a delivery address.

Now, we will disabled addresses for which basket products cannot be delivered:

![capture decran 2014-03-31 a 16 05 56](https://cloud.githubusercontent.com/assets/103900/2568085/cbebbe72-b8dd-11e3-801e-3bcbe788d92d.png)

Also, when clicking on "edit" from checkout/basket process, customer can only select countries from which basket products can be delivered:

![capture decran 2014-03-31 a 16 05 01](https://cloud.githubusercontent.com/assets/103900/2568097/ec1b0004-b8dd-11e3-9fcf-b54a272741b5.png)
