### PR TITLE
handling \DateTime product variations

### DIFF
--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -338,6 +338,12 @@ abstract class BaseProductProvider implements ProductProviderInterface
         foreach ($variations as $mVariation) {
             foreach ($fields as $field) {
                 $variationValue = $accessor->getValue($mVariation, $field);
+                
+                // In case variation is a DateTime
+                if ($variationValue instanceof \DateTime) {
+                    $variationValue = $variationValue->format('Y-m-d H:i');
+                }
+                
                 if (!array_key_exists($field, $choices) || !in_array($variationValue, $choices[$field])) {
                     $choices = array_merge_recursive($choices, array($field => array($variationValue)));
                 }


### PR DESCRIPTION
In order to handle datetime product variations, a format was added in getVariationsChoices. 
I don't really think this is the right place to add this, but that natcasesort was throwing an error.
Is there a better place for this ?
