### PR TITLE
Remove friendsofsymfony/user-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "cocur/slugify": "^1.4 || ^2.5",
         "friendsofsymfony/comment-bundle": "^2.0.13",
         "friendsofsymfony/rest-bundle": "^1.8 || ^2.2",
-        "friendsofsymfony/user-bundle": "^1.3",
         "jms/serializer-bundle": "^0.13 || ^1.5",
         "knplabs/knp-menu-bundle": "^1.1 || ^2.1",
         "knplabs/knp-paginator-bundle": "^2.6",

--- a/src/Component/Customer/CustomerInterface.php
+++ b/src/Component/Customer/CustomerInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\Component\Customer;
 
-use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 interface CustomerInterface
 {
@@ -81,14 +81,14 @@ interface CustomerInterface
     /**
      * Set user.
      *
-     * @param \FOS\UserBundle\Model\UserInterface $user
+     * @param UserInterface $user
      */
     public function setUser(UserInterface $user);
 
     /**
      * Get user.
      *
-     * @return \FOS\UserBundle\Model\UserInterface $user
+     * @return UserInterface $user
      */
     public function getUser();
 

--- a/src/Component/Customer/CustomerSelector.php
+++ b/src/Component/Customer/CustomerSelector.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\Component\Customer;
 
-use FOS\UserBundle\Model\UserInterface;
 use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class CustomerSelector implements CustomerSelectorInterface
 {
@@ -29,7 +29,7 @@ class CustomerSelector implements CustomerSelectorInterface
     protected $session;
 
     /**
-     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     * @var SecurityContextInterface
      */
     protected $securityContext;
 
@@ -69,7 +69,7 @@ class CustomerSelector implements CustomerSelectorInterface
             $user = $this->securityContext->getToken()->getUser();
 
             if (!$user instanceof UserInterface) {
-                throw new \RuntimeException('User must be an instance of FOS\UserBundle\Model\UserInterface');
+                throw new \RuntimeException('User must be an instance of Symfony\Component\Security\Core\User\UserInterface');
             }
 
             $customer = $this->customerManager->findOneBy([

--- a/src/CustomerBundle/Entity/BaseCustomer.php
+++ b/src/CustomerBundle/Entity/BaseCustomer.php
@@ -12,9 +12,9 @@
 namespace Sonata\CustomerBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use FOS\UserBundle\Model\UserInterface;
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Customer\CustomerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class BaseCustomer implements CustomerInterface
 {
@@ -78,7 +78,7 @@ abstract class BaseCustomer implements CustomerInterface
     protected $createdAt;
 
     /**
-     * @var \FOS\UserBundle\Model\UserInterface
+     * @var UserInterface
      */
     protected $user;
 

--- a/tests/Component/Customer/CustomerSelectorTest.php
+++ b/tests/Component/Customer/CustomerSelectorTest.php
@@ -11,16 +11,12 @@
 
 namespace Sonata\Component\Tests\Customer;
 
-use FOS\UserBundle\Model\User as BaseUser;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\Basket;
 use Sonata\Component\Customer\CustomerSelector;
+use Sonata\Component\Tests\Customer\ValidUser;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-
-class ValidUser extends BaseUser
-{
-}
 
 class User
 {
@@ -58,7 +54,7 @@ class CustomerSelectorTest extends TestCase
 
     /**
      * @expectedException        \RuntimeException
-     * @expectedExceptionMessage User must be an instance of FOS\UserBundle\Model\UserInterface
+     * @expectedExceptionMessage User must be an instance of Symfony\Component\Security\Core\User\UserInterface
      */
     public function testInvalidUserType()
     {

--- a/tests/Component/Customer/ValidUser.php
+++ b/tests/Component/Customer/ValidUser.php
@@ -11,13 +11,47 @@
 
 namespace Sonata\Component\Tests\Customer;
 
-use FOS\UserBundle\Model\User as AbstractUser;
+use Symfony\Component\Security\Core\User\UserInterface;
 
-// clean this by adding a dedicated interface into the SonataUserBundle
-class ValidUser extends AbstractUser
+class ValidUser implements UserInterface
 {
     public function getId()
     {
         return 1;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRoles()
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPassword()
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSalt()
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUsername()
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function eraseCredentials()
+    {
     }
 }


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Removed
- Removed `friendsofsymfony/user-bundle` dependency
```

## Help wanted

Do we need to ignore that `InvoiceController::checkAccess` needs `getId()` function and `Symfony\Component\Security\Core\User\UserInterface` does not have it? Or do we need to use `Sonata\UserBundle\Model\UserInterface` as we discussed with @jordisala1991 in #485 

```php
    protected function checkAccess(CustomerInterface $customer)
    {
        if (!($user = $this->getUser())
            || !$customer->getUser()
            || $customer->getUser()->getId() !== $user->getId()) {
            throw new AccessDeniedException();
        }
    }
```
