### PR TITLE
Remove NotNull constraint from Delivery Zone

### DIFF
--- a/src/ProductBundle/Resources/config/validation.xml
+++ b/src/ProductBundle/Resources/config/validation.xml
@@ -20,7 +20,6 @@
             <constraint name="Country"/>
         </getter>
         <getter property="zone">
-            <constraint name="NotNull"/>
             <constraint name="Length">
                 <option name="min">5</option>
                 <option name="max">5</option>


### PR DESCRIPTION
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is a patch for the current version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Removed
- Removed `NotNull` constraint from `BaseDelivery` validation

```

## Subject
I removed the `<constraint name="NotNull"/>` because otherwise it was impossible to add a Delivery Method for a whole country.
Before that, It was necessary to always insert all zones of a country  to enable this method for the whole country, for example for "Italy" I should add about 7000 zones.

Note: the zone can be nullable accoding to the entity definition: https://github.com/sonata-project/ecommerce/blob/2.x/src/ProductBundle/Resources/config/doctrine/BaseDelivery.orm.xml#L7
<!-- Describe your Pull Request content here -->
