### PR TITLE
Serializer config should always be called

### DIFF
--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -43,11 +43,11 @@ class SonataProductExtension extends Extension
         $loader->load('form.xml');
         $loader->load('twig.xml');
         $loader->load('menu.xml');
+        $loader->load('serializer.xml');
 
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_controllers.xml');
             $loader->load('api_form.xml');
-            $loader->load('serializer.xml');
         }
 
         if (isset($bundles['SonataAdminBundle'])) {


### PR DESCRIPTION
I am targeting this branch, because it it the latest stable.

## Changelog
```markdown
### Fixed
 - Fix SonataProductExtension loading
```

## Subject

Serializer is called in `BaseProductProvider` by the `getRawProduct` so I believe the service should always be loaded.
