### PR TITLE
Adding supports for disabled products (SEO friendliness)

### DIFF
--- a/src/ProductBundle/Controller/ProductController.php
+++ b/src/ProductBundle/Controller/ProductController.php
@@ -33,7 +33,7 @@ class ProductController extends Controller
      */
     public function viewAction($productId, $slug)
     {
-        $product = $this->get('sonata.product.set.manager')->findEnabledFromIdAndSlug($productId, $slug);
+        $product = $this->get('sonata.product.set.manager')->findOneBy(array('id' => $productId, 'slug' => $slug));
 
         if (!$product) {
             throw new NotFoundHttpException(sprintf('Unable to find the product with id=%d', $productId));

--- a/src/ProductBundle/Resources/translations/SonataProductBundle.en.xliff
+++ b/src/ProductBundle/Resources/translations/SonataProductBundle.en.xliff
@@ -306,6 +306,10 @@
                 <source>product_price</source>
                 <target>Price</target>
             </trans-unit>
+            <trans-unit id="product_not_available">
+                <source>product_not_available</source>
+                <target>This product is not available anymore.</target>
+            </trans-unit>
             <trans-unit id="product_variations">
                 <source>product_variations</source>
                 <target>Variations</target>

--- a/src/ProductBundle/Resources/translations/SonataProductBundle.fr.xliff
+++ b/src/ProductBundle/Resources/translations/SonataProductBundle.fr.xliff
@@ -341,6 +341,10 @@
                 <source>product_price</source>
                 <target>Prix</target>
             </trans-unit>
+            <trans-unit id="product_not_available">
+                <source>product_not_available</source>
+                <target>Ce produit n'est plus disponible.</target>
+            </trans-unit>
             <trans-unit id="product_variations">
                 <source>product_variations</source>
                 <target>Variations</target>

--- a/src/ProductBundle/Resources/views/Product/view.html.twig
+++ b/src/ProductBundle/Resources/views/Product/view.html.twig
@@ -69,10 +69,16 @@ file that was distributed with this source code.
                             {% block product_generic_properties %}
                                 <li class="list-group-item">
                                     {% block product_unit_price %}
-                                        <small class="list-group-item-text">
-                                            {{ 'product_price'|trans({}, "SonataProductBundle") }}:&nbsp;
-                                            <span itemprop="price">{{ sonata_product_price(product, currency, true)|number_format_currency(currency) }}</span>
-                                        </small><br/>
+                                        {% if product.enabled %}
+                                            <small class="list-group-item-text">
+                                                {{ 'product_price'|trans({}, "SonataProductBundle") }}:&nbsp;
+                                                <span itemprop="price">{{ sonata_product_price(product, currency, true)|number_format_currency(currency) }}</span>
+                                            </small><br/>
+                                        {% else %}
+                                            <small class="list-group-item-text">
+                                                <span>{{ 'product_not_available'|trans({}, "SonataProductBundle") }}</span>
+                                            </small><br/>
+                                        {% endif %}
                                     {% endblock %}
                                     {% block product_reference %}
                                         <small class="list-group-item-text">

--- a/src/ProductBundle/Resources/views/Product/view.html.twig
+++ b/src/ProductBundle/Resources/views/Product/view.html.twig
@@ -69,16 +69,14 @@ file that was distributed with this source code.
                             {% block product_generic_properties %}
                                 <li class="list-group-item">
                                     {% block product_unit_price %}
-                                        {% if product.enabled %}
-                                            <small class="list-group-item-text">
+                                        <small class="list-group-item-text">
+                                            {% if product.enabled %}
                                                 {{ 'product_price'|trans({}, "SonataProductBundle") }}:&nbsp;
                                                 <span itemprop="price">{{ sonata_product_price(product, currency, true)|number_format_currency(currency) }}</span>
-                                            </small><br/>
-                                        {% else %}
-                                            <small class="list-group-item-text">
+                                            {% else %}
                                                 <span>{{ 'product_not_available'|trans({}, "SonataProductBundle") }}</span>
-                                            </small><br/>
-                                        {% endif %}
+                                            {% endif %}
+                                        </small><br/>
                                     {% endblock %}
                                     {% block product_reference %}
                                         <small class="list-group-item-text">

--- a/src/ProductBundle/Resources/views/Product/view.html.twig
+++ b/src/ProductBundle/Resources/views/Product/view.html.twig
@@ -108,32 +108,34 @@ file that was distributed with this source code.
                             {% endblock %}
                         </ul>
                     {% endblock %}
-
-                    <div class="panel-footer">
-                        {% block  product_variations_form_block %}
-                            <div class="row">
-                                <div class="col-lg-12">
-                                    {{ sonata_block_render({'type': 'sonata.product.block.variations_form'}, {'product': product, 'variations_properties': variations_properties}) }}
+                    
+                    {% if product.enabled %}
+                        <div class="panel-footer">
+                            {% block  product_variations_form_block %}
+                                <div class="row">
+                                    <div class="col-lg-12">
+                                        {{ sonata_block_render({'type': 'sonata.product.block.variations_form'}, {'product': product, 'variations_properties': variations_properties}) }}
+                                    </div>
                                 </div>
-                            </div>
-                        {% endblock %}
-
-                        {% block product_delivery %}
-                            <div class="row">
-                                Block 'product_delivery' to override
-                            </div>
-                        {% endblock %}
-
-                        {% if product.isSalable %}
-                            <div itemprop="offers" class="row" itemscope itemtype="http://schema.org/Offer">
-                                <div class="col-lg-12">
-                                    {% block product_basket %}
-                                        {% include "SonataBasketBundle:Basket:add_product_form.html.twig" %}
-                                    {% endblock %}
+                            {% endblock %}
+    
+                            {% block product_delivery %}
+                                <div class="row">
+                                    Block 'product_delivery' to override
                                 </div>
-                            </div>
-                        {% endif %}
-                    </div>
+                            {% endblock %}
+    
+                            {% if product.isSalable %}
+                                <div itemprop="offers" class="row" itemscope itemtype="http://schema.org/Offer">
+                                    <div class="col-lg-12">
+                                        {% block product_basket %}
+                                            {% include "SonataBasketBundle:Basket:add_product_form.html.twig" %}
+                                        {% endblock %}
+                                    </div>
+                                </div>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
         {% endblock %}


### PR DESCRIPTION
Hi,
When we disable a product and then go on the page of this product, it results in 404, which is pretty bad for indexation bots.
So I added the ability to show the page of disabled products, with a notice. The products still don't appear in the catalog, similar, etc pages, and you can't add them in your cart.