### PR TITLE
Fix jQuery add_basket form selector. Resolves #405

### DIFF
--- a/src/BasketBundle/Resources/public/modal.js
+++ b/src/BasketBundle/Resources/public/modal.js
@@ -1,7 +1,7 @@
 var request = false;
 
 jQuery(document).ready(function() {
-    jQuery('form#form_add_basket').on('submit', function (e) {
+    jQuery('form[id^="form_add_basket"]').on('submit', function (e) {
         e.preventDefault();
 
         if (false === request) {


### PR DESCRIPTION
Fix jQuery `add_basket_button` form  selector for `ProductBundle:Product:view.html` and `ProductBundle:Product:view_thumbnail.html`
Resolves #405 