### PR TITLE
Use seo-bundle ~2.0@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "sonata-project/media-bundle": "~2.2@dev",
         "sonata-project/user-bundle": "~2.2@dev",
         "sonata-project/intl-bundle": "~2.1",
-        "sonata-project/seo-bundle": "~1",
+        "sonata-project/seo-bundle": "~2.0@dev",
         "sonata-project/classification-bundle": "~2.2",
         "sonata-project/notification-bundle": "~2.2",
         "sonata-project/comment-bundle": "~2.2@dev",


### PR DESCRIPTION
If we run a composer update on sonata-sandbox 2.4-develop, we got this:

```sh
$ composer up
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Package dflydev/markdown is abandoned, you should avoid using it. Use michelf/php-markdown instead.
Generating autoload files
Updating the "app/config/parameters.yml" file
PHP Fatal error:  Declaration of Sonata\SeoBundle\Block\Social\BaseFacebookSocialPluginsBlockService::validateBlock() must be compatible with Sonata\BlockBundle\Block\BlockAdminServiceInterface::validateBlock(Sonata\CoreBundle\Validator\ErrorElement $errorElement, Sonata\BlockBundle\Model\BlockInterface $block) in /home/sullivan/projects/fork/sonata-sandbox/vendor/sonata-project/seo-bundle/Block/Social/BaseFacebookSocialPluginsBlockService.php on line 51
PHP Stack trace:
PHP   1. {main}() /home/sullivan/projects/fork/sonata-sandbox/app/console:0
PHP   2. Symfony\Component\Console\Application->run() /home/sullivan/projects/fork/sonata-sandbox/app/console:34
PHP   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() /home/sullivan/projects/fork/sonata-sandbox/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:126
PHP   4. Symfony\Component\HttpKernel\Kernel->boot() /home/sullivan/projects/fork/sonata-sandbox/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:70
PHP   5. Symfony\Component\HttpKernel\Kernel->initializeContainer() /home/sullivan/projects/fork/sonata-sandbox/app/bootstrap.php.cache:2344
PHP   6. Symfony\Component\DependencyInjection\ContainerBuilder->compile() /home/sullivan/projects/fork/sonata-sandbox/app/bootstrap.php.cache:2565
PHP   7. Symfony\Component\DependencyInjection\Compiler\Compiler->compile() /home/sullivan/projects/fork/sonata-sandbox/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/ContainerBuilder.php:614
PHP   8. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->process() /home/sullivan/projects/fork/sonata-sandbox/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php:117
PHP   9. JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass->processDefinition() /home/sullivan/projects/fork/sonata-sandbox/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:64
PHP  10. class_exists() /home/sullivan/projects/fork/sonata-sandbox/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:110
PHP  11. spl_autoload_call() /home/sullivan/projects/fork/sonata-sandbox/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:110
PHP  12. Symfony\Component\Debug\DebugClassLoader->loadClass() /home/sullivan/projects/fork/sonata-sandbox/vendor/jms/aop-bundle/JMS/AopBundle/DependencyInjection/Compiler/PointcutMatchingPass.php:0
PHP  13. require() /home/sullivan/projects/fork/sonata-sandbox/vendor/symfony/symfony/src/Symfony/Component/Debug/DebugClassLoader.php:151
PHP  14. spl_autoload_call() /home/sullivan/projects/fork/sonata-sandbox/vendor/symfony/symfony/src/Symfony/Component/Debug/DebugClassLoader.php:26
PHP  15. Symfony\Component\Debug\DebugClassLoader->loadClass() /home/sullivan/projects/fork/sonata-sandbox/vendor/symfony/symfony/src/Symfony/Component/Debug/DebugClassLoader.php:0
Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the post-update-cmd event terminated with an exception
```

We need last commit of seo-bundle to fix this issue, but if we try `"sonata-project/seo-bundle": "~2.0@dev"` on config, we got this:

```sh
$ composer up
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - sonata-project/ecommerce dev-develop requires sonata-project/seo-bundle ~1 -> no matching package found.
    - sonata-project/ecommerce dev-develop requires sonata-project/seo-bundle ~1 -> no matching package found.
    - Installation request for sonata-project/ecommerce dev-develop -> satisfiable by sonata-project/ecommerce[dev-develop].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```

This PR should fix it.

Reference to thoses messages: https://github.com/sonata-project/SonataAdminBundle/pull/2793#issuecomment-78058921

Thanks.