### PR TITLE
[WIP] Add search engine

### DIFF
--- a/docs/reference/bundles/product.rst
+++ b/docs/reference/bundles/product.rst
@@ -73,6 +73,9 @@ The bundle allows you to configure the entity classes; you'll also need to regis
             delivery:             Application\Sonata\ProductBundle\Entity\Delivery
             gallery:              Application\Sonata\MediaBundle\Entity\Gallery
 
+        search:
+            provider: sonata.product.search.provider.doctrine # or: sonata.product.search.provider.elastica
+
     # Enable Doctrine to map the provided entities
     doctrine:
         orm:

--- a/docs/reference/tutorials/create-custom-search-provider.rst
+++ b/docs/reference/tutorials/create-custom-search-provider.rst
@@ -1,0 +1,108 @@
+.. index::
+single: Product
+    pair: Product; Tutorial
+
+===============================
+Create a custom search provider
+===============================
+
+Create provider class
+=====================
+
+First, you have to define a new ``CustomSearchProvider`` class and extends ``Sonata\ProductBundle\Search\Provider\BaseSearchProvider``:
+
+.. code-block:: php
+
+    <?php
+
+    namespace Application\Sonata\ProductBundle\Search\Provider;
+
+    use Sonata\DatagridBundle\Datagrid\Datagrid;
+    use Sonata\ProductBundle\Search\Provider\BaseSearchProvider;
+
+    use Symfony\Component\Form\FormFactoryInterface;
+
+    /**
+     * Class CustomSearchProvider
+     *
+     * Your custom search provider
+     */
+    class CustomSearchProvider extends BaseSearchProvider
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function getQuery()
+        {
+            // Return your query builder class
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function buildFilters()
+        {
+            // Add your custom filters
+            // $this->filters[] = ...;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function buildFacets()
+        {
+            // Add your custom facets
+            // $this->facets[] = ...;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function buildQuery()
+        {
+            // Build your query and add your filters & facets to your query
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function buildDatagrid()
+        {
+            // Build the Datagrid instance with ProxyQuery, Pager, Form and options
+            // $this->datagris = new Datagrid(...);
+        }
+    }
+
+You can have a look at existing providers to have more information on how to implement it:
+
+* Doctrine provider: ``Sonata\ProductBundle\Search\Provider\DoctrineSearchProvider``
+* ElasticSearch provider: ``Sonata\ProductBundle\Search\Provider\ElasticaSearchProvider``
+
+
+Create provider service
+=======================
+
+Add a service to use your provider:
+
+.. code-block:: xml
+
+    <service id="my.custom.search.provider" class="Application\Sonata\ProductBundle\Search\Provider\CustomSearchProvider">
+        <argument type="service" id="form.factory" />
+        <argument type="service" id="fos_elastica.manager.orm" />
+        <argument>%sonata.product.product.class%</argument>
+    </service>
+
+
+Update configuration
+====================
+
+In order to use your custom provider, you have to update your ``sonata_product`` configuration part as follows:
+
+.. code-block:: yaml
+
+    sonata_product:
+        search:
+            provider: my.custom.search.provider
+
+
+That's all, your provider is now used by product's search engine.

--- a/docs/reference/tutorials/index.rst
+++ b/docs/reference/tutorials/index.rst
@@ -18,6 +18,7 @@ So, let's get started!
 
     Create a category <create-category>
     Create a collection <create-collection>
+    Create a custom search provider <create-custom-search-provider>
     Create a product <create-product>
     Basic options for product providers <product-provider-options>
     Create a delivery method <create-delivery-method>

--- a/src/ProductBundle/Block/CategoriesMenuBlockService.php
+++ b/src/ProductBundle/Block/CategoriesMenuBlockService.php
@@ -64,9 +64,13 @@ class CategoriesMenuBlockService extends MenuBlockService
         parent::setDefaultSettings($resolver);
 
         $resolver->setDefaults(array(
-                'menu_template' => "SonataBlockBundle:Block:block_side_menu_template.html.twig",
-                'safe_labels'   => true
-            ));
+            'route'            => null,
+            'route_parameters' => array(),
+            'use_current_uri'  => false,
+            'facets'           => array(),
+            'menu_template'    => "SonataBlockBundle:Block:block_side_menu_template.html.twig",
+            'safe_labels'      => true,
+        ));
     }
 
     /**
@@ -79,13 +83,17 @@ class CategoriesMenuBlockService extends MenuBlockService
         $menu = parent::getMenu($blockContext);
 
         if (null === $menu || "" === $menu) {
-            $menu = $this->menuBuilder->createCategoryMenu(
-                array(
-                    'childrenAttributes' => array('class' => $settings['menu_class']),
-                    'attributes'         => array('class' => $settings['children_class']),
-                ),
-                $settings['current_uri']
+            $options = array(
+                'childrenAttributes' => array('class' => $settings['menu_class']),
+                'attributes'         => array('class' => $settings['children_class'])
             );
+
+            if ($settings['route']) {
+                $options['route'] = $settings['route'];
+                $options['routeParameters'] = $settings['route_parameters'];
+            }
+
+            $menu = $this->menuBuilder->createCategoryMenu($options, $settings['current_uri'], $settings['facets']);
         }
 
         return $menu;

--- a/src/ProductBundle/Block/FiltersMenuBlockService.php
+++ b/src/ProductBundle/Block/FiltersMenuBlockService.php
@@ -66,6 +66,8 @@ class FiltersMenuBlockService extends MenuBlockService
         $resolver->setDefaults(array(
             'menu_class'       => "nav nav-list",
             'product_provider' => null,
+            'route'            => null,
+            'route_parameters' => null,
         ));
     }
 
@@ -86,10 +88,17 @@ class FiltersMenuBlockService extends MenuBlockService
     {
         $settings = $blockContext->getSettings();
 
+        $options = array('childrenAttributes' => array('class' => $settings['menu_class']));
+
+        if ($settings['route']) {
+            $options['route'] = $settings['route'];
+            $options['routeParameters'] = $settings['route_parameters'];
+        }
+
         $menu = parent::getMenu($blockContext);
 
         if (null === $menu || "" === $menu) {
-            $menu = $this->menuBuilder->createFiltersMenu($settings['product_provider'], array('childrenAttributes' => array('class' => $settings['menu_class'])), $settings['current_uri']);
+            $menu = $this->menuBuilder->createFiltersMenu($settings['product_provider'], $options, $settings['current_uri']);
         }
 
         return $menu;

--- a/src/ProductBundle/Block/SearchFormBlockService.php
+++ b/src/ProductBundle/Block/SearchFormBlockService.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Block;
+
+use Doctrine\ORM\EntityRepository;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * This is the e-commerce products search block
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class SearchFormBlockService extends BaseBlockService
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        return $this->renderResponse($blockContext->getTemplate(), array(
+            'context'  => $blockContext,
+            'settings' => $blockContext->getSettings(),
+            'block'    => $blockContext->getBlock(),
+        ), $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+        // TODO: Implement validateBlock() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+            'keys' => array(
+                array('route', 'text', array('required' => true)),
+            )
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'Search engine (products)';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'route'    => 'sonata_product_search_index',
+            'template' => 'SonataProductBundle:Block:search.html.twig'
+        ));
+    }
+}

--- a/src/ProductBundle/Controller/SearchController.php
+++ b/src/ProductBundle/Controller/SearchController.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Controller;
+
+use Sonata\ClassificationBundle\Entity\CategoryManager;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\Component\Currency\CurrencyDetector;
+use Sonata\Component\Product\Pool;
+use Sonata\ProductBundle\Entity\ProductSetManager;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class SearchController
+ */
+class SearchController extends Controller
+{
+    /**
+     * Process a search.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @throws NotFoundHttpException
+     */
+    public function indexAction(Request $request)
+    {
+        $displayMode = $request->query->get('mode', 'grid');
+
+        if (!in_array($displayMode, array('grid'))) { // "list" mode will be added later
+            throw new NotFoundHttpException(sprintf('Given display_mode "%s" doesn\'t exist.', $displayMode));
+        }
+
+        $builder = $this->get('sonata.product.search.builder');
+        $builder->handleRequest($request);
+
+        $datagrid = $builder->getDatagrid();
+
+        $results = $datagrid->getResults();
+        $provider = $results ? $this->getProductPool()->getProvider(current($results)) : null;
+
+        return $this->render('SonataProductBundle:Search:index.html.twig', array_merge($builder->getSearchParameters(), array(
+            'category'     => null,
+            'currency'     => $this->getCurrencyDetector()->getCurrency(),
+            'datagrid'     => $datagrid,
+            'display_mode' => $displayMode,
+            'form'         => $datagrid->getForm()->createView(),
+            'provider'     => $provider,
+        )));
+    }
+
+    /**
+     * @return Pool
+     */
+    protected function getProductPool()
+    {
+        return $this->get('sonata.product.pool');
+    }
+
+    /**
+     * @return ProductSetManager
+     */
+    protected function getProductSetManager()
+    {
+        return $this->get('sonata.product.set.manager');
+    }
+
+    /**
+     * @return CurrencyDetector
+     */
+    protected function getCurrencyDetector()
+    {
+        return $this->get('sonata.price.currency.detector');
+    }
+
+    /**
+     * Gets the product provider associated with $category if any
+     *
+     * @param CategoryInterface $category
+     *
+     * @return null|\Sonata\Component\Product\ProductProviderInterface
+     */
+    protected function getProviderFromCategory(CategoryInterface $category = null)
+    {
+        if (null === $category) {
+            return null;
+        }
+
+        $product = $this->getProductSetManager()->findProductForCategory($category);
+
+        return $product ? $this->getProductPool()->getProvider($product) : null;
+    }
+}

--- a/src/ProductBundle/DependencyInjection/Configuration.php
+++ b/src/ProductBundle/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
         $this->addProductSection($node);
         $this->addModelSection($node);
         $this->addSeoSection($node);
+        $this->addSearchSection($node);
 
         return $treeBuilder;
     }
@@ -111,6 +112,23 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('media_format')->defaultValue('reference')->end()
                             ->end()
                         ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param  \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @return void
+     */
+    private function addSearchSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('search')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('provider')->defaultValue('sonata.product.search.provider.doctrine')->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -14,6 +14,7 @@ namespace Sonata\ProductBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
 
@@ -48,6 +49,7 @@ class SonataProductExtension extends Extension
         $loader->load('form.xml');
         $loader->load('twig.xml');
         $loader->load('menu.xml');
+        $loader->load('search.xml');
 
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_controllers.xml');
@@ -66,6 +68,7 @@ class SonataProductExtension extends Extension
         $this->registerParameters($container, $config);
         $this->registerDoctrineMapping($config);
         $this->registerSeoParameters($container, $config);
+        $this->registerSearchParameters($container, $config);
     }
 
     /**
@@ -346,5 +349,18 @@ class SonataProductExtension extends Extension
         foreach ($productSeo as $key => $value) {
             $container->setParameter(sprintf('sonata.product.seo.product.%s', $key), $value);
         }
+    }
+
+    /**
+     * Register search service parameters and updates search builder argument
+     *
+     * @param ContainerBuilder $container
+     * @param array            $config
+     */
+    protected function registerSearchParameters(ContainerBuilder $container, array $config)
+    {
+        $container->setParameter('sonata.product.search.provider', $config['search']['provider']);
+        $container->getDefinition('sonata.product.search.builder')
+            ->replaceArgument(0, new Reference($config['search']['provider']));
     }
 }

--- a/src/ProductBundle/Menu/ProductMenuBuilder.php
+++ b/src/ProductBundle/Menu/ProductMenuBuilder.php
@@ -77,7 +77,14 @@ class ProductMenuBuilder
             $menuItem = $menu->addChild($filter, array_merge(array('attributes' => array('class' => 'nav-header')), $itemOptions));
 
             foreach ($options as $option) {
-                $filterItemOptions = array_merge(array('uri' => $this->getFilterUri($currentUri, $filter, $option)), $itemOptions);
+                $itemOptions['routeParameters'][$filter] = $option;
+
+                if (isset($itemOptions['route']) && $itemOptions['route']) {
+                    $itemOptions['routeParameters'][$filter] = $option;
+                    $filterItemOptions = $itemOptions;
+                } else {
+                    $filterItemOptions = array_merge(array('uri' => $this->getFilterUri($currentUri, $filter, $option)), $itemOptions);
+                }
 
                 $menuItem->addChild(
                     $this->getFilterName($filter, $option),
@@ -93,14 +100,15 @@ class ProductMenuBuilder
     /**
      * @param array  $itemOptions The options given to the created menuItem
      * @param string $currentUri  The current URI
+     * @param array  $facets      The facets results list
      *
      * @return \Knp\Menu\ItemInterface
      */
-    public function createCategoryMenu(array $itemOptions = array(), $currentUri = null)
+    public function createCategoryMenu(array $itemOptions = array(), $currentUri = null, $facets = array())
     {
         $menu = $this->factory->createItem('categories', $itemOptions);
 
-        $this->buildCategoryMenu($menu, $itemOptions, $currentUri);
+        $this->buildCategoryMenu($menu, $itemOptions, $currentUri, $facets);
 
         return $menu;
     }
@@ -109,12 +117,19 @@ class ProductMenuBuilder
      * @param \Knp\Menu\ItemInterface $menu        The item to fill with $routes
      * @param array                   $options     The item options
      * @param string                  $currentUri  The current URI
+     * @param array                   $facets      The facets results list
      */
-    public function buildCategoryMenu(ItemInterface $menu, array $options = array(), $currentUri = null)
+    public function buildCategoryMenu(ItemInterface $menu, array $options = array(), $currentUri = null, $facets = array())
     {
         $categories = $this->categoryManager->getCategoryTree();
 
-        $this->fillMenu($menu, $categories, $options, $currentUri);
+        $terms = array();
+
+        foreach ($facets as $facet) {
+            $terms[$facet['term']] = $facet['count'];
+        }
+
+        $this->fillMenu($menu, $categories, $options, $currentUri, $terms);
     }
 
     /**
@@ -145,15 +160,25 @@ class ProductMenuBuilder
     /**
      * Recursive method to fill $menu with $categories
      *
-     * @param ItemInterface $menu
-     * @param array         $categories
-     * @param array         $options
-     * @param string        $currentUri
+     * @param ItemInterface $menu       The menu item
+     * @param array         $categories The corresponding categories
+     * @param array         $options    The item options
+     * @param string        $currentUri The current URI
+     * @param array         $terms      The facets terms results list
      */
-    protected function fillMenu(ItemInterface $menu, $categories, array $options = array(), $currentUri = null)
+    protected function fillMenu(ItemInterface $menu, $categories, array $options = array(), $currentUri = null, $terms = array())
     {
         foreach ($categories as $category) {
             if (false === $category->getEnabled()) {
+                continue;
+            }
+
+            $identifier = $category->getId();
+
+            $count = isset($terms[$identifier]) ? $terms[$identifier] : null;
+
+            // Fix for Doctrine search child categories to be displayed
+            if (!empty($terms) && null === $count) {
                 continue;
             }
 
@@ -161,7 +186,7 @@ class ProductMenuBuilder
                 'attributes'      => array('class' => ""),      // Ensuring it is set
                 'route'           => 'sonata_catalog_category',
                 'routeParameters' => array(
-                    'category_id'   => $category->getId(),
+                    'category_id'   => $identifier,
                     'category_slug' => $category->getSlug()
                 ),
                 'extras'           => array(
@@ -169,20 +194,24 @@ class ProductMenuBuilder
                 )
             ), $options);
 
+            if ($terms) {
+                $fullOptions['routeParameters']['category'] = $identifier;
+            }
+
             if (null === $category->getParent()) {
                 $fullOptions['attributes']['class'] = 'lead '.$fullOptions['attributes']['class'];
             }
 
             $child = $menu->addChild(
-                $this->getCategoryTitle($category),
+                $this->getCategoryTitle($category, 500, $count),
                 $fullOptions
             );
 
             if (count($category->getChildren()) > 0) {
                 if (null === $category->getParent()) {
-                    $this->fillMenu($menu, $category->getChildren(), $options, $currentUri);
+                    $this->fillMenu($menu, $category->getChildren(), $options, $currentUri, $terms);
                 } else {
-                    $this->fillMenu($child, $category->getChildren(), $options, $currentUri);
+                    $this->fillMenu($child, $category->getChildren(), $options, $currentUri, $terms);
                 }
             }
         }
@@ -195,12 +224,15 @@ class ProductMenuBuilder
      *
      * @param CategoryInterface $category A category instance
      * @param int               $limit    A limit for calculation (fixed to 500 by default)
+     * @param int               $count    A specific count to display
      *
      * @return string
      */
-    protected function getCategoryTitle(CategoryInterface $category, $limit = 500)
+    protected function getCategoryTitle(CategoryInterface $category, $limit = 500, $count = null)
     {
-        $count = $this->categoryManager->getProductCount($category, $limit);
+        if (null === $count) {
+            $count = $this->categoryManager->getProductCount($category, $limit);
+        }
 
         return sprintf("%s <span class=\"badge pull-right\">%d%s</span>", $category->getName(), $count, $count > $limit ? '+' : '');
     }

--- a/src/ProductBundle/Resources/config/block.xml
+++ b/src/ProductBundle/Resources/config/block.xml
@@ -61,6 +61,14 @@
             <argument type="service" id="sonata.product.pool" />
             <argument type="service" id="form.factory" />
         </service>
+
+        <service id="sonata.product.block.search_form" class="Sonata\ProductBundle\Block\SearchFormBlockService">
+            <tag name="sonata.block"/>
+
+            <argument>sonata.product.block.search_form</argument>
+            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.product.pool" />
+        </service>
     </services>
 
 </container>

--- a/src/ProductBundle/Resources/config/routing/search.xml
+++ b/src/ProductBundle/Resources/config/routing/search.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="sonata_product_search_index" pattern="/">
+        <default key="_controller">SonataProductBundle:Search:index</default>
+    </route>
+
+</routes>

--- a/src/ProductBundle/Resources/config/search.xml
+++ b/src/ProductBundle/Resources/config/search.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sonata.product.search.builder.class">Sonata\ProductBundle\Search\SearchBuilder</parameter>
+
+        <parameter key="sonata.product.search.provider.doctrine.class">Sonata\ProductBundle\Search\Provider\DoctrineSearchProvider</parameter>
+        <parameter key="sonata.product.search.provider.elastica.class">Sonata\ProductBundle\Search\Provider\ElasticaSearchProvider</parameter>
+    </parameters>
+
+    <services>
+        <!-- Builder -->
+
+        <service id="sonata.product.search.builder" class="%sonata.product.search.builder.class%">
+            <argument />
+        </service>
+
+        <!-- Providers -->
+
+        <service id="sonata.product.search.provider.doctrine" class="%sonata.product.search.provider.doctrine.class%">
+            <argument type="service" id="form.factory" />
+            <argument type="service" id="doctrine" />
+            <argument>%sonata.product.product.class%</argument>
+            <argument>%sonata.product.product_category.class%</argument>
+        </service>
+
+        <service id="sonata.product.search.provider.elastica" class="%sonata.product.search.provider.elastica.class%">
+            <argument type="service" id="form.factory" />
+            <argument type="service" id="fos_elastica.manager.orm" />
+            <argument>%sonata.product.product.class%</argument>
+        </service>
+    </services>
+
+</container>

--- a/src/ProductBundle/Resources/config/serializer/Entity.BaseProduct.xml
+++ b/src/ProductBundle/Resources/config/serializer/Entity.BaseProduct.xml
@@ -18,12 +18,20 @@
         <property name="priceIncludingVat" type="boolean" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
         <property name="price"             type="double"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
         <property name="vatRate"           type="double"  expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
-        
+
         <property name="stock" type="integer" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
 
         <property name="parent"  serialized-name="parent_id"  type="sonata_product_product_id" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
         <property name="image"   serialized-name="media_id"   type="sonata_media_media_id"     expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
         <property name="gallery" serialized-name="gallery_id" type="sonata_media_gallery_id"   expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search" />
+
+        <property type="ArrayCollection&lt;Sonata\ProductBundle\Entity\BaseProductCategory&gt;" name="productCategories" expose="true" since-version="1.0" groups="sonata_search">
+            <xml-list inline="false" entry-name="category" />
+        </property>
+
+        <property type="ArrayCollection&lt;Sonata\ProductBundle\Entity\BaseProductCollection&gt;" name="productCollections" expose="true" since-version="1.0" groups="sonata_search">
+            <xml-list inline="false" entry-name="collection" />
+        </property>
 
         <property name="createdAt" type="DateTime" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search" />
         <property name="updatedAt" type="DateTime" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search" />

--- a/src/ProductBundle/Resources/public/js/product.js
+++ b/src/ProductBundle/Resources/public/js/product.js
@@ -117,4 +117,9 @@ Sonata.Product = {
     }
 }
 
-
+// Search
+$(window).ready(function () {
+    $('form[data-name="sonata-select"] select').on('change', function (e) {
+        $(this).parents('form').submit();
+    });
+});

--- a/src/ProductBundle/Resources/views/Block/search.html.twig
+++ b/src/ProductBundle/Resources/views/Block/search.html.twig
@@ -1,0 +1,8 @@
+<form name="search" method="get" class="pull-right col-sm-4" action="{% if settings.route is defined %}{{ url(settings.route) }}{% endif %}">
+    <div class="input-group">
+        <input class="form-control" type="text" name="q" placeholder="Enter your search..." />
+        <span class="input-group-btn">
+            <button class="btn btn-primary" type="submit">Search</button>
+        </span>
+    </div>
+</form>

--- a/src/ProductBundle/Resources/views/Search/grid.html.twig
+++ b/src/ProductBundle/Resources/views/Search/grid.html.twig
@@ -1,0 +1,28 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+<div class="panel-body product-grid">
+
+    {% sonata_template_box 'This is the product search grid list template. Feel free to override it.' %}
+
+    {% for product in datagrid.results %}
+
+        {% if not sonata_product_has_variations(product) or (sonata_product_has_variations(product) and sonata_product_has_enabled_variations(product)) %}
+
+            <div class="col-sm-4" itemscope itemtype="http://schema.org/Product">
+                {% include 'SonataProductBundle:Catalog:_product_grid.html.twig' %}
+            </div>
+
+        {% endif %}
+
+    {% endfor %}
+
+</div>

--- a/src/ProductBundle/Resources/views/Search/index.html.twig
+++ b/src/ProductBundle/Resources/views/Search/index.html.twig
@@ -1,0 +1,19 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataProductBundle:Search:layout.html.twig' %}
+
+
+{% block products %}
+
+    {% include 'SonataProductBundle:Search:' ~ display_mode ~ '.html.twig' %}
+
+{% endblock %}

--- a/src/ProductBundle/Resources/views/Search/layout.html.twig
+++ b/src/ProductBundle/Resources/views/Search/layout.html.twig
@@ -1,0 +1,94 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% sonata_template_box 'This is the catalog template. Feel free to override it.' %}
+
+{% block sonata_page_breadcrumb %}
+    <div class="row-fluid clearfix">
+        {{ sonata_block_render_event('breadcrumb', { 'context': 'catalog', 'category': category, 'current_uri': app.request.requestUri }) }}
+    </div>
+{% endblock %}
+
+<div class="row">
+
+    <div class="col-sm-3">
+        {% block product_category %}
+            {{ sonata_block_render({'type': 'sonata.product.block.categories_menu', 'settings': {
+                'current_uri': app.request.requestUri,
+                'extra_cache_keys': {
+                    'block_id':    'sonata.product.block.categories_menu',
+                    'updated_at':  'now',
+                },
+                'facets': datagrid.query.results.facets is defined ? datagrid.query.results.facets.categories.terms : null,
+                'route': app.request.attributes.get('_route'),
+                'route_parameters': {sort: sort, q: q},
+                'ttl': 60
+            }}) }}
+        {% endblock %}
+
+        {% block product_filter %}
+            {% if provider %}
+                <div class="well" style="padding: 8px 0;">
+                    {{ sonata_block_render({'type': 'sonata.product.block.filters_menu'}, {
+                        'product_provider': provider,
+                        'current_uri': app.request.requestUri,
+                        'route': app.request.attributes.get('_route'),
+                        'route_parameters': {sort: sort, q: q, category: category}
+                    }) }}
+                </div>
+            {% endif %}
+        {% endblock %}
+
+    </div>
+
+    <div class="col-sm-9">
+
+        {% if datagrid.pager.count == 0 %}
+
+            {% block no_products %}
+                <div class="no-products-available">
+                    {% trans from 'SonataProductBundle' %}no_products_available{% endtrans %}
+                </div>
+            {% endblock %}
+
+        {% else %}
+
+            <div class="panel panel-default sonata-product-navigation-bar">
+                <div class="panel-heading">
+                    <div class="row">
+                        <div class="col-sm-3">
+                            <h4 class="panel-title">"{{ q }}"</h4>
+                        </div>
+                        <form name="search-sort" data-name="sonata-select" method="get" action="{{ path(app.request.attributes.get('_route')) }}">
+                            {{ form_widget(form.sort, {horizontal_input_wrapper_class: 'col-sm-4'}) }}
+                            {{ form_rest(form) }}
+                        </form>
+                        <div class="col-sm-5">
+                            {% include 'SonataDatagridBundle:Search:pager.html.twig' with {'pager_class': 'pull-right'} %}
+                        </div>
+                    </div>
+                </div>
+
+                {% block products %}{% endblock %}
+
+                <div class="panel-footer">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            {% include 'SonataDatagridBundle:Search:pager.html.twig' with {'pager_class': 'pull-right'} %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
+    </div>
+
+</div>

--- a/src/ProductBundle/Search/Provider/BaseSearchProvider.php
+++ b/src/ProductBundle/Search/Provider/BaseSearchProvider.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Search\Provider;
+
+use Sonata\DatagridBundle\Datagrid\DatagridInterface;
+
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class BaseSearchProvider
+ *
+ * This is the base search provider
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+abstract class BaseSearchProvider implements SearchProviderInterface
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * @var mixed
+     */
+    protected $manager;
+
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @var \Elastica\Query
+     */
+    protected $query;
+
+    /**
+     * @var array
+     */
+    protected $searchParameters;
+
+    /**
+     * @var array
+     */
+    protected $filters;
+
+    /**
+     * @var array
+     */
+    protected $facets;
+
+    /**
+     * @var DatagridInterface
+     */
+    protected $datagrid;
+
+    /**
+     * Constructor
+     *
+     * @param FormFactoryInterface $formFactory Symfony Form factory
+     * @param mixed                $manager     An elastica entity repository manager
+     * @param string               $class       An entity class name
+     */
+    public function __construct(FormFactoryInterface $formFactory, $manager, $class)
+    {
+        $this->formFactory = $formFactory;
+        $this->manager     = $manager;
+        $this->class       = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManager()
+    {
+        return $this->manager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository()
+    {
+        $class = $this->getClass();
+
+        return $this->manager->getRepository($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return $this->filters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFacets()
+    {
+        return $this->facets;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDatagrid()
+    {
+        return $this->datagrid;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSearchParameters(array $searchParameters)
+    {
+        $this->searchParameters = $searchParameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchParameters()
+    {
+        return $this->searchParameters;
+    }
+
+    /**
+     * Returns a search parameter by its key
+     *
+     * @param string $key
+     *
+     * @return string|null
+     */
+    public function getSearchParameter($key)
+    {
+        return isset($this->searchParameters[$key]) ? $this->searchParameters[$key] : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        $this->buildFilters();
+        $this->buildFacets();
+        $this->buildQuery();
+
+        $this->buildDatagrid();
+    }
+
+    /**
+     * Returns search form builder
+     *
+     * @return FormBuilderInterface
+     */
+    protected function buildForm()
+    {
+        $formBuilder = $this->formFactory->createNamedBuilder('', 'form', array(), array(
+            'csrf_protection' => false
+        ));
+
+        // Add sort options
+        $formBuilder->add('sort', 'choice', array(
+            'multiple' => false,
+            'choices' => array(
+                'score'      => 'Sort by pertinence',
+                'price_asc'  => 'Sort by ascending price',
+                'price_desc' => 'Sort by descending price',
+            )
+        ));
+
+        // Add hidden fields corresponding to current URL parameters
+        foreach ($this->getSearchParameters() as $parameter => $value) {
+            if ($value && !in_array($parameter, array('term', 'sort', 'page'))) {
+                $formBuilder->add($parameter, 'hidden', array('data' => $value));
+            }
+        }
+
+        return $formBuilder;
+    }
+
+    /**
+     * Returns sort value
+     *
+     * @param $option
+     *
+     * @return string|null
+     */
+    protected function getSortValue($option)
+    {
+        $sort = array('by' => null, 'order' => null);
+
+        switch ($this->getSearchParameter('sort')) {
+            case 'price_asc':
+                $sort = array('by' => 'price', 'order' => 'asc');
+                break;
+
+            case 'price_desc':
+                $sort = array('by' => 'price', 'order' => 'desc');
+                break;
+        }
+
+        return isset($sort[$option]) ? $sort[$option] : null;
+    }
+}

--- a/src/ProductBundle/Search/Provider/DoctrineSearchProvider.php
+++ b/src/ProductBundle/Search/Provider/DoctrineSearchProvider.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Search\Provider;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+use Sonata\DatagridBundle\Datagrid\Datagrid;
+use Sonata\DatagridBundle\Pager\Doctrine\Pager;
+use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * Class DoctrineSearchProvider
+ *
+ * This is the Doctrine search provider
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class DoctrineSearchProvider extends BaseSearchProvider implements SearchProviderInterface
+{
+    /**
+     * @var string
+     */
+    protected $productCategoriesClass;
+
+    /**
+     * Constructor
+     *
+     * @param FormFactoryInterface $formFactory            Symfony Form factory
+     * @param ManagerRegistry      $manager                An elastica entity repository manager
+     * @param string               $class                  An entity class name
+     * @param string               $productCategoriesClass A product categories entity class name
+     */
+    public function __construct(FormFactoryInterface $formFactory, ManagerRegistry $manager, $class, $productCategoriesClass)
+    {
+        parent::__construct($formFactory, $manager, $class);
+
+        $this->manager = $this->manager->getManagerForClass($class);
+        $this->productCategoriesClass = $productCategoriesClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuery()
+    {
+        if (!$this->query) {
+            $this->query = $this->getRepository()->createQueryBuilder('product');
+        }
+
+        return $this->query;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFilters()
+    {
+        $qb = $this->getQuery();
+
+        // Master product only filter (no variations)
+        $field = sprintf('%s.parent', $qb->getRootAlias());
+        $this->filters[] = $qb->expr()->isNull($field);
+
+        // Category filter
+        $category = $this->getSearchParameter('category');
+
+        if ($category) {
+            $this->filters[] = $qb->expr()->orX(
+                $qb->expr()->eq('category.id', $category),
+                $qb->expr()->eq('category.parent', $category)
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFacets()
+    {
+
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildQuery()
+    {
+        $query = $this->getQuery();
+        $query->select('DISTINCT product')
+              ->leftJoin(sprintf('%s.productCategories', $query->getRootAlias()), 'pc')
+              ->leftJoin('pc.category', 'category')
+              ->andWhere('product.name LIKE :term OR product.description LIKE :term')
+              ->setParameter('term', '%' . $this->getSearchParameter('q') . '%');
+
+        $filters = $query->expr()->andX();
+
+        foreach ($this->getFilters() as $filter) {
+            $filters->add($filter);
+        }
+
+        $query->andWhere($filters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildDatagrid()
+    {
+        if ($this->datagrid) {
+            return;
+        }
+
+        $form = $this->buildForm();
+
+        $this->datagrid = new Datagrid(new ProxyQuery($this), new Pager(), $form, array(
+            '_page'       => $this->getSearchParameter('page'),
+            '_per_page'   => 6,
+            '_sort_by'    => $this->getSortValue('by'),
+            '_sort_order' => $this->getSortValue('order'),
+            'sort'        => $this->getSearchParameter('sort'),
+            'q'           => $this->getSearchParameter('q'),
+            'category'    => $this->getSearchParameter('category'),
+            'price'       => $this->getSearchParameter('price'),
+        ));
+    }
+
+    /**
+     * Returns Doctrine categories facets query
+     *
+     * @return mixed
+     */
+    public function getFacetsQuery()
+    {
+        $query = $this->getManager()->createQueryBuilder();
+        $query->select('category.id AS term, count(pc.product) AS products_nb')
+            ->from($this->productCategoriesClass, 'pc')
+            ->innerJoin('pc.category', 'category')
+            ->innerJoin('pc.product', 'product')
+            ->groupBy('category.id');
+
+        $query->andWhere('product.name LIKE :term OR product.description LIKE :term')
+            ->setParameter('term', '%' . $this->getSearchParameter('q') . '%');
+
+        $filters = $query->expr()->andX();
+
+        foreach ($this->getFilters() as $filter) {
+            $filters->add($filter);
+        }
+
+        $query->andWhere($filters);
+
+        return $query;
+    }
+}

--- a/src/ProductBundle/Search/Provider/ElasticaSearchProvider.php
+++ b/src/ProductBundle/Search/Provider/ElasticaSearchProvider.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Search\Provider;
+
+use FOS\ElasticaBundle\Manager\RepositoryManagerInterface;
+use Sonata\DatagridBundle\Datagrid\Datagrid;
+use Sonata\DatagridBundle\Pager\Elastica\Pager;
+use Sonata\DatagridBundle\ProxyQuery\Elastica\ProxyQuery;
+
+/**
+ * Class ElasticaSearchProvider
+ *
+ * This is the Elasticsearch search provider (used via FOSElasticaBundle)
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class ElasticaSearchProvider extends BaseSearchProvider implements SearchProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuery()
+    {
+        if (!$this->query) {
+            $this->query = new \Elastica\Query();
+        }
+
+        return $this->query;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFilters()
+    {
+        if ($this->filters) {
+            return;
+        }
+
+        // Master product only filter (no variations)
+        $this->filters[] = new \Elastica\Filter\Missing('parent');
+
+        // Category filter
+        if ($this->getSearchParameter('category')) {
+            $this->filters[] = new \Elastica\Filter\Term(array(
+                'product_categories.category_id' => $this->getSearchParameter('category')
+            ));
+        }
+
+        // Price filter
+        if ($this->getSearchParameter('price')) {
+            $this->filters[] = new \Elastica\Filter\Range('price', array(
+                'to' => $this->getSearchParameter('price')
+            ));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFacets()
+    {
+        if ($this->facets) {
+            return;
+        }
+
+        // Categories facet
+        $categories = new \Elastica\Facet\Terms('categories');
+        $categories->setField('product_categories.category_id');
+
+        $this->facets[] = $categories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildQuery()
+    {
+        $query = $this->getQuery();
+        $query->setQuery(new \Elastica\Query\QueryString($this->getSearchParameter('term')));
+
+        $filters = new \Elastica\Filter\Bool();
+
+        // Filters
+        foreach ($this->getFilters() as $filter)
+        {
+            $filters->addMust($filter);
+        }
+
+        $query->setFilter($filters);
+
+        // Facets
+        foreach($this->getFacets() as $facet) {
+            $facet->setFilter($filters);
+
+            $query->addFacet($facet);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildDatagrid()
+    {
+        if ($this->datagrid) {
+            return;
+        }
+
+        $form = $this->buildForm();
+
+        $this->datagrid = new Datagrid(new ProxyQuery($this), new Pager(), $form, array(
+            '_page'       => $this->getSearchParameter('page'),
+            '_per_page'   => 6,
+            '_sort_by'    => $this->getSortValue('by'),
+            '_sort_order' => $this->getSortValue('order'),
+            'sort'        => $this->getSearchParameter('sort'),
+            'q'           => $this->getSearchParameter('q'),
+            'category'    => $this->getSearchParameter('category'),
+            'price'       => $this->getSearchParameter('price'),
+        ));
+    }
+}

--- a/src/ProductBundle/Search/Provider/SearchProviderInterface.php
+++ b/src/ProductBundle/Search/Provider/SearchProviderInterface.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Search\Provider;
+
+use Sonata\DatagridBundle\Datagrid\DatagridInterface;
+
+/**
+ * Class SearchProviderInterface
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+interface SearchProviderInterface
+{
+    /**
+     * Builds search request
+     *
+     * @return void
+     */
+    public function build();
+
+    /**
+     * Returns search entity manager
+     *
+     * @return mixed
+     */
+    public function getManager();
+
+    /**
+     * Returns search entity class name
+     *
+     * @return string
+     */
+    public function getClass();
+
+    /**
+     * Returns search entity repository
+     *
+     * @return mixed
+     */
+    public function getRepository();
+
+    /**
+     * Returns search provider query
+     *
+     * @return mixed
+     */
+    public function getQuery();
+
+    /**
+     * Sets search parameters like the query string, sort order, filters, ...
+     *
+     * @param array $searchParameters
+     */
+    public function setSearchParameters(array $searchParameters);
+
+    /**
+     * Returns search parameters
+     *
+     * @return array
+     */
+    public function getSearchParameters();
+
+    /**
+     * Returns search provider facets
+     *
+     * @return array
+     */
+    public function getFacets();
+
+    /**
+     * Returns search provider filters
+     *
+     * @return array
+     */
+    public function getFilters();
+
+    /**
+     * Returns search provider datagrid
+     *
+     * @return DatagridInterface
+     */
+    public function getDatagrid();
+
+    /**
+     * Builds product search filters to apply to query
+     *
+     * @return void
+     */
+    public function buildFilters();
+
+    /**
+     * Builds product search facets to apply to query
+     *
+     * @return void
+     */
+    public function buildFacets();
+
+    /**
+     * Builds product search query
+     *
+     * @return void
+     */
+    public function buildQuery();
+
+    /**
+     * Builds product datagrid
+     *
+     * @return void
+     */
+    public function buildDatagrid();
+}

--- a/src/ProductBundle/Search/SearchBuilder.php
+++ b/src/ProductBundle/Search/SearchBuilder.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Search;
+
+use Sonata\DatagridBundle\Datagrid\DatagridInterface;
+use Sonata\ProductBundle\Search\Provider\SearchProviderInterface;
+
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class SearchBuilder
+ *
+ * This is the search builder
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class SearchBuilder
+{
+    /**
+     * @var SearchProviderInterface
+     */
+    protected $provider;
+
+    /**
+     * Constructor
+     *
+     * @param SearchProviderInterface $provider A Sonata search provider
+     */
+    public function __construct(SearchProviderInterface $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Returns search provider
+     *
+     * @return SearchProviderInterface
+     */
+    public function getProvider()
+    {
+        return $this->provider;
+    }
+
+    /**
+     * Returns product search filters
+     *
+     * @return array
+     */
+    public function getFilters()
+    {
+        return $this->getProvider()->getFilters();
+    }
+
+    /**
+     * Returns product search facets
+     *
+     * @return array
+     */
+    public function getFacets()
+    {
+        return $this->getProvider()->getFacets();
+    }
+
+    /**
+     * Returns datagrid
+     *
+     * @return DatagridInterface
+     */
+    public function getDatagrid()
+    {
+        return $this->getProvider()->getDatagrid();
+    }
+
+    /**
+     * Handles a search from a Symfony Request instance
+     *
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function handleRequest(Request $request)
+    {
+        $this->getProvider()->setSearchParameters(array(
+            'q'          => $request->query->get('q'),
+            'term'       => sprintf('*%s*', $request->query->get('q')),
+            'page'       => $request->query->get('page', 1),
+            'category'   => $request->query->get('category'),
+            'price'      => $request->query->get('price'),
+            'sort'       => $request->query->get('sort'),
+        ));
+
+        $this->getProvider()->build();
+    }
+
+    /**
+     * Returns search parameters
+     *
+     * @return array
+     */
+    public function getSearchParameters()
+    {
+        return $this->getProvider()->getSearchParameters();
+    }
+}

--- a/tests/ProductBundle/Search/Provider/BaseSearchProviderTest.php
+++ b/tests/ProductBundle/Search/Provider/BaseSearchProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Tests\ProductBundle\Search\Provider;
+
+use Sonata\ProductBundle\Search\Provider\BaseSearchProvider;
+
+class TestSearchProvider extends BaseSearchProvider {
+    public function buildFilters()
+    {
+        $this->filters[] = 'myfilter';
+    }
+
+    public function buildFacets()
+    {
+        $this->facets[] = 'myfacet';
+    }
+
+    public function buildDatagrid()
+    {
+        $this->datagrid = 'datagrid';
+    }
+
+    public function buildQuery()
+    {
+
+    }
+
+    public function getQuery()
+    {
+
+    }
+}
+
+class ManagerTest {
+    public function getRepository($class)
+    {
+        return $class;
+    }
+}
+
+/**
+ * Class BaseSearchProviderTest
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BaseSearchProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetters()
+    {
+        // Given
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $class = 'Sonata\Test\MyClass';
+
+        $manager = $this->getMock('Sonata\Tests\ProductBundle\Search\Provider\ManagerTest');
+        $manager->expects($this->any())->method('getRepository')->will($this->returnValue(null));
+
+        // When
+        $provider = new TestSearchProvider($formFactory, $manager, $class);
+        $provider->setSearchParameters(array(
+            'parameter' => 'value'
+        ));
+
+        $provider->build();
+
+        // Then
+        $this->assertEquals(array('myfilter'), $provider->getFilters());
+        $this->assertEquals(array('myfacet'), $provider->getFacets());
+        $this->assertEquals('datagrid', $provider->getDatagrid());
+        $this->assertEquals('Sonata\Test\MyClass', $provider->getClass());
+        $this->assertEquals($manager, $provider->getManager());
+        $this->assertNull($provider->getRepository());
+        $this->assertEquals(array('parameter' => 'value'), $provider->getSearchParameters());
+        $this->assertEquals('value', $provider->getSearchParameter('parameter'));
+    }
+}

--- a/tests/ProductBundle/Search/SearchBuilderTest.php
+++ b/tests/ProductBundle/Search/SearchBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Tests\ProductBundle\Search;
+
+use Sonata\ProductBundle\Search\SearchBuilder;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class SearchBuilderTest
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class SearchBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetters()
+    {
+        // Given
+        $provider = $this->getMock('Sonata\ProductBundle\Search\Provider\SearchProviderInterface');
+        $provider->expects($this->any())->method('getFilters')->will($this->returnValue(array('myfilter')));
+        $provider->expects($this->any())->method('getFacets')->will($this->returnValue(array('myfacet')));
+        $provider->expects($this->any())->method('getSearchParameters')->will($this->returnValue(array('parameters')));
+
+        $datagrid = $this->getMock('Sonata\DatagridBundle\Datagrid\DatagridInterface');
+        $provider->expects($this->any())->method('getDatagrid')->will($this->returnValue($datagrid));
+
+        $provider->expects($this->once())->method('setSearchParameters');
+        $provider->expects($this->once())->method('build');
+
+        $request = new Request(array(
+            'q'        => 'my search term',
+            'page'     => 2,
+            'category' => 3,
+            'price'    => 20,
+            'sort'     => 'price_asc'
+        ));
+
+        // When
+        $builder = new SearchBuilder($provider);
+        $builder->handleRequest($request);
+
+        // Then
+        $this->assertEquals($provider, $builder->getProvider());
+        $this->assertEquals($datagrid, $builder->getDatagrid());
+        $this->assertEquals($provider->getSearchParameters(), $builder->getSearchParameters());
+        $this->assertEquals($provider->getFilters(), $builder->getFilters());
+        $this->assertEquals($provider->getFacets(), $builder->getFacets());
+    }
+}


### PR DESCRIPTION
This is a **Work In Progress** PR to add a search engine on e-commerce.

### About

There is using a `SonataDatagridBundle` (not available yet) using the `SonataAdminBundle` Datagrid logic (a `ProxyQuery`, a `Pager`, a `Form`) outside `SonataAdminBundle`.

### Search providers

The idea is to have a `SearchBuilder` class building query from a (search) provider specified in configuration.

There is 2 providers:

* `sonata.product.search.provider.doctrine`: *(default)* Search engine will use Doctrine to perform search,
* `sonata.product.search.provider.elastica`: Search engine will use ElasticSearch (via FOSElasticaBundle) to perform search.

They can be specified in `SonataProductBundle` configuration as follows:

```yml
sonata_product:
    search:
        provider: sonata.product.search.provider.doctrine
```

### Todo

* [x] Add search builder logic with 2 providers (doctrine & elasticsearch)
* [ ] Manage product search filters
* [ ] Add e-commerce documentation
* [ ] Add unit tests
* [x] Release a SonataDatagridBundle