### PR TITLE
Remove "number" field from configureShowFields in BaseProductProvider

### DIFF
--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -526,7 +526,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
             ->add('sku')
             ->add('description')
             ->add('price')
-            ->add('number')
+            ->add('isPriceIncludingVat', 'boolean')
             ->add('vatRate')
             ->add('stock')
             ->add('enabled')


### PR DESCRIPTION
there is no "number" property in BaseProduct whereas "priceIncludingVat" exists