### PR TITLE
Multiple level product type hierarchy

### DIFF
--- a/src/Component/Product/Pool.php
+++ b/src/Component/Product/Pool.php
@@ -77,7 +77,7 @@ class Pool
     {
         foreach ($this->products as $code => $productDescription) {
             $className = $productDescription->getManager()->getClass();
-            if ($product instanceof $className) {
+            if (get_class($product) == $className) {
                 return $code;
             }
         }


### PR DESCRIPTION
if I have a product type that is a descendant of other type managed by the pool, the match is not sure, because - if the parent is listed before the actual- the "code" return if the one of the parent.