### PR TITLE
Fix Basket::removeBasketElement() for non existing products

### DIFF
--- a/src/Component/Basket/Basket.php
+++ b/src/Component/Basket/Basket.php
@@ -393,10 +393,11 @@ class Basket implements \Serializable, BasketInterface
 
         --$this->cptElement;
 
-        unset(
-            $this->positions[$element->getProduct()->getId()],
-            $this->basketElements[$pos]
-        );
+        if ($element->getProduct()) {
+            unset($this->positions[$element->getProduct()->getId()]);
+        }
+
+        unset($this->basketElements[$pos]);
 
         if (!$this->inBuild) {
             $this->buildPrices();

--- a/tests/Component/Basket/BasketTest.php
+++ b/tests/Component/Basket/BasketTest.php
@@ -14,6 +14,7 @@ namespace Sonata\Component\Tests\Basket;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\Basket;
 use Sonata\Component\Basket\BasketElement;
+use Sonata\Component\Basket\BasketElementInterface;
 use Sonata\Component\Currency\CurrencyPriceCalculator;
 use Sonata\Component\Delivery\BaseServiceDelivery;
 use Sonata\Component\Product\Pool;
@@ -411,6 +412,24 @@ class BasketTest extends TestCase
         $basket->clean();
 
         $this->assertEquals(1, count($basket->getBasketElements()));
+    }
+
+    public function testRemoveElementWithNotExistingProduct()
+    {
+        $basket = $this->getPreparedBasket();
+        $product = $this->getMockProduct();
+
+        $basketElement = $this->createMock(BasketElementInterface::class);
+        $basketElement->expects($this->any())->method('getProduct')->will($this->returnValue($product));
+        $basketElement->expects($this->any())->method('getPosition')->will($this->returnValue(0));
+
+        $basket->addBasketElement($basketElement);
+
+        $basketElement = $this->createMock(BasketElementInterface::class);
+        $basketElement->expects($this->any())->method('getProduct')->will($this->returnValue(null));
+        $basketElement->expects($this->any())->method('getPosition')->will($this->returnValue(0));
+
+        $this->assertEquals($basket->removeBasketElement($basketElement), $basketElement);
     }
 
     public function testGettersSetters()


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

## Changelog

```markdown
### Fixed
- Fixed clearing basket with deleted from db products
```

## Subject

When product exists in user's basket and is removed from db, it is automaticly removed from the basket (when user enters it) but it fails with error `Call to a member function getId() on null` in `removeBasketElement()` function.

`$element->getProduct()` returns null, and `$element->getProduct()->getId()` crashes.