### PR TITLE
Incorrect Address Type send to Payment Selector

### DIFF
--- a/src/BasketBundle/Form/PaymentType.php
+++ b/src/BasketBundle/Form/PaymentType.php
@@ -82,7 +82,7 @@ class PaymentType extends AbstractType
         $address = $basket->getBillingAddress() ?: current($addresses);
         $basket->setBillingAddress($address ?: null);
 
-        $methods = $this->paymentSelector->getAvailableMethods($basket, $basket->getDeliveryAddress());
+        $methods = $this->paymentSelector->getAvailableMethods($basket, $basket->getBillingAddress());
 
         $choices = array();
         foreach ($methods as $method) {


### PR DESCRIPTION
Sonata\Component\Payment\Selector -> getAvailableMethods()expect to have a BillingAddress as second parameters, but it's the basket's delivery address which is send.

Moreover, in the case of a takeaway delivery, we don't have a delivery address, but we need billing methods.