### PR TITLE
Fix typo in TransformerEvents consts values

### DIFF
--- a/src/Component/Event/TransformerEvents.php
+++ b/src/Component/Event/TransformerEvents.php
@@ -17,9 +17,9 @@ namespace Sonata\Component\Event;
 final class TransformerEvents
 {
     const PRE_BASKET_TO_ORDER_TRANSFORM = 'sonata.ecommerce.pre_basket_to_order_transform';
-    const POST_BASKET_TO_ORDER_TRANSFORM = 'sonata.ecommerce.pre_basket_to_order_transform';
+    const POST_BASKET_TO_ORDER_TRANSFORM = 'sonata.ecommerce.post_basket_to_order_transform';
     const PRE_ORDER_TO_BASKET_TRANSFORM = 'sonata.ecommerce.pre_order_to_basket_transform';
-    const POST_ORDER_TO_BASKET_TRANSFORM = 'sonata.ecommerce.pre_order_to_basket_transform';
+    const POST_ORDER_TO_BASKET_TRANSFORM = 'sonata.ecommerce.post_order_to_basket_transform';
     const PRE_ORDER_TO_INVOICE_TRANSFORM = 'sonata.ecommerce.pre_order_to_invoice_transform';
-    const POST_ORDER_TO_INVOICE_TRANSFORM = 'sonata.ecommerce.pre_order_to_invoice_transform';
+    const POST_ORDER_TO_INVOICE_TRANSFORM = 'sonata.ecommerce.post_order_to_invoice_transform';
 }


### PR DESCRIPTION
I am targeting this branch, because this is pedantic.

Closes #394

## Subject
I checked git log, this typo is here from the beginning, and there are no comments about it.