### PR TITLE
Update OgonePayment.php

### DIFF
--- a/src/Component/Payment/Ogone/OgonePayment.php
+++ b/src/Component/Payment/Ogone/OgonePayment.php
@@ -199,7 +199,7 @@ class OgonePayment extends BasePayment
     protected function compareOrderToParams(OrderInterface $order, array $params)
     {
         return $order->getReference() === $params['orderID']
-            && $order->getCurrency() === $params['currency']
+            && $order->getCurrency() == $params['currency']
             && floatval($order->getTotalInc()) === floatval($params['amount']);
     }
 


### PR DESCRIPTION
In compareOrderToParams, comparison shall be made on value (and not on type) as $order->getCurrency() is now Object whereas $params['currency'] is String (currently throws a UnauthorizedHttpException)