### PR TITLE
Cast always quantity to integer in calculatePrice

### DIFF
--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -992,7 +992,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
         $this->getEventDispatcher()->dispatch(BasketEvents::PRE_CALCULATE_PRICE, $event);
 
         $vat      = $event->getVat();
-        $quantity = $event->getQuantity();
+        $quantity = intval($event->getQuantity());
 
         if (!is_int($quantity) || $quantity < 1) {
             throw new InvalidParameterException("Expected integer >= 1 for quantity, ".$quantity." given.");


### PR DESCRIPTION
When we hide the quantity input in method BaseProductProvider::defineAddBasketForm($product, $formBuilder, true, $option), the quantity is send to string format (="1") and not as an integer (=1).

In this case an exception is thrown systematically.