### PR TITLE
Make choice fields compatible with >=SF 2.7

### DIFF
--- a/src/BasketBundle/Form/AddressType.php
+++ b/src/BasketBundle/Form/AddressType.php
@@ -97,10 +97,21 @@ class AddressType extends AbstractType
         $builder->add('name', null, array('required' => !count($addresses)));
 
         if (isset($options['types'])) {
-            $builder->add('type', $choiceType, array(
-                'choices' => $options['types'],
-                'translation_domain' => 'SonataCustomerBundle', )
+            $types = $options['types'];
+            $typeOptions = array(
+                'translation_domain' => 'SonataCustomerBundle',
             );
+            // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.7)
+            if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+                $types = array_flip($types);
+                // choice_as_value option is not needed in SF 3.0+
+                if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                    $typeOptions['choices_as_values'] = true;
+                }
+            }
+            $typeOptions['choices'] = $types;
+
+            $builder->add('type', $choiceType, $typeOptions);
         }
 
         $builder

--- a/src/Component/Form/Type/VariationChoiceType.php
+++ b/src/Component/Form/Type/VariationChoiceType.php
@@ -49,13 +49,23 @@ class VariationChoiceType extends AbstractType
         $choices = $this->pool->getProvider($options['product'])->getVariationsChoices($options['product'], $options['fields']);
 
         foreach ($choices as $choiceTitle => $choiceValues) {
+            $choiceOptions = array(
+                'label' => sprintf('form_%s', $choiceTitle),
+                'translation_domain' => 'SonataProductBundle',
+            );
+            // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.7)
+            if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+                $choiceValues = array_flip($choiceValues);
+                // choice_as_value option is not needed in SF 3.0+
+                if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                    $choiceOptions['choices_as_values'] = true;
+                }
+            }
+            $choiceOptions['choices'] = $choiceValues;
+
             $builder->add($choiceTitle, $choiceType, array_merge(
-                    array('translation_domain' => 'SonataProductBundle'),
-                    $options['field_options'],
-                    array(
-                        'label' => sprintf('form_%s', $choiceTitle),
-                        'choices' => $choiceValues,
-                    )
+                    $choiceOptions,
+                    $options['field_options']
                 )
             );
         }

--- a/src/OrderBundle/Admin/OrderElementAdmin.php
+++ b/src/OrderBundle/Admin/OrderElementAdmin.php
@@ -70,9 +70,21 @@ class OrderElementAdmin extends AbstractAdmin
             $productDeliveryStatusType = 'sonata_product_delivery_status';
         }
 
+        $productTypeOptions = array();
+        $productTypes = array_keys($this->productPool->getProducts());
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.7)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $productTypes = array_flip($productTypes);
+            // choice_as_value option is not needed in SF 3.0+
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $productTypeOptions['choices_as_values'] = true;
+            }
+        }
+        $productTypeOptions['choices'] = $productTypes;
+
         $formMapper
             ->with($this->trans('order_element.form.group_main_label', array(), 'SonataOrderBundle'))
-                ->add('productType', $choiceType, array('choices' => array_keys($this->productPool->getProducts())))
+                ->add('productType', $choiceType, $productTypeOptions)
                 ->add('quantity')
                 ->add('price')
                 ->add('vatRate')


### PR DESCRIPTION
I am targeting this branch, because it is a bug fix.

Closes #434

## Changelog

```markdown
### Fixed
- Made `choice` fields compatible with >=SF 2.7
```