### PR TITLE
Fix usage of deprecated methods in controllers

### DIFF
--- a/src/CustomerBundle/Controller/CustomerController.php
+++ b/src/CustomerBundle/Controller/CustomerController.php
@@ -13,11 +13,14 @@ namespace Sonata\CustomerBundle\Controller;
 
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Customer\AddressManagerInterface;
+use Sonata\Component\Customer\CustomerInterface;
 use Sonata\Component\Customer\CustomerManagerInterface;
 use Sonata\CustomerBundle\Entity\BaseAddress;
 use Sonata\CustomerBundle\Form\Type\AddressType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -29,7 +32,7 @@ class CustomerController extends Controller
     /**
      * Lists customer's addresses.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function addressesAction()
     {
@@ -70,7 +73,7 @@ class CustomerController extends Controller
     /**
      * Adds an address to current customer.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function addAddressAction()
     {
@@ -82,7 +85,7 @@ class CustomerController extends Controller
      *
      * @param $id
      *
-     * @return RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return RedirectResponse|Response
      */
     public function editAddressAction($id)
     {
@@ -98,7 +101,7 @@ class CustomerController extends Controller
      */
     public function deleteAddressAction($id)
     {
-        if ('POST' !== $this->getRequest()->getMethod()) {
+        if ('POST' !== $this->getCurrentRequest()->getMethod()) {
             throw new MethodNotAllowedHttpException(['POST']);
         }
 
@@ -135,10 +138,11 @@ class CustomerController extends Controller
      *
      * @param int $id Address id
      *
-     * @return RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return RedirectResponse|Response
      */
     protected function updateAddress($id = null)
     {
+        $request = $this->getCurrentRequest();
         $customer = $this->getCustomer();
 
         // Show address creation/edition form
@@ -149,14 +153,14 @@ class CustomerController extends Controller
             $this->checkAddress($address);
 
             $form = $this->createForm(AddressType::class, $address, [
-                'context' => $this->getRequest()->query->get('context'),
+                'context' => $request->query->get('context'),
             ]);
         }
 
         $template = 'SonataCustomerBundle:Addresses:new.html.twig';
 
-        if ('POST' == $this->get('request')->getMethod()) {
-            $form->handleRequest($this->get('request'));
+        if ('POST' == $request->getMethod()) {
+            $form->handleRequest($request);
 
             if ($form->isValid()) {
                 $address = $form->getData();
@@ -184,7 +188,7 @@ class CustomerController extends Controller
      *
      * @param AddressInterface $address
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws NotFoundHttpException
      */
     protected function checkAddress(AddressInterface $address = null)
     {
@@ -195,7 +199,7 @@ class CustomerController extends Controller
     }
 
     /**
-     * @return \Sonata\Component\Customer\CustomerInterface
+     * @return CustomerInterface
      */
     protected function getCustomer()
     {
@@ -218,5 +222,15 @@ class CustomerController extends Controller
     protected function getCustomerManager()
     {
         return $this->get('sonata.customer.manager');
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method (inject Request $request into actions parameters)
+     *
+     * @return Request
+     */
+    private function getCurrentRequest()
+    {
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/src/InvoiceBundle/Controller/InvoiceController.php
+++ b/src/InvoiceBundle/Controller/InvoiceController.php
@@ -13,6 +13,7 @@ namespace Sonata\InvoiceBundle\Controller;
 
 use Sonata\Component\Customer\CustomerInterface;
 use Sonata\Component\Invoice\InvoiceManagerInterface;
+use Sonata\Component\Order\OrderManagerInterface;
 use Sonata\Component\Transformer\InvoiceTransformer;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/OrderBundle/Controller/OrderController.php
+++ b/src/OrderBundle/Controller/OrderController.php
@@ -16,6 +16,7 @@ use Sonata\Component\Order\OrderElementInterface;
 use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Order\OrderManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class OrderController extends Controller
@@ -23,7 +24,7 @@ class OrderController extends Controller
     /**
      * @throws AccessDeniedException
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function indexAction()
     {
@@ -48,7 +49,7 @@ class OrderController extends Controller
      *
      * @throws AccessDeniedException
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function viewAction($reference)
     {

--- a/src/PaymentBundle/Controller/DebugPaymentController.php
+++ b/src/PaymentBundle/Controller/DebugPaymentController.php
@@ -12,10 +12,15 @@
 namespace Sonata\PaymentBundle\Controller;
 
 use Sonata\Component\Order\OrderInterface;
+use Sonata\Component\Payment\Debug\DebugPayment;
 use Sonata\Component\Payment\InvalidTransactionException;
+use Sonata\OrderBundle\Entity\OrderManager;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
@@ -33,20 +38,20 @@ class DebugPaymentController extends Controller
 
         return $this->render('SonataPaymentBundle:Payment:debug.html.twig', [
             'order' => $order,
-            'check' => $this->getRequest()->get('check'),
+            'check' => $this->getCurrentRequest()->get('check'),
         ]);
     }
 
     /**
      * Process the User choice.
      *
-     * @return Reponse
+     * @return Response
      */
     public function processPaymentAction()
     {
         $order = $this->checkRequest();
 
-        return $this->getDebugPayment()->processCallback($order, $this->getRequest()->get('action'));
+        return $this->getDebugPayment()->processCallback($order, $this->getCurrentRequest()->get('action'));
     }
 
     /**
@@ -64,7 +69,8 @@ class DebugPaymentController extends Controller
             throw new \RuntimeException('Debug Payment is not authorized in production environment.');
         }
 
-        $reference = $this->getRequest()->get('reference');
+        $request = $this->getCurrentRequest();
+        $reference = $request->get('reference');
 
         $order = $this->getOrderManager()->findOneBy(['reference' => $reference]);
 
@@ -72,7 +78,7 @@ class DebugPaymentController extends Controller
             throw new NotFoundHttpException(sprintf('Order with reference "%s" not found.', $reference));
         }
 
-        if ($this->getRequest()->get('check') !== $this->getDebugPayment()->generateUrlCheck($order)) {
+        if ($request->get('check') !== $this->getDebugPayment()->generateUrlCheck($order)) {
             throw new InvalidTransactionException($reference);
         }
 
@@ -80,7 +86,7 @@ class DebugPaymentController extends Controller
     }
 
     /**
-     * @return \Sonata\Component\Payment\Debug\DebugPayment
+     * @return DebugPayment
      */
     protected function getDebugPayment()
     {
@@ -88,7 +94,7 @@ class DebugPaymentController extends Controller
     }
 
     /**
-     * @return \Sonata\OrderBundle\Entity\OrderManager
+     * @return OrderManager
      */
     protected function getOrderManager()
     {
@@ -96,7 +102,7 @@ class DebugPaymentController extends Controller
     }
 
     /**
-     * @return \Symfony\Component\HttpKernel\Kernel
+     * @return KernelInterface
      */
     protected function getKernel()
     {
@@ -104,10 +110,20 @@ class DebugPaymentController extends Controller
     }
 
     /**
-     * @return \Symfony\Component\Routing\RouterInterface
+     * @return RouterInterface
      */
     protected function getRouter()
     {
         return $this->get('router');
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method (inject Request $request into actions parameters)
+     *
+     * @return Request
+     */
+    private function getCurrentRequest()
+    {
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/src/ProductBundle/Controller/BaseProductController.php
+++ b/src/ProductBundle/Controller/BaseProductController.php
@@ -17,6 +17,8 @@ use Sonata\Component\Product\ProductInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -133,12 +135,13 @@ abstract class BaseProductController extends Controller
      * @param ProductInterface      $product
      * @param ProductInterface|null $variation
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @throws NotFoundHttpException
      *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return JsonResponse|RedirectResponse
      */
     public function variationToProductAction(ProductInterface $product, ProductInterface $variation = null)
     {
+        $request = $this->getCurrentRequest();
         $provider = $this->get('sonata.product.pool')->getProvider($product);
 
         if (!$provider->hasEnabledVariations($product)) {
@@ -146,7 +149,7 @@ abstract class BaseProductController extends Controller
         }
 
         if (null === $variation || 0 === $provider->getStockAvailable($variation)) {
-            if ($this->getRequest()->isXmlHttpRequest()) {
+            if ($request->isXmlHttpRequest()) {
                 return new JsonResponse(['error' => $this->get('translator')->trans('variation_not_found', [], 'SonataProductBundle')]);
             }
 
@@ -161,7 +164,7 @@ abstract class BaseProductController extends Controller
             'slug' => $variation->getSlug(),
         ]);
 
-        if ($this->getRequest()->isXmlHttpRequest()) {
+        if ($request->isXmlHttpRequest()) {
             return new JsonResponse(['variation_url' => $url]);
         }
 
@@ -179,5 +182,15 @@ abstract class BaseProductController extends Controller
         $seoPage->setTitle($product->getName());
         $this->get('sonata.product.seo.facebook')->alterPage($seoPage, $product, $currency);
         $this->get('sonata.product.seo.twitter')->alterPage($seoPage, $product, $currency);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method (inject Request $request into actions parameters)
+     *
+     * @return Request
+     */
+    private function getCurrentRequest()
+    {
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/src/ProductBundle/Controller/CatalogController.php
+++ b/src/ProductBundle/Controller/CatalogController.php
@@ -15,8 +15,10 @@ use Sonata\ClassificationBundle\Entity\CategoryManager;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\Component\Currency\CurrencyDetector;
 use Sonata\Component\Product\Pool;
+use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\ProductBundle\Entity\ProductSetManager;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -31,11 +33,12 @@ class CatalogController extends Controller
      */
     public function indexAction()
     {
-        $page = $this->getRequest()->get('page', 1);
-        $displayMax = $this->getRequest()->get('max', 9);
-        $displayMode = $this->getRequest()->get('mode', 'grid');
-        $filter = $this->getRequest()->get('filter');
-        $option = $this->getRequest()->get('option');
+        $request = $this->getCurrentRequest();
+        $page = $request->get('page', 1);
+        $displayMax = $request->get('max', 9);
+        $displayMode = $request->get('mode', 'grid');
+        $filter = $request->get('filter');
+        $option = $request->get('option');
 
         if (!in_array($displayMode, ['grid'])) { // "list" mode will be added later
             throw new NotFoundHttpException(sprintf('Given display_mode "%s" doesn\'t exist.', $displayMode));
@@ -64,11 +67,12 @@ class CatalogController extends Controller
      */
     protected function retrieveCategoryFromQueryString()
     {
-        $categoryId = $this->getRequest()->get('category_id');
-        $categorySlug = $this->getRequest()->get('category_slug');
+        $request = $this->getCurrentRequest();
+        $categoryId = $request->get('category_id');
+        $categorySlug = $request->get('category_slug');
 
         if (!$categoryId || !$categorySlug) {
-            return;
+            return null;
         }
 
         return $this->getCategoryManager()->findOneBy([
@@ -82,12 +86,12 @@ class CatalogController extends Controller
      *
      * @param CategoryInterface $category
      *
-     * @return null|\Sonata\Component\Product\ProductProviderInterface
+     * @return ProductProviderInterface|null
      */
     protected function getProviderFromCategory(CategoryInterface $category = null)
     {
         if (null === $category) {
-            return;
+            return null;
         }
 
         $product = $this->getProductSetManager()->findProductForCategory($category);
@@ -125,5 +129,15 @@ class CatalogController extends Controller
     protected function getCategoryManager()
     {
         return $this->get('sonata.classification.manager.category');
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method (inject Request $request into actions parameters)
+     *
+     * @return Request
+     */
+    private function getCurrentRequest()
+    {
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/src/ProductBundle/Controller/CategoryController.php
+++ b/src/ProductBundle/Controller/CategoryController.php
@@ -12,6 +12,7 @@
 namespace Sonata\ProductBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
 
 class CategoryController extends Controller
 {
@@ -20,7 +21,7 @@ class CategoryController extends Controller
      * @param int  $depth
      * @param int  $deep
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
+     * @return Response
      */
     public function listSideMenuCategoriesAction($category = null, $depth = 1, $deep = 0)
     {

--- a/src/ProductBundle/Controller/CollectionController.php
+++ b/src/ProductBundle/Controller/CollectionController.php
@@ -13,6 +13,8 @@ namespace Sonata\ProductBundle\Controller;
 
 use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CollectionController extends Controller
@@ -25,7 +27,7 @@ class CollectionController extends Controller
     public function indexAction()
     {
         $pager = $this->get('sonata.classification.manager.collection')
-            ->getRootCollectionsPager($this->get('request')->get('page'));
+            ->getRootCollectionsPager($this->getCurrentRequest()->get('page'));
 
         return $this->render('SonataProductBundle:Collection:index.html.twig', [
             'pager' => $pager,
@@ -61,12 +63,12 @@ class CollectionController extends Controller
      *
      * @param $collectionId
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
+     * @return Response
      */
     public function listSubCollectionsAction($collectionId)
     {
         $pager = $this->get('sonata.classification.manager.collection')
-            ->getSubCollectionsPager($collectionId, $this->get('request')->get('page'));
+            ->getSubCollectionsPager($collectionId, $this->getCurrentRequest()->get('page'));
 
         return $this->render('SonataProductBundle:Collection:list_sub_collections.html.twig', [
             'pager' => $pager,
@@ -78,12 +80,12 @@ class CollectionController extends Controller
      *
      * @param $collectionId
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
+     * @return Response
      */
     public function listProductsAction($collectionId)
     {
         $pager = $this->get('sonata.product.set.manager')
-            ->getProductsByCollectionIdPager($collectionId, $this->get('request')->get('page'));
+            ->getProductsByCollectionIdPager($collectionId, $this->getCurrentRequest()->get('page'));
 
         return $this->render('SonataProductBundle:Collection:list_products.html.twig', [
             'pager' => $pager,
@@ -95,7 +97,7 @@ class CollectionController extends Controller
      * @param int  $depth
      * @param int  $deep
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
+     * @return Response
      */
     public function listSideMenuCollectionsAction($collection = null, $depth = 1, $deep = 0)
     {
@@ -106,5 +108,15 @@ class CollectionController extends Controller
           'depth' => $depth,
           'deep' => $deep + 1,
         ]);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method (inject Request $request into actions parameters)
+     *
+     * @return Request
+     */
+    private function getCurrentRequest()
+    {
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Fixed
- Fixed usage of deprecated methods in controllers (Improve compatibility with SF 3)
```