### PR TITLE
Fix basket delivery address "use selected" button to be disabled

### DIFF
--- a/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
@@ -32,8 +32,13 @@ file that was distributed with this source code.
                         </div>
                     </div>
                     <ul class="list-group">
+                    {% set has_deliverable = false %}
+
                     {% for address in form.addresses %}
                         {% set deliverable = sonata_address_deliverable(addresses.get(address.vars.value), basket) %}
+                        {% if deliverable %}
+                            {% set has_deliverable = true %}
+                        {% endif %}
 
                         <li class="list-group-item">
                             <div class="radio">
@@ -51,7 +56,11 @@ file that was distributed with this source code.
                     </ul>
 
                     <div class="panel-body">
-                        {{ form_widget(form.useSelected, {'attr': {'class': 'pull-right btn btn-primary'}}) }}
+                        {% if has_deliverable %}
+                            {{ form_widget(form.useSelected, {'attr': {'class': 'pull-right btn btn-primary'}}) }}
+                        {% else %}
+                            {{ form_widget(form.useSelected, {'attr': {'class': 'pull-right btn btn-primary', 'disabled': true}}) }}
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
If no address can be delivered, disable the "use selected" button:

![capture decran 2014-04-03 a 15 28 45](https://cloud.githubusercontent.com/assets/103900/2603962/9f8a5064-bb35-11e3-9759-60348c21a400.png)
