### PR TITLE
add a contraint of validation to field "type" of address form

### DIFF
--- a/src/CustomerBundle/Resources/config/validation.xml
+++ b/src/CustomerBundle/Resources/config/validation.xml
@@ -31,6 +31,10 @@
             <constraint name="NotNull" />
         </getter>
 
+        <getter property="type">
+            <constraint name="NotNull" />
+        </getter>
+
         <getter property="address1">
             <constraint name="NotNull" />
         </getter>


### PR DESCRIPTION
'type' cannot be null when we create or modify an adress