### PR TITLE
detect where is the ProductBundle directory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -123,7 +123,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/reference/architecture/api.rst
+++ b/docs/reference/architecture/api.rst
@@ -8,8 +8,8 @@ Setup
 
 If you wish to use it, you must first follow the installation instructions of both bundles:
 
-* `FOSRestBundle<https://github.com/FriendsOfSymfony/FOSRestBundle>`_
-* `NelmioApiDocBundle<https://github.com/nelmio/NelmioApiDocBundle>`_
+* `FOSRestBundle <https://github.com/FriendsOfSymfony/FOSRestBundle>`_
+* `NelmioApiDocBundle <https://github.com/nelmio/NelmioApiDocBundle>`_
 
 Here's the configuration we used, you may adapt it to your needs:
 

--- a/docs/reference/architecture/index.rst
+++ b/docs/reference/architecture/index.rst
@@ -109,3 +109,4 @@ Going in depths
     order
     payment
     invoice
+    api

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -13,7 +13,7 @@ Pre-requisites
 
 
 One-line installation
-=================
+=====================
 Create a new project is as simple as using composer.
 ::
 

--- a/docs/reference/tutorials/create-product.rst
+++ b/docs/reference/tutorials/create-product.rst
@@ -26,7 +26,7 @@ Run the following command to create the files:
 
 	php app/console sonata:product:generate Bowl sonata.ecommerce_demo.product.bowl
 
-The required base files will be created in ``src/Application/Sonata/ProductBundle``. 
+The required base files will be created in the ``ProductBundle`` directory (ex. ``src/Application/Sonata/ProductBundle``). 
 To finalize the installation, we have to define the missing parameters like the type itself and the related manager. These data have to be provided in ``src/Application/Sonata/ProductBundle/Resources/config/product.yml``.
 ::
 

--- a/src/ProductBundle/Command/GenerateProductCommand.php
+++ b/src/ProductBundle/Command/GenerateProductCommand.php
@@ -49,13 +49,19 @@ class GenerateProductCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // find a better way to detect the Application folder
-        $bundle_dir = sprintf("%s/../src/Application/Sonata/ProductBundle",
-            $this->getContainer()->get('kernel')->getRootDir()
-        );
+        $childBundle = array_filter($this->getContainer()->get('kernel')->getBundle('SonataProductBundle', false), function($class) {
+            return $class->getParent() == 'SonataProductBundle';
+        });
+        if (count($childBundle) == 0) {
+            throw new \Exception('Please initialize a ProductBundle first');
+        } elseif (count($childBundle) > 1) {
+            throw new \Exception('Multiple children of SonataProductBundle detected');
+        }
+
+        $bundle_dir = $childBundle[0]->getPath();
 
         if (!is_dir($bundle_dir)) {
-            throw new \Exception('Please initialize a ProductBundle first in the Application directory');
+            throw new \Exception('Please initialize a ProductBundle first in an Application directory');
         }
 
         $output->writeln(sprintf('Generating files for the <info>%s</info>', $input->getArgument('product')));


### PR DESCRIPTION
@rande solved issue https://github.com/sonata-project/ecommerce/issues/332.
The child bundle is detected searching for bundles with `SonataProductBundle` as a parent.
If only one is found, no errors are thrown.

Also I found some errors/warnings in the documentation