### PR TITLE
Remove deprecated Admin class, use AbstractAdmin

### DIFF
--- a/src/CustomerBundle/Admin/AddressAdmin.php
+++ b/src/CustomerBundle/Admin/AddressAdmin.php
@@ -11,12 +11,12 @@
 
 namespace Sonata\CustomerBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class AddressAdmin extends Admin
+class AddressAdmin extends AbstractAdmin
 {
     protected $translationDomain = 'SonataCustomerBundle';
 

--- a/src/CustomerBundle/Admin/CustomerAdmin.php
+++ b/src/CustomerBundle/Admin/CustomerAdmin.php
@@ -12,14 +12,14 @@
 namespace Sonata\CustomerBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 
-class CustomerAdmin extends Admin
+class CustomerAdmin extends AbstractAdmin
 {
     /**
      * {@inheritdoc}

--- a/src/InvoiceBundle/Admin/InvoiceAdmin.php
+++ b/src/InvoiceBundle/Admin/InvoiceAdmin.php
@@ -11,13 +11,13 @@
 
 namespace Sonata\InvoiceBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\Component\Currency\CurrencyDetectorInterface;
 
-class InvoiceAdmin extends Admin
+class InvoiceAdmin extends AbstractAdmin
 {
     /**
      * @var CurrencyDetectorInterface

--- a/src/OrderBundle/Admin/OrderAdmin.php
+++ b/src/OrderBundle/Admin/OrderAdmin.php
@@ -12,7 +12,7 @@
 namespace Sonata\OrderBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -22,7 +22,7 @@ use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Sonata\Component\Invoice\InvoiceManagerInterface;
 use Sonata\Component\Order\OrderManagerInterface;
 
-class OrderAdmin extends Admin
+class OrderAdmin extends AbstractAdmin
 {
     /**
      * @var CurrencyDetectorInterface

--- a/src/OrderBundle/Admin/OrderElementAdmin.php
+++ b/src/OrderBundle/Admin/OrderElementAdmin.php
@@ -11,13 +11,13 @@
 
 namespace Sonata\OrderBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Sonata\Component\Product\Pool;
 
-class OrderElementAdmin extends Admin
+class OrderElementAdmin extends AbstractAdmin
 {
     /**
      * @var CurrencyDetectorInterface

--- a/src/ProductBundle/Admin/ProductVariationAdmin.php
+++ b/src/ProductBundle/Admin/ProductVariationAdmin.php
@@ -12,7 +12,6 @@
 namespace Sonata\ProductBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;


### PR DESCRIPTION
## Changelog

```markdown
### Changed
- use `AbstractAdmin` instead of deprecated `Admin` class
```

## Note
In `ProductVariationAdmin` `Admin` is not needed, because it extends `ProductAdmin`