### PR TITLE
SONATA-543 - Add missing save for adding product

### DIFF
--- a/src/BasketBundle/Controller/BasketController.php
+++ b/src/BasketBundle/Controller/BasketController.php
@@ -135,6 +135,8 @@ class BasketController extends Controller
                 $basketElement = $provider->basketAddProduct($basket, $product, $basketElement);
             }
 
+            $this->get('sonata.basket.factory')->save($basket);
+
             if ($request->isXmlHttpRequest() && $provider->getOption('product_add_modal')) {
                 return $this->render('SonataBasketBundle:Basket:add_product_popin.html.twig', array(
                     'basketElement' => $basketElement,


### PR DESCRIPTION
When adding a product and using `BasketEntityFactory` (database), we need to explicitly call the `save()` method in order to persist the basket, which was never called at this moment.

The `BasketSessionFactory` also has a `save()` method so this will work with both services.
