### PR TITLE
Update validation of address form

### DIFF
--- a/src/BasketBundle/Form/AddressType.php
+++ b/src/BasketBundle/Form/AddressType.php
@@ -146,7 +146,8 @@ class AddressType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class'  => $this->addressClass,
-            'addresses'   => array()
+            'addresses'   => array(),
+            'validation_groups' => array('front'),
         ));
     }
 

--- a/src/CustomerBundle/Resources/config/validation.xml
+++ b/src/CustomerBundle/Resources/config/validation.xml
@@ -28,28 +28,62 @@
 
     <class name="Sonata\CustomerBundle\Entity\BaseAddress">
         <getter property="name">
-            <constraint name="NotNull" />
+            <constraint name="NotNull">
+                <option name="groups">
+                    <value>front</value>
+                    <value>Default</value>
+                </option>
+            </constraint>
         </getter>
 
         <getter property="type">
-            <constraint name="NotNull" />
+            <constraint name="NotNull">
+                <option name="groups">
+                    <value>Default</value>
+                </option>
+            </constraint>
         </getter>
 
         <getter property="address1">
-            <constraint name="NotNull" />
+            <constraint name="NotNull">
+                <option name="groups">
+                    <value>front</value>
+                    <value>Default</value>
+                </option>
+            </constraint>
         </getter>
 
         <getter property="postcode">
-            <constraint name="NotNull" />
+            <constraint name="NotNull">
+                <option name="groups">
+                    <value>front</value>
+                    <value>Default</value>
+                </option>
+            </constraint>
         </getter>
 
         <getter property="city">
-            <constraint name="NotNull" />
+            <constraint name="NotNull">
+                <option name="groups">
+                    <value>front</value>
+                    <value>Default</value>
+                </option>
+            </constraint>
         </getter>
 
         <getter property="countryCode">
-            <constraint name="NotNull" />
-            <constraint name="Country" />
+            <constraint name="NotNull">
+                <option name="groups">
+                    <value>front</value>
+                    <value>Default</value>
+                </option>
+            </constraint>
+            <constraint name="Country">
+                <option name="groups">
+                    <value>front</value>
+                    <value>Default</value>
+                </option>
+            </constraint>
         </getter>
     </class>
 


### PR DESCRIPTION
Update validation of address form with to groups
* 'Default' : group used by the default form (used by API) where 'type' can not be null
* 'front' : group used by the basketBundle where type is not mandatory (it is defined before the save of the address with the appropriate value)
