### PR TITLE
Fix AddressType choices option for SF>=2.7. Closes #389

### DIFF
--- a/src/BasketBundle/Form/AddressType.php
+++ b/src/BasketBundle/Form/AddressType.php
@@ -106,6 +106,16 @@ class AddressType extends AbstractType
         $countryOptions = array('required' => !count($addresses));
 
         if (count($countries) > 0) {
+            // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.7)
+            if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+                $countries = array_flip($countries);
+
+                // choice_as_value options is not needed in SF 3.0+
+                if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                    $countryOptions['choices_as_values'] = true;
+                }
+            }
+
             $countryOptions['choices'] = $countries;
         }
 

--- a/src/CustomerBundle/Form/Type/AddressType.php
+++ b/src/CustomerBundle/Form/Type/AddressType.php
@@ -68,6 +68,16 @@ class AddressType extends AbstractType
         }
 
         if (count($countries) > 0) {
+            // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.7)
+            if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+                $countries = array_flip($countries);
+
+                // choice_as_value options is not needed in SF 3.0+
+                if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                    $countryOptions['choices_as_values'] = true;
+                }
+            }
+
             $countryOptions['choices'] = $countries;
         }
 


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

Closes #389

## Changelog

```markdown
### Fixed
- Fixed `AddressType` forms `choices` option for SF>=2.7
```
