### PR TITLE
Add error message when no address deliverable

### DIFF
--- a/src/BasketBundle/Resources/config/form.xml
+++ b/src/BasketBundle/Resources/config/form.xml
@@ -13,6 +13,7 @@
             <tag name="form.type" alias="sonata_basket_address" />
 
             <argument>%sonata.customer.address.class%</argument>
+            <argument type="service" id="sonata.basket" />
         </service>
 
         <service id="sonata.basket.form.type.shipping" class="Sonata\BasketBundle\Form\ShippingType">

--- a/src/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
+++ b/src/BasketBundle/Resources/translations/SonataBasketBundle.en.xliff
@@ -70,6 +70,10 @@
                 <source>sonata.basket.message_no_billing_addresses_available</source>
                 <target>No payment addresses available</target>
             </trans-unit>
+            <trans-unit id="sonata.basket.message_country_not_delivery_zone">
+                <source>sonata.basket.message_country_not_delivery_zone</source>
+                <target>Country is not in the delivery zone</target>
+            </trans-unit>
             <trans-unit id="sonata.basket.order_terms_and_conditions_title">
                 <source>sonata.basket.order_terms_and_conditions_title</source>
                 <target>Terms and conditions of use</target>

--- a/src/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
+++ b/src/BasketBundle/Resources/translations/SonataBasketBundle.fr.xliff
@@ -70,6 +70,10 @@
                 <source>sonata.basket.message_no_billing_addresses_available</source>
                 <target>Aucune adresse de facturation n'est disponible</target>
             </trans-unit>
+            <trans-unit id="sonata.basket.message_country_not_delivery_zone">
+                <source>sonata.basket.message_country_not_delivery_zone</source>
+                <target>Le pays n'est pas dans une zone livrable</target>
+            </trans-unit>
             <trans-unit id="sonata.basket.order_terms_and_conditions_title">
                 <source>sonata.basket.order_terms_and_conditions_title</source>
                 <target>Conditions générales de vente</target>

--- a/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
@@ -42,6 +42,12 @@ file that was distributed with this source code.
 
                         <li class="list-group-item">
                             <div class="radio">
+                                {% if false == deliverable %}
+                                    <span class="label label-danger">
+                                        {% trans from 'SonataBasketBundle' %}sonata.basket.message_country_not_delivery_zone{% endtrans %}
+                                    </span>
+                                {% endif %}
+
                                 <label for="{{ address.vars.id }}"{% if false == deliverable %} class="disabled"{% endif %}>
                                     {{ form_widget(address, {
                                         'checked': (address.vars.value in (form.addresses.vars.preferred_choices|keys)),
@@ -56,11 +62,10 @@ file that was distributed with this source code.
                     </ul>
 
                     <div class="panel-body">
-                        {% if has_deliverable %}
-                            {{ form_widget(form.useSelected, {'attr': {'class': 'pull-right btn btn-primary'}}) }}
-                        {% else %}
-                            {{ form_widget(form.useSelected, {'attr': {'class': 'pull-right btn btn-primary', 'disabled': true}}) }}
-                        {% endif %}
+                        {{ form_widget(form.useSelected, {
+                            'attr': {'class': 'pull-right btn btn-primary'},
+                            'disabled': false == has_deliverable
+                        }) }}
                     </div>
                 </div>
             </div>

--- a/src/CustomerBundle/Form/AddressType.php
+++ b/src/CustomerBundle/Form/AddressType.php
@@ -63,17 +63,18 @@ class AddressType extends AbstractType
     {
         $address = $builder->getData();
 
+        $countryOptions = array();
         $countries = array();
 
         if ('delivery' == $options['context'] && $address) {
             $countries = $this->getBasketDeliveryCountries();
         }
 
-        if (count($countries) == 0) {
-            $countries = Intl::getRegionBundle()->getCountryNames();
+        if (count($countries) > 0) {
+            $countryOptions['choices'] = $countries;
         }
 
-        $builder->add('countryCode', 'choice', array('choices' => $countries));
+        $builder->add('countryCode', 'country', $countryOptions);
     }
 
     /**


### PR DESCRIPTION
As suggested by @Bladrak, I've added an error message when no deliverable address are available and also restricted the country list on the basket `AddressType` with available countries only:

![capture decran 2014-04-03 a 16 27 51](https://cloud.githubusercontent.com/assets/103900/2604613/3292e4b0-bb3c-11e3-8b8f-ea985fe68e49.png)
