### PR TITLE
Add missing price_inc_vat column in BaseBasketElement.orm.xml

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -23,3 +23,6 @@ See also the [diff code](https://github.com/sonata-project/ecommerce/compare/2.x
 - `unitPriceExcl` field - `precision` changed from `10` to `20`
 - `unitPriceInc` field - `precision` changed from `10` to `20`
 - `price` field - `precision` changed from `10` to `20`
+
+#### BaseBasketElement
+- Added missing `price_inc_vat` column for `priceIncludingVat` field

--- a/src/BasketBundle/Resources/config/doctrine/BaseBasketElement.orm.xml
+++ b/src/BasketBundle/Resources/config/doctrine/BaseBasketElement.orm.xml
@@ -4,6 +4,7 @@
         <field name="productId" column="product_id" type="integer"/>
         <field name="position" column="position" type="integer"/>
         <field name="vatRate" column="vat_rate" type="string" length="255"/>
+        <field name="priceIncludingVat" column="price_inc_vat" type="boolean"/>
         <field name="unitPrice" column="unit_price" type="string" length="255"/>
         <field name="price" column="price" type="string" length="255"/>
         <field name="quantity" column="quantity" type="integer"/>


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix with schema migration.

Closes #277

## Changelog

```markdown
### Added
- Added missing `price_inc_vat` column in `BaseBasketElement.orm.xml`
```

## Subject

For unknown reasons this column is missing in orm schema.
