### PR TITLE
Update basket API

### DIFF
--- a/src/BasketBundle/Form/ApiBasketType.php
+++ b/src/BasketBundle/Form/ApiBasketType.php
@@ -13,8 +13,7 @@ namespace Sonata\BasketBundle\Form;
 
 use Metadata\MetadataFactoryInterface;
 
-use Sonata\Component\Currency\CurrencyDataTransformer;
-use Sonata\Component\Currency\CurrencyManagerInterface;
+use Sonata\Component\Currency\CurrencyFormType;
 use Sonata\Component\Form\Transformer\SerializeDataTransformer;
 
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -35,20 +34,20 @@ class ApiBasketType extends AbstractType
     protected $class;
 
     /**
-     * @var CurrencyManagerInterface
+     * @var CurrencyFormType
      */
-    protected $currencyManager;
+    protected $currencyFormType;
 
     /**
      * Constructor
      *
-     * @param string                   $class           An entity data class
-     * @param CurrencyManagerInterface $currencyManager A Sonata ecommerce currency manager
+     * @param string                $class           An entity data class
+     * @param CurrencyFormType      $currencyFormType A Sonata ecommerce currency form type
      */
-    public function __construct($class, CurrencyManagerInterface $currencyManager)
+    public function __construct($class, CurrencyFormType $currencyFormType)
     {
-        $this->class           = $class;
-        $this->currencyManager = $currencyManager;
+        $this->class            = $class;
+        $this->currencyFormType = $currencyFormType;
     }
 
     /**
@@ -56,11 +55,8 @@ class ApiBasketType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $currencyTransformer = new CurrencyDataTransformer($this->currencyManager);
-
         $builder->add(
-            $builder->create('currency', null)
-                ->addModelTransformer($currencyTransformer)
+            $builder->create('currency', $this->currencyFormType)
         );
     }
 
@@ -72,6 +68,7 @@ class ApiBasketType extends AbstractType
         $resolver->setDefaults(array(
             'data_class'      => $this->class,
             'csrf_protection' => false,
+            'validation_groups' => array('api'),
         ));
     }
 

--- a/src/BasketBundle/Resources/config/api_form.xml
+++ b/src/BasketBundle/Resources/config/api_form.xml
@@ -21,7 +21,7 @@
             <tag name="form.type" alias="sonata_basket_api_form_basket" />
 
             <argument>%sonata.basket.basket.class%</argument>
-            <argument type="service" id="sonata.price.currency.manager" />
+            <argument type="service" id="sonata.price.currency.form_type" />
         </service>
 
         <!-- Basket element type -->

--- a/src/BasketBundle/Resources/config/validation.xml
+++ b/src/BasketBundle/Resources/config/validation.xml
@@ -43,6 +43,43 @@
                </option>
            </constraint>
         </getter>
+
+        <getter property="paymentMethodCode">
+            <constraint name="NotNull" >
+                <option name="groups" >
+                    <value>api</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="deliveryMethodCode">
+            <constraint name="NotNull" >
+                <option name="groups" >
+                    <value>api</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="locale">
+            <constraint name="Locale" >
+                <option name="groups" >
+                    <value>api</value>
+                </option>
+            </constraint>
+            <constraint name="NotNull" >
+                <option name="groups" >
+                    <value>api</value>
+                </option>
+            </constraint>
+        </getter>
+
+        <getter property="currency">
+            <constraint name="NotNull" >
+                <option name="groups" >
+                    <value>api</value>
+                </option>
+            </constraint>
+        </getter>
     </class>
 
     <class name="Sonata\CustomerBundle\Entity\BaseAddress">

--- a/src/Component/Basket/Basket.php
+++ b/src/Component/Basket/Basket.php
@@ -717,6 +717,14 @@ class Basket implements \Serializable, BasketInterface
     /**
      * {@inheritdoc}
      */
+    public function setDeliveryMethodCode($deliveryMethodCode)
+    {
+        $this->deliveryMethodCode = $deliveryMethodCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDeliveryMethodCode()
     {
         return $this->deliveryMethodCode;

--- a/tests/BasketBundle/Form/ApiBasketTypeTest.php
+++ b/tests/BasketBundle/Form/ApiBasketTypeTest.php
@@ -11,6 +11,8 @@
 namespace Sonata\BasketBundle\Tests\Form;
 
 use Sonata\BasketBundle\Form\ApiBasketType;
+use Sonata\Component\Currency\CurrencyDataTransformer;
+use Sonata\Component\Currency\CurrencyFormType;
 
 /**
  * Class ApiBasketTypeTest
@@ -23,11 +25,14 @@ class ApiBasketTypeTest extends \PHPUnit_Framework_TestCase
     {
         $currencyManager = $this->getMock('Sonata\Component\Currency\CurrencyManagerInterface');
 
-        $type = new ApiBasketType('my.test.class', $currencyManager);
+        $currencyDataTransformer = new CurrencyDataTransformer($currencyManager);
+
+        $currencyFormType = new CurrencyFormType($currencyDataTransformer);
+
+        $type = new ApiBasketType('my.test.class', $currencyFormType);
 
         $builder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $builder->expects($this->once())->method('create')->will($this->returnSelf());
-        $builder->expects($this->once())->method('addModelTransformer');
 
         $type->buildForm($builder, array());
     }


### PR DESCRIPTION
Some modifications of basket API
* use of 'CurrencyFormType' in basket form
* update validation of the basket form with a group 'api' and new constraints : 
   * 'paymentMethodCode', 'deliveryMethodCode', 'locale' and 'currency' can not be null
   * 'locale' must have one of specific values
* add a method 'setDeliveryMethodCode' in the basket component that was missing
* add a control to verify the customer does not already have another basket when a new one is created with API