### PR TITLE
Fix ProductCategoryManager to work with PostgreSQL

### DIFF
--- a/src/ProductBundle/Entity/ProductCategoryManager.php
+++ b/src/ProductBundle/Entity/ProductCategoryManager.php
@@ -84,7 +84,6 @@ class ProductCategoryManager extends BaseEntityManager implements ProductCategor
             ->leftJoin('pc.category', 'c')
             ->where('pc.enabled = true')
             ->andWhere('c.enabled = true')
-            ->groupBy('c.id')
         ;
 
         $pCategories = $qb->getQuery()->execute();
@@ -108,7 +107,7 @@ class ProductCategoryManager extends BaseEntityManager implements ProductCategor
         $productMetadata = $this->getEntityManager()->getClassMetadata($metadata->getAssociationTargetClass('product'));
         $categoryMetadata = $this->getEntityManager()->getClassMetadata($metadata->getAssociationTargetClass('category'));
 
-        $sql = 'SELECT count(cnt.product_id) AS cntId
+        $sql = 'SELECT count(cnt.product_id) AS "cntId"
             FROM (
                 SELECT DISTINCT pc.product_id
                 FROM %s pc


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

Closes #487 

## Changelog

```markdown

### Fixed
- Fixed `ProductCategoryManager` compatibility with PostgreSQL
```
## Subject

Grouping by category.id does nothing here (except causing crash with postgres), because all selected categories are putted manualy in a tree. This tree contains only root categories (parent==null). Further going down by tree is done by getChildren().

```php
        $pCategories = $qb->getQuery()->execute();

        $categoryTree = [];

        foreach ($pCategories as $category) {
            $this->putInTree($category->getCategory(), $categoryTree);
        }

        return $categoryTree;
```
```php
    protected function putInTree(CategoryInterface $category, array &$tree)
    {
        if (null === $category->getParent()) {
            $tree[$category->getId()] = $category;
        } else {
            $this->putInTree($category->getParent(), $tree);
        }
    }
```