### PR TITLE
Allows to override customer selector component from configuration

### DIFF
--- a/docs/reference/bundles/customer.rst
+++ b/docs/reference/bundles/customer.rst
@@ -30,6 +30,9 @@ The bundle allows you to configure the entity classes; you'll also need to regis
             order:                Application\Sonata\OrderBundle\Entity\Order
             user:                 Application\Sonata\UserBundle\Entity\User
 
+            # You can also implement custom components classes
+            customer_selector:    Sonata\Component\Customer\CustomerSelector
+
     # Enable Doctrine to map the provided entities
     doctrine:
         orm:

--- a/src/CustomerBundle/DependencyInjection/Configuration.php
+++ b/src/CustomerBundle/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('customer')->defaultValue('Application\\Sonata\\CustomerBundle\\Entity\\Customer')->end()
+                        ->scalarNode('customer_selector')->defaultValue('Sonata\\Component\\Customer\\CustomerSelector')->end()
                         ->scalarNode('address')->defaultValue('Application\\Sonata\\CustomerBundle\\Entity\\Address')->end()
                         ->scalarNode('order')->defaultValue('Application\\Sonata\\OrderBundle\\Entity\\Order')->end()
                         ->scalarNode('user')->defaultValue('Application\\Sonata\\UserBundle\\Entity\\User')->end()

--- a/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
+++ b/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
@@ -73,6 +73,7 @@ class SonataCustomerExtension extends Extension
     {
         $container->setParameter('sonata.customer.customer.class', $config['class']['customer']);
         $container->setParameter('sonata.customer.address.class', $config['class']['address']);
+        $container->setParameter('sonata.customer.selector.class', $config['class']['customer_selector']);
 
         $container->setParameter('sonata.customer.admin.customer.entity', $config['class']['customer']);
         $container->setParameter('sonata.customer.admin.address.entity', $config['class']['address']);


### PR DESCRIPTION
I've added a configuration entry to allows doing this:

``` yml
sonata_customer:
    class:
        customer_selector: My\Custom\CustomerSelector
```
