### PR TITLE
BasketEntityFactory must implements LogoutHandlerInterface

### DIFF
--- a/src/Component/Basket/BaseBasketFactory.php
+++ b/src/Component/Basket/BaseBasketFactory.php
@@ -12,6 +12,10 @@ namespace Sonata\Component\Basket;
 
 use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * Class BaseBasketFactory
@@ -20,7 +24,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  *
  * @author Hugo Briand <briand@ekino.com>
  */
-abstract class BaseBasketFactory implements BasketFactoryInterface
+abstract class BaseBasketFactory implements BasketFactoryInterface, LogoutHandlerInterface
 {
     /**
      * @var \Sonata\Component\Basket\BasketManagerInterface
@@ -54,5 +58,14 @@ abstract class BaseBasketFactory implements BasketFactoryInterface
         $this->basketBuilder    = $basketBuilder;
         $this->currencyDetector = $currencyDetector;
         $this->session          = $session;
+    }
+
+     /**
+     * {@inheritdoc}
+     */
+    public function logout(Request $request, Response $response, TokenInterface $token)
+    {
+        // Remove anonymous basket
+        $this->session->remove($this->getSessionVarName());
     }
 }

--- a/src/Component/Basket/BasketEntityFactory.php
+++ b/src/Component/Basket/BasketEntityFactory.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 /**
  * @todo Refacto (add an abstract class with the properties & constructor)
  */
-class BasketEntityFactory implements BasketFactoryInterface
+class BasketEntityFactory extends BaseBasketFactory implements BasketFactoryInterface
 {
     /**
      * @var \Sonata\Component\Basket\BasketManagerInterface


### PR DESCRIPTION
The class BasketEntityFactory must implements LogoutHandlerInterface in order to avoid trigger this isse

Catchable Fatal Error: Argument 1 passed to Symfony\Component\Security\Http\Firewall\LogoutListener::addHandler() must implement interface Symfony\Component\Security\Http\Logout\LogoutHandlerInterface, instance of Sonata\Component\Basket\BasketEntityFactory given, called in /data/www/prod/.../sandbox/app/cache/dev/appDevDebugProjectContainer.php on line 7133 and defined 