### PR TITLE
Add sonata.payment.generator.postgres service

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -169,7 +169,7 @@ Follow these instructions:
                 selector: sonata.payment.selector.simple
 
                 # service which generate the correct order and invoice number
-                generator: sonata.payment.generator.mysql
+                generator: sonata.payment.generator.mysql # or sonata.payment.generator.postgres
 
                 transformers:
                     order:  sonata.payment.transformer.order

--- a/src/Component/Generator/PostgresReference.php
+++ b/src/Component/Generator/PostgresReference.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Component\Generator;
+
+use Sonata\Component\Invoice\InvoiceInterface;
+use Sonata\Component\Order\OrderInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+final class PostgresReference implements ReferenceInterface
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    public function __construct(RegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invoice(InvoiceInterface $invoice)
+    {
+        if (!$invoice->getId()) {
+            throw new \RuntimeException('The invoice is not persisted into the database');
+        }
+
+        $this->generateReference($invoice,
+            $this->registry->getManager()->getClassMetadata(get_class($invoice))->table['name']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function order(OrderInterface $order)
+    {
+        if (!$order->getId()) {
+            throw new \RuntimeException('The order is not persisted into the database');
+        }
+
+        $this->generateReference($order,
+            $this->registry->getManager()->getClassMetadata(get_class($order))->table['name']);
+    }
+
+    /**
+     * @param mixed  $object
+     * @param string $tableName
+     *
+     * @throws \Exception
+     *
+     * @return string
+     */
+    protected function generateReference($object, $tableName)
+    {
+        $date = new \DateTime();
+
+        $sql = sprintf(
+            "SELECT count(id) as counter FROM %s WHERE created_at >= '%s' AND reference IS NOT NULL",
+            $tableName,
+            $date->format('Y-m-d')
+        );
+
+        $this->registry->getConnection()->exec(sprintf('BEGIN WORK'));
+
+        $this->registry->getConnection()->exec(sprintf('LOCK TABLE %s IN EXCLUSIVE MODE', $tableName));
+
+        try {
+            $statement = $this->registry->getConnection()->query($sql);
+            $row = $statement->fetch();
+
+            $reference = sprintf('%02d%02d%02d%06d',
+                $date->format('y'),
+                $date->format('n'),
+                $date->format('j'),
+                $row['counter'] + 1
+            );
+
+            $this->registry->getConnection()->update(
+                $tableName,
+                array('reference' => $reference),
+                array('id' => $object->getId())
+            );
+            $object->setReference($reference);
+        } catch (\Exception $e) {
+            $this->registry->getConnection()->exec(sprintf('ROLLBACK WORK'));
+
+            throw $e;
+        }
+
+        $this->registry->getConnection()->exec(sprintf('COMMIT WORK'));
+
+        return $reference;
+    }
+}

--- a/src/PaymentBundle/Resources/config/generator.xml
+++ b/src/PaymentBundle/Resources/config/generator.xml
@@ -2,9 +2,13 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sonata.payment.generator.mysql.class">Sonata\Component\Generator\MysqlReference</parameter>
+        <parameter key="sonata.payment.generator.postgres.class">Sonata\Component\Generator\PostgresReference</parameter>
     </parameters>
     <services>
         <service id="sonata.payment.generator.mysql" class="%sonata.payment.generator.mysql.class%">
+            <argument type="service" id="doctrine"/>
+        </service>
+        <service id="sonata.payment.generator.postgres" class="%sonata.payment.generator.postgres.class%">
             <argument type="service" id="doctrine"/>
         </service>
     </services>

--- a/src/PaymentBundle/Resources/docs/reference/configuration.rst
+++ b/src/PaymentBundle/Resources/docs/reference/configuration.rst
@@ -117,7 +117,7 @@ Full Configuration Options
         selector: sonata.payment.selector.simple
 
         # service which generate the correct order and invoice number
-        generator: sonata.payment.generator.mysql
+        generator: sonata.payment.generator.mysql # or sonata.payment.generator.postgres
 
         transformers:
             order:  sonata.payment.transformer.order

--- a/tests/Component/Generator/PostgresReferenceTest.php
+++ b/tests/Component/Generator/PostgresReferenceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Component\Tests\Generator;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Sonata\Component\Generator\PostgresReference;
+use Sonata\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+/**
+ * @author Anton Zlotnikov <exp.razor@gmail.com>
+ */
+class PostgresReferenceTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvoice()
+    {
+        $invoice = new InvoiceMock();
+        $postgresReference = $this->generateNewObject();
+
+        $this->expectException('\RuntimeException', 'The invoice is not persisted into the database');
+        $postgresReference->invoice($invoice);
+
+        $invoice->setId(13);
+
+        try {
+            $this->assertNull($postgresReference->invoice($invoice));
+        } catch (\Exception $e) {
+            $this->fail('->invoice() should return a NULL value but should now throw an \Exception');
+        }
+    }
+
+    public function testOrder()
+    {
+        $order = new OrderMock();
+        $postgresReference = $this->generateNewObject();
+
+        $this->expectException('\RuntimeException', 'The order is not persisted into the database');
+        $postgresReference->order($order);
+
+        $order->setId(13);
+
+        try {
+            $this->assertNull($postgresReference->order($order));
+        } catch (\Exception $e) {
+            $this->fail('->order() should return a NULL value but should not throw an \Exception');
+        }
+    }
+
+    /**
+     * @return \Sonata\Component\Generator\PostgresReference
+     */
+    private function generateNewObject()
+    {
+        $metadata = new ClassMetadata('entityName');
+        $metadata->table = array('name' => 'tableName');
+
+        $connection = $this->createMock('Doctrine\DBAL\Connection');
+
+        $em = $this->createMock('Doctrine\ORM\EntityManager');
+        $em->expects($this->any())
+            ->method('getClassMetadata')
+            ->will($this->returnValue($metadata));
+
+        $connection->expects($this->any())
+            ->method('query')
+            ->will($this->returnValue(new \PDOStatement()));
+
+        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry->expects($this->any())->method('getManager')->will($this->returnValue($em));
+        $registry->expects($this->any())->method('getConnection')->will($this->returnValue($connection));
+
+        return new PostgresReference($registry);
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because its BC.

## Changelog


```markdown
### Added
- Added `sonata.payment.generator.postgres` service
```

## Subject

At the current moment there is only mysql generator ( https://github.com/sonata-project/ecommerce/blob/2.x/src/Component/Generator/MysqlReference.php] )
Added `sonata.payment.generator.postgres` to support PostgreSQL