### PR TITLE
use AbstractAdmin instead of deprecated Admin class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "knplabs/knp-paginator-bundle": "^2.4",
         "kriswallsmith/buzz": "^0.15",
         "nelmio/api-doc-bundle": "^2.4",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/block-bundle": "^3.0",
         "sonata-project/classification-bundle": "^3.0",
         "sonata-project/comment-bundle": "^3.0",

--- a/src/ProductBundle/Admin/DeliveryAdmin.php
+++ b/src/ProductBundle/Admin/DeliveryAdmin.php
@@ -12,13 +12,13 @@
 namespace Sonata\ProductBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class DeliveryAdmin extends Admin
+class DeliveryAdmin extends AbstractAdmin
 {
     protected $parentAssociationMapping = 'product';
 

--- a/src/ProductBundle/Admin/ProductAdmin.php
+++ b/src/ProductBundle/Admin/ProductAdmin.php
@@ -12,7 +12,7 @@
 namespace Sonata\ProductBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -23,7 +23,7 @@ use Sonata\Component\Product\Pool;
 use Sonata\Component\Product\ProductInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 
-class ProductAdmin extends Admin
+class ProductAdmin extends AbstractAdmin
 {
     /**
      * @var \Sonata\Component\Product\Pool

--- a/src/ProductBundle/Admin/ProductCategoryAdmin.php
+++ b/src/ProductBundle/Admin/ProductCategoryAdmin.php
@@ -12,13 +12,13 @@
 namespace Sonata\ProductBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class ProductCategoryAdmin extends Admin
+class ProductCategoryAdmin extends AbstractAdmin
 {
     protected $parentAssociationMapping = 'product';
 

--- a/src/ProductBundle/Admin/ProductCollectionAdmin.php
+++ b/src/ProductBundle/Admin/ProductCollectionAdmin.php
@@ -12,13 +12,13 @@
 namespace Sonata\ProductBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class ProductCollectionAdmin extends Admin
+class ProductCollectionAdmin extends AbstractAdmin
 {
     protected $parentAssociationMapping = 'product';
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Use `AbstractAdmin` instead of deprecated `AdminClass` and added dependency for `SonataAdminBundle`
```
