### PR TITLE
fix block deprecated method

### DIFF
--- a/src/BasketBundle/Block/BasketBlockService.php
+++ b/src/BasketBundle/Block/BasketBlockService.php
@@ -17,7 +17,7 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author     Xavier Coureau <xcoureau@ekino.com>
@@ -59,7 +59,7 @@ class BasketBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'template' => 'SonataBasketBundle:Block:block_basket_items.html.twig',

--- a/src/CustomerBundle/Block/RecentCustomersBlockService.php
+++ b/src/CustomerBundle/Block/RecentCustomersBlockService.php
@@ -20,7 +20,7 @@ use Sonata\Component\Customer\CustomerManagerInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class RecentCustomersBlockService.
@@ -101,7 +101,7 @@ class RecentCustomersBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'number' => 5,

--- a/src/CustomerBundle/SonataCustomerBundle.php
+++ b/src/CustomerBundle/SonataCustomerBundle.php
@@ -41,8 +41,8 @@ class SonataCustomerBundle extends Bundle
         FormHelper::registerFormTypeMapping(array(
             'sonata_customer_address' => 'Sonata\CustomerBundle\Form\Type\AddressType',
             'sonata_customer_address_types' => 'Sonata\CustomerBundle\Form\Type\AddressTypeType',
-            'sonata_customer_api_form_customer' => 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType',
-            'sonata_customer_api_form_address' => 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType',
+            'sonata_customer_api_form_customer' => 'Sonata\CustomerBundle\Form\Type\ApiCustomerType',
+            'sonata_customer_api_form_address' => 'Sonata\CustomerBundle\Form\Type\ApiAddressType',
         ));
     }
 }

--- a/src/OrderBundle/Block/RecentOrdersBlockService.php
+++ b/src/OrderBundle/Block/RecentOrdersBlockService.php
@@ -21,7 +21,7 @@ use Sonata\Component\Order\OrderManagerInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -125,7 +125,7 @@ class RecentOrdersBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'number' => 5,

--- a/src/ProductBundle/Block/CategoriesMenuBlockService.php
+++ b/src/ProductBundle/Block/CategoriesMenuBlockService.php
@@ -15,7 +15,7 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Sonata\ProductBundle\Menu\ProductMenuBuilder;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Templating\EngineInterface;
 
 /**
@@ -57,9 +57,9 @@ class CategoriesMenuBlockService extends MenuBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
-        parent::setDefaultSettings($resolver);
+        parent::configureSettings($resolver);
 
         $resolver->setDefaults(array(
                 'menu_template' => 'SonataBlockBundle:Block:block_side_menu_template.html.twig',

--- a/src/ProductBundle/Block/FiltersMenuBlockService.php
+++ b/src/ProductBundle/Block/FiltersMenuBlockService.php
@@ -15,7 +15,7 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Sonata\ProductBundle\Menu\ProductMenuBuilder;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Templating\EngineInterface;
 
 /**
@@ -57,9 +57,9 @@ class FiltersMenuBlockService extends MenuBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
-        parent::setDefaultSettings($resolver);
+        parent::configureSettings($resolver);
 
         $resolver->setDefaults(array(
             'menu_class' => 'nav nav-list',

--- a/src/ProductBundle/Block/RecentProductsBlockService.php
+++ b/src/ProductBundle/Block/RecentProductsBlockService.php
@@ -22,7 +22,7 @@ use Sonata\ProductBundle\Repository\BaseProductRepository;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
@@ -105,7 +105,7 @@ class RecentProductsBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'number' => 5,

--- a/src/ProductBundle/Block/SimilarProductsBlockService.php
+++ b/src/ProductBundle/Block/SimilarProductsBlockService.php
@@ -23,7 +23,7 @@ use Sonata\ProductBundle\Repository\BaseProductRepository;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
@@ -117,7 +117,7 @@ class SimilarProductsBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'number' => 5,

--- a/src/ProductBundle/Block/VariationsFormBlockService.php
+++ b/src/ProductBundle/Block/VariationsFormBlockService.php
@@ -22,7 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -129,7 +129,7 @@ class VariationsFormBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'product' => null,

--- a/src/ProductBundle/SonataProductBundle.php
+++ b/src/ProductBundle/SonataProductBundle.php
@@ -44,7 +44,7 @@ class SonataProductBundle extends Bundle
         FormHelper::registerFormTypeMapping(array(
             'sonata_product_delivery_status' => 'Sonata\ProductBundle\Form\Type\ProductDeliveryStatusType',
             'sonata_product_variation_choices' => 'Sonata\Component\Form\Type\VariationChoiceType',
-            'sonata_product_api_form_product_parent' => 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType',
+            'sonata_product_api_form_product_parent' => 'Sonata\ProductBundle\Form\Type\ApiProductParentType',
             'sonata_product_api_form_product' => 'Sonata\ProductBundle\Form\Type\ApiProductType',
             'sonata_currency' => 'Sonata\Component\Currency\CurrencyFormType',
         ));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because there it is the latest one :)

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #386 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - use `configureSettings ` instead of `setDefaultSettings`

### Fixed
 - fix missing configuration to the CoreBundle's FormHelper
```

## Subject

<!-- Describe your Pull Request content here -->

There is a regression with the method called by BlockContextManager. Only ``configureSettings`` methods are being called.