### PR TITLE
Fix missing default transformers section in PaymentBundle configuration

### DIFF
--- a/src/PaymentBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentBundle/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('selector')->defaultValue('sonata.payment.selector.simple')->cannotBeEmpty()->end()
                 ->scalarNode('generator')->defaultValue('sonata.payment.generator.mysql')->cannotBeEmpty()->end()
                 ->arrayNode('transformers')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('order')->defaultValue('sonata.payment.transformer.order')->cannotBeEmpty()->end()
                         ->scalarNode('basket')->defaultValue('sonata.payment.transformer.basket')->cannotBeEmpty()->end()

--- a/tests/PaymentBundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/PaymentBundle/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PaymentBundle\Tests\DependencyInjection;
+
+use Sonata\PaymentBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * @author Anton Zlotnikov <exp.razor@gmail.com>
+ */
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaults()
+    {
+        $processor = new Processor();
+
+        $config = $processor->processConfiguration(new Configuration(), array());
+
+        $this->validateClass($config);
+        $this->validateTransformers($config);
+
+        $this->assertSame('sonata.payment.selector.simple', $config['selector']);
+        $this->assertSame('sonata.payment.generator.mysql', $config['generator']);
+
+        $this->assertArrayHasKey('methods', $config);
+        $this->assertEmpty($config['methods']);
+    }
+
+    public function validateClass($config)
+    {
+        $this->assertSame(array(
+            'order' => 'Application\\Sonata\\OrderBundle\\Entity\\Order',
+            'transaction' => 'Application\\Sonata\\PaymentBundle\\Entity\\Transaction',
+        ), $config['class']);
+    }
+
+    public function validateTransformers($config)
+    {
+        $this->assertArrayHasKey('transformers', $config);
+        $this->assertSame('sonata.payment.transformer.order', $config['transformers']['order']);
+        $this->assertSame('sonata.payment.transformer.basket', $config['transformers']['basket']);
+    }
+}


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Fixed missing default `transformers` section in `PaymentBundle` configuration
```