### PR TITLE
Fix usage of not persisted addresses in BasketController

### DIFF
--- a/src/BasketBundle/Controller/BasketController.php
+++ b/src/BasketBundle/Controller/BasketController.php
@@ -360,6 +360,15 @@ class BasketController extends Controller
 
         $addresses = $customer->getAddressesByType(AddressInterface::TYPE_DELIVERY);
 
+        $em = $this->container->get('sonata.address.manager')->getEntityManager();
+        foreach ($addresses as $key => $address) {
+            // Prevents usage of not persisted addresses in AddressType to avoid choice field error
+            // This case occurs when customer is taken from a session
+            if (!$em->contains($address)) {
+                unset($addresses[$key]);
+            }
+        }
+
         // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
             $addressFormType = 'Sonata\BasketBundle\Form\AddressType';


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

Closes #444 

## Changelog

```markdown
### Fixed
- Fixed usage of not persisted addresses when the customer is taken from a session.
```

## Subject
I suppose this is not the best way to do it, but other ways involve reworking the whole structure of order process or BC break.

We definitely need to change the order process in the next major.
