### PR TITLE
Product Entity should be abstract

### DIFF
--- a/src/ProductBundle/Resources/skeleton/product/Entity/Entity.php
+++ b/src/ProductBundle/Resources/skeleton/product/Entity/Entity.php
@@ -20,7 +20,7 @@ use Sonata\ProductBundle\Entity\BaseProduct;
  *
  * @author <yourname> <youremail>
  */
-class {{ product }} extends BaseProduct
+abstract class {{ product }} extends BaseProduct
 {
     /**
      * @var integer $id


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a patch for the current branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #261 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- changed skeleton to create abstract class for Product Entity

```

## Subject

Using easy extends with 'php app/console sonata:easy-extends:generate SonataProductBundle' it generates an Entity Class for Product: This class must be abstract.
If the class is not abstract it will throw an exception 
```
Entity 'Application\Sonata\ProductBundle\Entity\Product' has to be part of
the discriminator map of 'Application\Sonata\ProductBundle\Entity\Product' to be properly mapped in the inheritance hierarchy. Alternatively you can make 'Application\Sonata\ProductBundle\Entity\Product' an abstract class to avoid this exception from occurring.
```