### PR TITLE
Fix BasketElement price calculation with priceIncludingVat=true

### DIFF
--- a/src/Component/Basket/BasketElement.php
+++ b/src/Component/Basket/BasketElement.php
@@ -200,7 +200,7 @@ class BasketElement implements \Serializable, BasketElementInterface
         $price = $this->unitPrice;
 
         if (!$vat && true === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcsub(1, bcdiv($this->getVatRate(), 100)));
+            $price = bcdiv($price, bcadd(1, bcdiv($this->getVatRate(), 100)));
         }
 
         if ($vat && false === $this->isPriceIncludingVat()) {
@@ -215,7 +215,7 @@ class BasketElement implements \Serializable, BasketElementInterface
      */
     public function getTotal($vat = false)
     {
-        return $this->getUnitPrice($vat) * $this->getQuantity();
+        return bcmul($this->getUnitPrice($vat), $this->getQuantity(), 100);
     }
 
     /**
@@ -278,7 +278,7 @@ class BasketElement implements \Serializable, BasketElementInterface
         $price = $this->price;
 
         if (!$vat && true === $this->isPriceIncludingVat()) {
-            $price = bcmul($price, bcsub(1, bcdiv($this->getVatRate(), 100)));
+            $price = bcdiv($price, bcadd(1, bcdiv($this->getVatRate(), 100)));
         }
 
         if ($vat && false === $this->isPriceIncludingVat()) {

--- a/src/Component/Basket/BasketElementInterface.php
+++ b/src/Component/Basket/BasketElementInterface.php
@@ -85,7 +85,7 @@ interface BasketElementInterface extends PriceComputableInterface
     /**
      * Sets if current price is including VAT.
      *
-     * @param float $priceIncludingVat
+     * @param bool $priceIncludingVat
      */
     public function setPriceIncludingVat($priceIncludingVat);
 

--- a/src/Component/Currency/CurrencyPriceCalculator.php
+++ b/src/Component/Currency/CurrencyPriceCalculator.php
@@ -25,12 +25,12 @@ class CurrencyPriceCalculator implements CurrencyPriceCalculatorInterface
     {
         $price = $product->getPrice();
 
-        if ($vat && false === $product->isPriceIncludingVat()) {
-            $price = $price * (1 + $product->getVatRate() / 100);
+        if (!$vat && true === $product->isPriceIncludingVat()) {
+            $price = bcdiv($price, bcadd(1, bcdiv($product->getVatRate(), 100)));
         }
 
-        if (!$vat && true === $product->isPriceIncludingVat()) {
-            $price = $price * (1 - $product->getVatRate() / 100);
+        if ($vat && false === $product->isPriceIncludingVat()) {
+            $price = bcmul($price, bcadd(1, bcdiv($product->getVatRate(), 100)));
         }
 
         return $price;

--- a/src/Component/Product/ProductInterface.php
+++ b/src/Component/Product/ProductInterface.php
@@ -175,7 +175,7 @@ interface ProductInterface extends PriceComputableInterface
     /**
      * Sets if current price is including VAT.
      *
-     * @param float $priceIncludingVat
+     * @param bool $priceIncludingVat
      */
     public function setPriceIncludingVat($priceIncludingVat);
 

--- a/tests/Component/Basket/BasketElementTest.php
+++ b/tests/Component/Basket/BasketElementTest.php
@@ -90,6 +90,23 @@ class BasketElementTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2.940, $basketElement->getVatAmount(), 'BasketElement returns the correct VAT amount');
     }
 
+    public function testPriceIncludingVat()
+    {
+        $basketElement = $this->getBasketElement();
+        $basketElement->setPriceIncludingVat(true);
+
+        $this->assertEquals(19.6, $basketElement->getVatRate(), 'BasketElement returns the correct VAT');
+        $this->assertEquals(1, $basketElement->getQuantity(), 'BasketElement returns the correct default quantity');
+
+        $this->assertEquals(12.541, $basketElement->getUnitPrice(), 'BasketElement return the correct price w/o VAT');
+        $this->assertEquals(15, $basketElement->getUnitPrice(true), 'BasketElement return the correct price w/ VAT');
+
+        $this->assertEquals(12.541, $basketElement->getTotal(), 'BasketElement return the correct price w/o VAT');
+        $this->assertEquals(15, $basketElement->getTotal(true), 'BasketElement return the correct price w VAT');
+
+        $this->assertEquals(2.459, $basketElement->getVatAmount(), 'BasketElement returns the correct VAT amount');
+    }
+
     public function testOptions()
     {
         $basketElement = $this->getBasketElement();
@@ -112,6 +129,23 @@ class BasketElementTest extends PHPUnit_Framework_TestCase
 
         $basketElement->setQuantity(-10);
         $this->assertEquals(15, $basketElement->getTotal(false), 'BasketElement returns the correct price w/ VAT when negative quantity set');
+
+        $basketElement->setQuantity(0);
+        $this->assertEquals(0, $basketElement->getTotal(false), 'BasketElement returns the correct price w/ VAT when no quantity set');
+    }
+
+    public function testQuantityWithPriceIncludingVat()
+    {
+        $basketElement = $this->getBasketElement();
+        $basketElement->setQuantity(10);
+        $basketElement->setPriceIncludingVat(true);
+
+        $this->assertEquals(19.6, $basketElement->getVatRate(), 'BasketElement returns the correct VAT');
+        $this->assertEquals(125.410, $basketElement->getTotal(false), 'BasketElement returns the correct price w/ VAT');
+        $this->assertEquals(150, $basketElement->getTotal(true), 'BasketElement returns the correct price w/ VAT');
+
+        $basketElement->setQuantity(-10);
+        $this->assertEquals(12.541, $basketElement->getTotal(false), 'BasketElement returns the correct price w/ VAT when negative quantity set');
 
         $basketElement->setQuantity(0);
         $this->assertEquals(0, $basketElement->getTotal(false), 'BasketElement returns the correct price w/ VAT when no quantity set');


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

Closes #385 

## Changelog

```markdown
### Fixed
- Fixed `BasketElement`, `CurrencyPriceCalculator` price calculation with `priceIncludingVat=true`
- Fixed `setPriceIncludingVat` param type in `BasketElementInterface` and `ProductInterface`

```

## Subject

For example, when product has `price = 15`, `vat = 6.5` and `priceIncludingVat = true`, this means, that price excluding vat should be calculated by formula `finalPrice = price / (1 + vat)`, `15 / (1 + 0.065) = 14.08`

Before this PR price was calculated by this formula `finalPrice = price * (1 - vat)`, which is wrong.