### PR TITLE
Fix price bundle documentation

### DIFF
--- a/docs/reference/bundles/price.rst
+++ b/docs/reference/bundles/price.rst
@@ -50,7 +50,7 @@ Price bundle configuration is as follows:
             # ...
 
             types:
-                currency: Sonata\Component\Currency\CurrencyType
+                currency: Sonata\Component\Currency\CurrencyDoctrineType
 
 You can also change the services class (defined as parameters):
 


### PR DESCRIPTION
I've renamed a class name in documentation: CurrencyType to correct CurrencyDoctrineType.
