### PR TITLE
Update SonataOrderExtension.php

### DIFF
--- a/src/OrderBundle/DependencyInjection/SonataOrderExtension.php
+++ b/src/OrderBundle/DependencyInjection/SonataOrderExtension.php
@@ -118,7 +118,7 @@ class SonataOrderExtension extends Extension
             'targetEntity'  => $config['class']['order'],
             'cascade'       => array(),
             'mappedBy'      => NULL,
-            'inversedBy'    => NULL,
+            'inversedBy'    => 'orderElements',
             'joinColumns'   => array(
                 array(
                     'name'  => 'order_id',


### PR DESCRIPTION
fixes that:
php app/console doctrine:schema:validate
[Mapping]  FAIL - The entity-class 'Application\Sonata\OrderBundle\Entity\Order' mapping is invalid:
* The field Application\Sonata\OrderBundle\Entity\Order#orderElements is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Application\Sonata\OrderBundle\Entity\OrderElement#order does not contain the required 'inversedBy=orderElements' attribute.