### PR TITLE
remove MopaBootrap dependency

### DIFF
--- a/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
@@ -17,8 +17,6 @@ file that was distributed with this source code.
 
 {% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'delivery'} %}
 
-{% form_theme form 'SonataBasketBundle:Form:label.html.twig' %}
-
 {{ form_start(form, {'attr': {'role': 'form', 'class': 'form-horizontal'}}) }}
     {{ form_errors(form) }}
 

--- a/src/BasketBundle/Resources/views/Basket/payment_address_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/payment_address_step.html.twig
@@ -17,8 +17,6 @@ file that was distributed with this source code.
 
 {% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'billing'} %}
 
-{% form_theme form 'SonataBasketBundle:Form:label.html.twig' %}
-
 {{ form_start(form, {'attr': {'class': 'form-horizontal'}}) }}
 {{ form_errors(form) }}
 

--- a/src/BasketBundle/Resources/views/Form/label.html.twig
+++ b/src/BasketBundle/Resources/views/Form/label.html.twig
@@ -1,7 +1,0 @@
-{% extends "MopaBootstrapBundle:Form:fields.html.twig" %}
-
-{% block form_label %}
-    {% set translation_domain = 'SonataBasketBundle' %}
-    {% set label = id %}
-    {{ parent() }}
-{% endblock form_label %}

--- a/src/CustomerBundle/Resources/views/Addresses/new.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/new.html.twig
@@ -16,8 +16,6 @@ file that was distributed with this source code.
 
 {% sonata_template_box 'This is the customer address creation template. Feel free to override it.' %}
 
-{% form_theme form 'SonataCustomerBundle:Form:label.html.twig' %}
-
 {{ form_start(form, {'attr': {'class': 'form-horizontal'}}) }}
     {{ form_errors(form) }}
     {{ form_rest(form) }}

--- a/src/CustomerBundle/Resources/views/Form/label.html.twig
+++ b/src/CustomerBundle/Resources/views/Form/label.html.twig
@@ -1,7 +1,0 @@
-{% extends "MopaBootstrapBundle:Form:fields.html.twig" %}
-
-{% block form_label %}
-    {% set translation_domain = 'SonataCustomerBundle' %}
-    {% set label = id %}
-    {{ parent() }}
-{% endblock form_label %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because MopaBoostrap is not a dependency and should be removed.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #442 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->
```markdown
### Fixed
- usage of `MopaBootstrapBundle`
```

## Subject

In different page there was a reference to MopaBootstrap bundle that is not a required library so it failed to load returning an exception (see #442 ).
Removing MopaBootstraBundle references make them work.
