### PR TITLE
Update RecentOrdersBlockService.php

### DIFF
--- a/src/OrderBundle/Block/RecentOrdersBlockService.php
+++ b/src/OrderBundle/Block/RecentOrdersBlockService.php
@@ -19,7 +19,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\AdminBundle\Validator\ErrorElement;
 
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Block\BaseBlockService;


### PR DESCRIPTION
Fix this error: 
```php
Declaration of Sonata\OrderBundle\Block\RecentOrdersBlockService::validateBlock() must be compatible with Sonata\BlockBundle\Block\BlockServiceInterface::validateBlock(Sonata\AdminBundle\Validator\ErrorElement $errorElement, Sonata\BlockBundle\Model\BlockInterface $block)
```

Changed the ErrorElement namespace from BlockServiceInterface