### PR TITLE
handling \DateTime product variations 

### DIFF
--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -361,7 +361,11 @@ abstract class BaseProductProvider implements ProductProviderInterface
 
         // We retrieve the variations fresh from DB so we may find the values
         $variations = $this->getEnabledVariations($product->getParent() ?: $product);
-
+        // In case variation is a DateTime
+        if ($variationValue instanceof \DateTime) {
+            $variationValue = $variationValue->format('Y-m-d H:i');
+        }
+                
         $accessor = PropertyAccess::createPropertyAccessor();
 
         $choices = array();


### PR DESCRIPTION
In order to handle datetime product variations, a format was added in getVariationsChoices. 
I don't really think this is the right place to add this, but that natcasesort was throwing an error.
Is there a better place for this ?
