### PR TITLE
Allow Symfony 3 and 4

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -26,3 +26,9 @@ See also the [diff code](https://github.com/sonata-project/ecommerce/compare/2.x
 
 #### BaseBasketElement
 - Added missing `price_inc_vat` column for `priceIncludingVat` field
+
+## CustomerSelector
+If you have implemented custom `CustomerSelector` you must adapt constructor arguments to the new ones. Note that all protected properties are now private.
+
+## ProductInterface
+`ProductInterface::validateOneMainCategory` now uses `Symfony\Component\Validator\Context\ExecutionContextInterface` instead of `Symfony\Component\Validator\ExecutionContextInterface`

--- a/composer.json
+++ b/composer.json
@@ -36,15 +36,17 @@
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.4",
         "sonata-project/user-bundle": "^3.6 || ^4.0",
-        "symfony/config": "^2.8",
-        "symfony/console": "^2.8",
-        "symfony/form": "^2.8",
-        "symfony/http-foundation": "^2.8",
-        "symfony/process": "^2.8",
-        "symfony/routing": "^2.8",
-        "symfony/security-bundle": "^2.8",
-        "symfony/twig-bridge": "^2.8",
-        "symfony/validator": "^2.8"
+        "symfony/config": "^2.8 || ^3.2 || ^4.0",
+        "symfony/console": "^2.8 || ^3.2 || ^4.0",
+        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
+        "symfony/form": "^2.8 || ^3.2 || ^4.0",
+        "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
+        "symfony/process": "^2.8 || ^3.2 || ^4.0",
+        "symfony/routing": "^2.8 || ^3.2 || ^4.0",
+        "symfony/security": "^2.8 || ^3.2 || ^4.0",
+        "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
+        "symfony/validator": "^2.8 || ^3.2 || ^4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.3 || ^4.0"

--- a/src/BasketBundle/Resources/config/basket.xml
+++ b/src/BasketBundle/Resources/config/basket.xml
@@ -13,7 +13,8 @@
         <service id="sonata.customer.selector" class="%sonata.customer.selector.class%">
             <argument type="service" id="sonata.customer.manager"/>
             <argument type="service" id="session"/>
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.authorization_checker"/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="sonata.intl.locale_detector"/>
         </service>
         <service id="sonata.basket.loader.standard" class="Sonata\Component\Basket\Loader">

--- a/src/Component/Form/BasketValidator.php
+++ b/src/Component/Form/BasketValidator.php
@@ -16,9 +16,9 @@ namespace Sonata\Component\Form;
 use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Product\Pool as ProductPool;
 use Sonata\CoreBundle\Validator\ErrorElement;
-use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 
 class BasketValidator extends ConstraintValidator
 {
@@ -28,15 +28,15 @@ class BasketValidator extends ConstraintValidator
     protected $productPool;
 
     /**
-     * @var ConstraintValidatorFactory
+     * @var ContainerConstraintValidatorFactory
      */
     protected $constraintValidatorFactory;
 
     /**
-     * @param ProductPool                $productPool
-     * @param ConstraintValidatorFactory $constraintValidatorFactory
+     * @param ProductPool                         $productPool
+     * @param ContainerConstraintValidatorFactory $constraintValidatorFactory
      */
-    public function __construct(ProductPool $productPool, ConstraintValidatorFactory $constraintValidatorFactory)
+    public function __construct(ProductPool $productPool, ContainerConstraintValidatorFactory $constraintValidatorFactory)
     {
         $this->productPool = $productPool;
         $this->constraintValidatorFactory = $constraintValidatorFactory;
@@ -68,7 +68,10 @@ class BasketValidator extends ConstraintValidator
         }
 
         if (count($this->context->getViolations()) > 0) {
-            $this->context->addViolationAt('basketElements', $constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->atPath('\'basketElements\'')
+                ->addViolation();
         }
     }
 }

--- a/src/Component/Product/ProductInterface.php
+++ b/src/Component/Product/ProductInterface.php
@@ -16,7 +16,7 @@ namespace Sonata\Component\Product;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
-use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 interface ProductInterface extends PriceComputableInterface
 {

--- a/src/ProductBundle/Entity/BaseProduct.php
+++ b/src/ProductBundle/Entity/BaseProduct.php
@@ -23,7 +23,7 @@ use Sonata\Component\Product\ProductInterface;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 abstract class BaseProduct implements ProductInterface
 {

--- a/tests/Component/Customer/CustomerSelectorTest.php
+++ b/tests/Component/Customer/CustomerSelectorTest.php
@@ -23,8 +23,9 @@ use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class User
 {
@@ -47,13 +48,15 @@ class CustomerSelectorTest extends TestCase
 
         $session = $this->createMock(SessionInterface::class);
 
-        $securityContext = $this->createMock(SecurityContextInterface::class);
-        $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(false));
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())->method('isGranted')->will($this->returnValue(false));
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
 
         $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
-        $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
+        $customerSelector = new CustomerSelector($customerManager, $session, $authorizationChecker, $tokenStorage, $localeDetector);
 
         $customer = $customerSelector->get();
 
@@ -72,14 +75,16 @@ class CustomerSelectorTest extends TestCase
         $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue(new User()));
 
-        $securityContext = $this->createMock(SecurityContextInterface::class);
-        $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
-        $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())->method('isGranted')->will($this->returnValue(true));
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
         $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
-        $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
+        $customerSelector = new CustomerSelector($customerManager, $session, $authorizationChecker, $tokenStorage, $localeDetector);
 
         $customerSelector->get();
     }
@@ -98,14 +103,16 @@ class CustomerSelectorTest extends TestCase
         $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue($user));
 
-        $securityContext = $this->createMock(SecurityContextInterface::class);
-        $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
-        $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())->method('isGranted')->will($this->returnValue(true));
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
         $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
-        $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
+        $customerSelector = new CustomerSelector($customerManager, $session, $authorizationChecker, $tokenStorage, $localeDetector);
 
         $customer = $customerSelector->get();
 
@@ -127,14 +134,16 @@ class CustomerSelectorTest extends TestCase
         $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue($user));
 
-        $securityContext = $this->createMock(SecurityContextInterface::class);
-        $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
-        $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())->method('isGranted')->will($this->returnValue(true));
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
         $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
-        $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
+        $customerSelector = new CustomerSelector($customerManager, $session, $authorizationChecker, $tokenStorage, $localeDetector);
 
         $customer = $customerSelector->get();
 
@@ -159,14 +168,16 @@ class CustomerSelectorTest extends TestCase
         $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue($user));
 
-        $securityContext = $this->createMock(SecurityContextInterface::class);
-        $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
-        $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())->method('isGranted')->will($this->returnValue(true));
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
         $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
-        $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
+        $customerSelector = new CustomerSelector($customerManager, $session, $authorizationChecker, $tokenStorage, $localeDetector);
 
         $customer = $customerSelector->get();
 

--- a/tests/Component/Form/BasketValidatorTest.php
+++ b/tests/Component/Form/BasketValidatorTest.php
@@ -19,9 +19,10 @@ use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Form\BasketValidator;
 use Sonata\Component\Product\Pool;
 use Sonata\Component\Product\ProductProviderInterface;
-use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\ExecutionContext;
+use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -39,11 +40,15 @@ class BasketValidatorTest extends TestCase
         $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $consValFact = $this->createMock(ConstraintValidatorFactory::class);
+        $consValFact = $this->createMock(ContainerConstraintValidatorFactory::class);
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $violationBuilder->expects($this->once())->method('atPath')->will($this->returnValue($violationBuilder));
+        $violationBuilder->expects($this->once())->method('addViolation');
 
         $context = $this->createMock(ExecutionContext::class);
         $context->expects($this->once())->method('getViolations')->will($this->returnValue(['violation1']));
-        $context->expects($this->once())->method('addViolationAt');
+        $context->expects($this->once())->method('buildViolation')->will($this->returnValue($violationBuilder));
 
         $validator = new BasketValidator($pool, $consValFact);
         $validator->initialize($context);

--- a/tests/ProductBundle/Command/GenerateProductCommandTest.php
+++ b/tests/ProductBundle/Command/GenerateProductCommandTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Sonata\ProductBundle\Command\GenerateProductCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @author Xavier Coureau <xcoureau@ekino.com>
@@ -69,8 +68,7 @@ class GenerateProductCommandTest extends TestCase
      */
     private function getCommandInstance()
     {
-        $kernel = $this->createMock(Kernel::class);
-        $app = new Application($kernel);
+        $app = new Application();
         $app->add(new GenerateProductCommand());
 
         return $app->find('sonata:product:generate');


### PR DESCRIPTION
I'm targeting this branch because this PR breaks BC.

## Changelog

```markdown
### Fixed
- Allowed to install Symfony 3 and 4
### Changed
- Changed constructor arguments in `CustomerSelector`
- Replaced `ExecutionContextInterface` with `Context\ExecutionContextInterface`
- Replaced `ConstraintValidatorFactory` with `ContainerConstraintValidatorFactory `
```

## Subject
I think we should focus on master branch now, because adding support of SF 3 in 2.x with keeping BC will be too difficult.