### PR TITLE
Add missing basket property in AddressType

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,13 @@
 UPGRADE 2.x
 ===========
 
+UPGRADE FROM 2.1.1 to 2.x
+=========================
+
+### Sonata\CustomerBundle\Form\Type\AddressType
+
+If you redefined this class, note that missing `basket` property was added, which means it is no longer public.
+
 UPGRADE FROM 2.0 to 2.1
 =======================
 

--- a/src/CustomerBundle/Form/Type/AddressType.php
+++ b/src/CustomerBundle/Form/Type/AddressType.php
@@ -40,6 +40,11 @@ class AddressType extends AbstractType
     protected $name;
 
     /**
+     * @var BasketInterface
+     */
+    protected $basket;
+
+    /**
      * @param string          $class  A class to apply getter
      * @param string          $getter A getter method name
      * @param string          $name   A form type name


### PR DESCRIPTION
I am targeting this branch, because this is a bug fix.

## Changelog

```markdown
### Added
- Added missing `basket` property in `AddressType`
```