### PR TITLE
Remove internal test classes from autoloader

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -4,3 +4,7 @@ UPGRADE FROM 1.x to 2.0
 ### Sonata dependencies
 
 Bump all Sonata dependencies to versions managed by the new management system.
+
+### Tests
+
+All files under the ``Tests`` directory are now correctly handled as internal test classes. You can't extend them anymore, because they are only loaded when running internal tests. More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,11 @@
             "Sonata\\OrderBundle\\": "src/OrderBundle",
             "Sonata\\PaymentBundle\\": "src/PaymentBundle",
             "Sonata\\PriceBundle\\": "src/PriceBundle",
-            "Sonata\\ProductBundle\\": "src/ProductBundle",
+            "Sonata\\ProductBundle\\": "src/ProductBundle"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Sonata\\Tests\\Component\\": "tests/Component",
             "Sonata\\Tests\\BasketBundle\\": "tests/BasketBundle",
             "Sonata\\Tests\\CustomerBundle\\": "tests/CustomerBundle",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a major BC break for all tests.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/dev-kit/issues/179

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - internal test classes are now excluded from the autoloader
```

## Subject

Tests for internal components shouldn't be loaded in production or extended by other bundles.

