### PR TITLE
Replace FQCN strings with ::class constants

### DIFF
--- a/src/BasketBundle/Entity/BaseBasket.php
+++ b/src/BasketBundle/Entity/BaseBasket.php
@@ -13,6 +13,7 @@ namespace Sonata\BasketBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\Component\Basket\Basket;
+use Sonata\Component\Basket\BasketElementInterface;
 
 abstract class BaseBasket extends Basket
 {
@@ -27,7 +28,7 @@ abstract class BaseBasket extends Basket
     public function setBasketElements($basketElements)
     {
         foreach ($basketElements as $basketElement) {
-            if (!$basketElement instanceof \Sonata\Component\Basket\BasketElementInterface) {
+            if (!$basketElement instanceof BasketElementInterface) {
                 continue;
             }
 

--- a/src/BasketBundle/SonataBasketBundle.php
+++ b/src/BasketBundle/SonataBasketBundle.php
@@ -12,6 +12,14 @@
 namespace Sonata\BasketBundle;
 
 use Sonata\BasketBundle\DependencyInjection\Compiler\GlobalVariableCompilerPass;
+use Sonata\BasketBundle\Form\AddressType;
+use Sonata\BasketBundle\Form\ApiBasketElementParentType;
+use Sonata\BasketBundle\Form\ApiBasketElementType;
+use Sonata\BasketBundle\Form\ApiBasketParentType;
+use Sonata\BasketBundle\Form\ApiBasketType;
+use Sonata\BasketBundle\Form\BasketType;
+use Sonata\BasketBundle\Form\PaymentType;
+use Sonata\BasketBundle\Form\ShippingType;
 use Sonata\CoreBundle\Form\FormHelper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -42,14 +50,14 @@ class SonataBasketBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_basket_basket' => 'Sonata\BasketBundle\Form\BasketType',
-            'sonata_basker_address' => 'Sonata\BasketBundle\Form\Type\AddressType',
-            'sonata_basket_shipping' => 'Sonata\BasketBundle\Form\ShippingType',
-            'sonata_basket_payment' => 'Sonata\BasketBundle\Form\PaymentType',
-            'sonata_basket_api_form_basket' => 'Sonata\BasketBundle\Form\ApiBasketType',
-            'sonata_basket_api_form_basket_element' => 'Sonata\BasketBundle\Form\ApiBasketElementType',
-            'sonata_basket_api_form_basket_parent' => 'Sonata\BasketBundle\Form\ApiBasketParentType',
-            'sonata_basket_api_form_basket_element_parent' => 'Sonata\BasketBundle\Form\ApiBasketElementParentType',
+            'sonata_basket_basket' => BasketType::class,
+            'sonata_basket_address' => AddressType::class,
+            'sonata_basket_shipping' => ShippingType::class,
+            'sonata_basket_payment' => PaymentType::class,
+            'sonata_basket_api_form_basket' => ApiBasketType::class,
+            'sonata_basket_api_form_basket_element' => ApiBasketElementType::class,
+            'sonata_basket_api_form_basket_parent' => ApiBasketParentType::class,
+            'sonata_basket_api_form_basket_element_parent' => ApiBasketElementParentType::class,
         ]);
     }
 }

--- a/src/Component/Delivery/Selector.php
+++ b/src/Component/Delivery/Selector.php
@@ -147,7 +147,7 @@ class Selector implements ServiceDeliverySelectorInterface
 
         // STEP 2 : We select the delivery methods with the highest priority
         $instances = array_values($instances);
-        usort($instances, ['Sonata\Component\Delivery\Selector', 'sort']);
+        usort($instances, [self::class, 'sort']);
 
         return $instances;
     }

--- a/src/Component/Payment/Paypal.php
+++ b/src/Component/Payment/Paypal.php
@@ -14,6 +14,7 @@ namespace Sonata\Component\Payment;
 use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Product\ProductInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -101,7 +102,7 @@ class Paypal extends BasePaypal
             echo "<!-- Encrypted Array : \n".print_r($fields, 1).'-->';
         }
 
-        $response = new \Symfony\Component\HttpFoundation\Response($html, 200, [
+        $response = new Response($html, 200, [
             'Content-Type' => 'text/html',
         ]);
         $response->setPrivate(true);
@@ -252,7 +253,7 @@ class Paypal extends BasePaypal
     public function sendConfirmationReceipt(TransactionInterface $transaction)
     {
         if (!$transaction->isValid()) {
-            return new \Symfony\Component\HttpFoundation\Response('');
+            return new Response('');
         }
 
         $params = $transaction->getParameters();
@@ -284,7 +285,7 @@ class Paypal extends BasePaypal
             }
         }
 
-        return new \Symfony\Component\HttpFoundation\Response('');
+        return new Response('');
     }
 
     /**

--- a/src/CustomerBundle/SonataCustomerBundle.php
+++ b/src/CustomerBundle/SonataCustomerBundle.php
@@ -12,6 +12,10 @@
 namespace Sonata\CustomerBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\CustomerBundle\Form\Type\AddressType;
+use Sonata\CustomerBundle\Form\Type\AddressTypeType;
+use Sonata\CustomerBundle\Form\Type\ApiAddressType;
+use Sonata\CustomerBundle\Form\Type\ApiCustomerType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -39,10 +43,10 @@ class SonataCustomerBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_customer_address' => 'Sonata\CustomerBundle\Form\Type\AddressType',
-            'sonata_customer_address_types' => 'Sonata\CustomerBundle\Form\Type\AddressTypeType',
-            'sonata_customer_api_form_customer' => 'Sonata\CustomerBundle\Form\Type\ApiCustomerType',
-            'sonata_customer_api_form_address' => 'Sonata\CustomerBundle\Form\Type\ApiAddressType',
+            'sonata_customer_address' => AddressType::class,
+            'sonata_customer_address_types' => AddressTypeType::class,
+            'sonata_customer_api_form_customer' => ApiCustomerType::class,
+            'sonata_customer_api_form_address' => ApiAddressType::class,
         ]);
     }
 }

--- a/src/DeliveryBundle/SonataDeliveryBundle.php
+++ b/src/DeliveryBundle/SonataDeliveryBundle.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DeliveryBundle;
 
+use Sonata\Component\Form\Type\DeliveryChoiceType;
 use Sonata\CoreBundle\Form\FormHelper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -39,7 +40,7 @@ class SonataDeliveryBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_delivery_choice' => 'Sonata\Component\Form\Type\DeliveryChoiceType',
+            'sonata_delivery_choice' => DeliveryChoiceType::class,
         ]);
     }
 }

--- a/src/InvoiceBundle/SonataInvoiceBundle.php
+++ b/src/InvoiceBundle/SonataInvoiceBundle.php
@@ -12,6 +12,7 @@
 namespace Sonata\InvoiceBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\InvoiceBundle\Form\Type\InvoiceStatusType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -39,7 +40,7 @@ class SonataInvoiceBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_invoice_status' => 'Sonata\InvoiceBundle\Form\Type\InvoiceStatusType',
+            'sonata_invoice_status' => InvoiceStatusType::class,
         ]);
     }
 }

--- a/src/OrderBundle/Entity/BaseOrder.php
+++ b/src/OrderBundle/Entity/BaseOrder.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\OrderBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\Component\Currency\CurrencyInterface;
 use Sonata\Component\Customer\CustomerInterface;
 use Sonata\Component\Delivery\BaseServiceDelivery;
@@ -208,7 +209,7 @@ abstract class BaseOrder implements OrderInterface
 
     public function __construct()
     {
-        $this->orderElements = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->orderElements = new ArrayCollection();
     }
 
     /**

--- a/src/OrderBundle/SonataOrderBundle.php
+++ b/src/OrderBundle/SonataOrderBundle.php
@@ -12,6 +12,7 @@
 namespace Sonata\OrderBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\OrderBundle\Form\Type\OrderStatusType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -39,7 +40,7 @@ class SonataOrderBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_order_status' => 'Sonata\OrderBundle\Form\Type\OrderStatusType',
+            'sonata_order_status' => OrderStatusType::class,
         ]);
     }
 }

--- a/src/PaymentBundle/SonataPaymentBundle.php
+++ b/src/PaymentBundle/SonataPaymentBundle.php
@@ -12,6 +12,7 @@
 namespace Sonata\PaymentBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\PaymentBundle\Form\Type\PaymentTransactionStatusType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -39,7 +40,7 @@ class SonataPaymentBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_payment_transaction_status' => 'Sonata\PaymentBundle\Form\Type\PaymentTransactionStatusType',
+            'sonata_payment_transaction_status' => PaymentTransactionStatusType::class,
         ]);
     }
 }

--- a/src/ProductBundle/DependencyInjection/Compiler/AddProductProviderCompilerPass.php
+++ b/src/ProductBundle/DependencyInjection/Compiler/AddProductProviderCompilerPass.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\ProductBundle\DependencyInjection\Compiler;
 
+use Sonata\Component\Product\ProductDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -41,7 +42,7 @@ class AddProductProviderCompilerPass implements CompilerPassInterface
 
             foreach ($arguments[1] as $code => $options) {
                 // define a new ProductDefinition
-                $definition = new Definition('Sonata\Component\Product\ProductDefinition', [new Reference($options['provider']), new Reference($options['manager'])]);
+                $definition = new Definition(ProductDefinition::class, [new Reference($options['provider']), new Reference($options['manager'])]);
                 $definition->setPublic(false);
                 $container->setDefinition($code, $definition);
 

--- a/src/ProductBundle/SonataProductBundle.php
+++ b/src/ProductBundle/SonataProductBundle.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\ProductBundle;
 
+use Sonata\Component\Currency\CurrencyFormType;
+use Sonata\Component\Form\Type\VariationChoiceType;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\ProductBundle\DependencyInjection\Compiler\AddProductProviderCompilerPass;
+use Sonata\ProductBundle\Form\Type\ApiProductParentType;
+use Sonata\ProductBundle\Form\Type\ApiProductType;
+use Sonata\ProductBundle\Form\Type\ProductDeliveryStatusType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -42,11 +47,11 @@ class SonataProductBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_product_delivery_status' => 'Sonata\ProductBundle\Form\Type\ProductDeliveryStatusType',
-            'sonata_product_variation_choices' => 'Sonata\Component\Form\Type\VariationChoiceType',
-            'sonata_product_api_form_product_parent' => 'Sonata\ProductBundle\Form\Type\ApiProductParentType',
-            'sonata_product_api_form_product' => 'Sonata\ProductBundle\Form\Type\ApiProductType',
-            'sonata_currency' => 'Sonata\Component\Currency\CurrencyFormType',
+            'sonata_product_delivery_status' => ProductDeliveryStatusType::class,
+            'sonata_product_variation_choices' => VariationChoiceType::class,
+            'sonata_product_api_form_product_parent' => ApiProductParentType::class,
+            'sonata_product_api_form_product' => ApiProductType::class,
+            'sonata_currency' => CurrencyFormType::class,
         ]);
     }
 }

--- a/tests/BasketBundle/Block/BasketBlockServiceTest.php
+++ b/tests/BasketBundle/Block/BasketBlockServiceTest.php
@@ -13,6 +13,8 @@ namespace Sonata\BasketBundle\Tests\Block;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\BasketBundle\Block\BasketBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,7 +24,7 @@ class BasketBlockServiceTest extends TestCase
 {
     public function testGetName()
     {
-        $engineInterfaceMock = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $engineInterfaceMock = $this->createMock(EngineInterface::class);
         $block = new BasketBlockService('test', $engineInterfaceMock);
 
         $this->assertEquals('Basket items', $block->getName());
@@ -30,11 +32,11 @@ class BasketBlockServiceTest extends TestCase
 
     public function testExecute()
     {
-        $engineInterfaceMock = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $engineInterfaceMock = $this->createMock(EngineInterface::class);
         $engineInterfaceMock->expects($this->once())->method('renderResponse')->will($this->returnValue(new Response()));
-        $context = $this->createMock('Sonata\BlockBundle\Block\BlockContextInterface');
+        $context = $this->createMock(BlockContextInterface::class);
         $block = new BasketBlockService('test', $engineInterfaceMock);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $block->execute($context));
+        $this->assertInstanceOf(Response::class, $block->execute($context));
     }
 }

--- a/tests/BasketBundle/Controller/Api/BasketControllerTest.php
+++ b/tests/BasketBundle/Controller/Api/BasketControllerTest.php
@@ -11,9 +11,24 @@
 
 namespace Sonata\BasketBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
 use Sonata\BasketBundle\Controller\Api\BasketController;
+use Sonata\Component\Basket\BasketBuilderInterface;
+use Sonata\Component\Basket\BasketElementInterface;
+use Sonata\Component\Basket\BasketElementManagerInterface;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Basket\BasketManagerInterface;
+use Sonata\Component\Product\Pool;
+use Sonata\Component\Product\ProductDefinition;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -22,10 +37,10 @@ class BasketControllerTest extends TestCase
 {
     public function testGetBasketsAction()
     {
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -34,9 +49,9 @@ class BasketControllerTest extends TestCase
 
     public function testGetBasketAction()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
         $this->assertEquals($basket, $this->createBasketController($basketManager)->getBasketAction(1));
@@ -44,7 +59,7 @@ class BasketControllerTest extends TestCase
 
     public function testGetBasketActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Basket (42) not found');
 
         $this->createBasketController()->getBasketAction(42);
@@ -54,10 +69,10 @@ class BasketControllerTest extends TestCase
     {
         $elements = [1, 2];
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue($elements));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
         $this->assertEquals($elements, $this->createBasketController($basketManager)->getBasketBasketelementsAction(1));
@@ -65,7 +80,7 @@ class BasketControllerTest extends TestCase
 
     public function testGetBasketelementsActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Basket (42) not found');
 
         $this->createBasketController()->getBasketBasketelementsAction(42);
@@ -73,91 +88,91 @@ class BasketControllerTest extends TestCase
 
     public function testPostBasketAction()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('save')->will($this->returnValue($basket));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basket));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, null, null, null, $formFactory)->postBasketAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostBasketInvalidAction()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->never())->method('save')->will($this->returnValue($basket));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData')->will($this->returnValue($basket));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, null, null, null, $formFactory)->postBasketAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutBasketAction()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('save')->will($this->returnValue($basket));
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basket));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, null, null, null, $formFactory)->putBasketAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutBasketInvalidAction()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->never())->method('save')->will($this->returnValue($basket));
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData')->will($this->returnValue($basket));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, null, null, null, $formFactory)->putBasketAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteBasketAction()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('delete');
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
@@ -168,9 +183,9 @@ class BasketControllerTest extends TestCase
 
     public function testDeleteBasketInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue(null));
         $basketManager->expects($this->never())->method('delete');
 
@@ -179,191 +194,191 @@ class BasketControllerTest extends TestCase
 
     public function testPostBasketBasketelementsAction()
     {
-        $productDefinition = $this->getMockBuilder('Sonata\Component\Product\ProductDefinition')
+        $productDefinition = $this->getMockBuilder(ProductDefinition::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(Pool::class);
         $productPool->expects($this->once())->method('getProduct')->will($this->returnValue($productDefinition));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getProductPool')->will($this->returnValue($productPool));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('save')->will($this->returnValue($basket));
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
 
-        $basketElementManager = $this->createMock('Sonata\Component\Basket\BasketElementManagerInterface');
+        $basketElementManager = $this->createMock(BasketElementManagerInterface::class);
         $basketElementManager->expects($this->once())->method('create')->will($this->returnValue($basketElement));
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basketElement));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, $basketElementManager, $productManager, $basketBuilder, $formFactory)->postBasketBasketelementsAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostBasketBasketelementsInvalidAction()
     {
-        $productDefinition = $this->getMockBuilder('Sonata\Component\Product\ProductDefinition')
+        $productDefinition = $this->getMockBuilder(ProductDefinition::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(Pool::class);
         $productPool->expects($this->once())->method('getProduct')->will($this->returnValue($productDefinition));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getProductPool')->will($this->returnValue($productPool));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->never())->method('save')->will($this->returnValue($basket));
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
 
-        $basketElementManager = $this->createMock('Sonata\Component\Basket\BasketElementManagerInterface');
+        $basketElementManager = $this->createMock(BasketElementManagerInterface::class);
         $basketElementManager->expects($this->once())->method('create')->will($this->returnValue($basketElement));
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData');
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, $basketElementManager, $productManager, $basketBuilder, $formFactory)->postBasketBasketelementsAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutBasketBasketelementsAction()
     {
-        $productDefinition = $this->getMockBuilder('Sonata\Component\Product\ProductDefinition')
+        $productDefinition = $this->getMockBuilder(ProductDefinition::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(Pool::class);
         $productPool->expects($this->once())->method('getProduct')->will($this->returnValue($productDefinition));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getProductPool')->will($this->returnValue($productPool));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->never())->method('save')->will($this->returnValue($basket));
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
 
-        $basketElementManager = $this->createMock('Sonata\Component\Basket\BasketElementManagerInterface');
+        $basketElementManager = $this->createMock(BasketElementManagerInterface::class);
         $basketElementManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basketElement));
         $basketElementManager->expects($this->once())->method('save')->will($this->returnValue($basketElement));
         $basketElementManager->expects($this->never())->method('create')->will($this->returnValue($basketElement));
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basketElement));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, $basketElementManager, $productManager, $basketBuilder, $formFactory)->putBasketBasketelementsAction(1, 1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutBasketBasketelementsInvalidAction()
     {
-        $productDefinition = $this->getMockBuilder('Sonata\Component\Product\ProductDefinition')
+        $productDefinition = $this->getMockBuilder(ProductDefinition::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(Pool::class);
         $productPool->expects($this->once())->method('getProduct')->will($this->returnValue($productDefinition));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getProductPool')->will($this->returnValue($productPool));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->never())->method('save')->will($this->returnValue($basket));
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
 
-        $basketElementManager = $this->createMock('Sonata\Component\Basket\BasketElementManagerInterface');
+        $basketElementManager = $this->createMock(BasketElementManagerInterface::class);
         $basketElementManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basketElement));
         $basketElementManager->expects($this->never())->method('create')->will($this->returnValue($basketElement));
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData');
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createBasketController($basketManager, $basketElementManager, $productManager, $basketBuilder, $formFactory)->putBasketBasketelementsAction(1, 1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteBasketBasketelementsAction()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue([]));
         $basket->expects($this->once())->method('setBasketElements');
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('findOneBy')->will($this->returnValue($basket));
         $basketManager->expects($this->once())->method('save');
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
         $view = $this->createBasketController($basketManager, null, null, $basketBuilder)->deleteBasketBasketelementsAction(1, 1);
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     /**
@@ -378,19 +393,19 @@ class BasketControllerTest extends TestCase
     public function createBasketController($basketManager = null, $basketElementManager = null, $productManager = null, $basketBuilder = null, $formFactory = null)
     {
         if (null === $basketManager) {
-            $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+            $basketManager = $this->createMock(BasketManagerInterface::class);
         }
         if (null === $basketElementManager) {
-            $basketElementManager = $this->createMock('Sonata\Component\Basket\BasketElementManagerInterface');
+            $basketElementManager = $this->createMock(BasketElementManagerInterface::class);
         }
         if (null === $productManager) {
-            $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+            $productManager = $this->createMock(ProductManagerInterface::class);
         }
         if (null === $basketBuilder) {
-            $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+            $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new BasketController($basketManager, $basketElementManager, $productManager, $basketBuilder, $formFactory);

--- a/tests/BasketBundle/Entity/BaseBasketTest.php
+++ b/tests/BasketBundle/Entity/BaseBasketTest.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\BasketBundle\Tests\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Sonata\BasketBundle\Entity\BaseBasket;
+use Sonata\BasketBundle\Entity\BaseBasketElement;
+use Sonata\Component\Product\Pool;
+use Sonata\Component\Product\ProductProviderInterface;
+use Sonata\ProductBundle\Entity\BaseProduct;
 
 class BasketTest extends BaseBasket
 {
@@ -27,13 +32,13 @@ class BaseBasketTest extends TestCase
     {
         $basket = new BasketTest();
 
-        $pool = $this->createMock('Sonata\Component\Product\Pool');
-        $pool->expects($this->any())->method('getProvider')->will($this->returnValue($this->createMock('Sonata\Component\Product\ProductProviderInterface')));
+        $pool = $this->createMock(Pool::class);
+        $pool->expects($this->any())->method('getProvider')->will($this->returnValue($this->createMock(ProductProviderInterface::class)));
 
         $basket->setProductPool($pool);
 
-        $element = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
-        $element->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element = $this->getMockBuilder(BaseBasketElement::class)->getMock();
+        $element->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder(BaseProduct::class)->getMock()));
 
         $elements = [
             'notBasketElementInterface',
@@ -49,13 +54,13 @@ class BaseBasketTest extends TestCase
     {
         $basket = new BasketTest();
 
-        $pool = $this->createMock('Sonata\Component\Product\Pool');
-        $pool->expects($this->any())->method('getProvider')->will($this->returnValue($this->createMock('Sonata\Component\Product\ProductProviderInterface')));
+        $pool = $this->createMock(Pool::class);
+        $pool->expects($this->any())->method('getProvider')->will($this->returnValue($this->createMock(ProductProviderInterface::class)));
 
         $basket->setProductPool($pool);
 
-        $element = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
-        $element->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element = $this->getMockBuilder(BaseBasketElement::class)->getMock();
+        $element->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder(BaseProduct::class)->getMock()));
 
         $elements = [
             'notBasketElementInterface',
@@ -71,30 +76,30 @@ class BaseBasketTest extends TestCase
         $basket->reset();
 
         $this->assertEquals(0, count($basket->getBasketElements()));
-        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $basket->getBasketElements());
+        $this->assertInstanceOf(ArrayCollection::class, $basket->getBasketElements());
     }
 
     public function testBasketElementsVatAmounts()
     {
         $basket = new BasketTest();
 
-        $pool = $this->createMock('Sonata\Component\Product\Pool');
-        $pool->expects($this->any())->method('getProvider')->will($this->returnValue($this->createMock('Sonata\Component\Product\ProductProviderInterface')));
+        $pool = $this->createMock(Pool::class);
+        $pool->expects($this->any())->method('getProvider')->will($this->returnValue($this->createMock(ProductProviderInterface::class)));
 
         $basket->setProductPool($pool);
 
-        $element1 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
-        $element1->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element1 = $this->getMockBuilder(BaseBasketElement::class)->getMock();
+        $element1->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder(BaseProduct::class)->getMock()));
         $element1->expects($this->any())->method('getVatRate')->will($this->returnValue(20));
         $element1->expects($this->any())->method('getVatAmount')->will($this->returnValue(3));
 
-        $element2 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
-        $element2->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element2 = $this->getMockBuilder(BaseBasketElement::class)->getMock();
+        $element2->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder(BaseProduct::class)->getMock()));
         $element2->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
         $element2->expects($this->any())->method('getVatAmount')->will($this->returnValue(2));
 
-        $element3 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
-        $element3->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()));
+        $element3 = $this->getMockBuilder(BaseBasketElement::class)->getMock();
+        $element3->expects($this->any())->method('getProduct')->will($this->returnValue($this->getMockBuilder(BaseProduct::class)->getMock()));
         $element3->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
         $element3->expects($this->any())->method('getVatAmount')->will($this->returnValue(5));
 

--- a/tests/BasketBundle/Entity/BasketElementTest.php
+++ b/tests/BasketBundle/Entity/BasketElementTest.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\BasketBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BasketElement;
 
 /**
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class BasketElementTest extends \PHPUnit\Framework\TestCase
+class BasketElementTest extends TestCase
 {
     /**
      * Test quantity setter, if quantity is negative, must returns a quantity of 1.

--- a/tests/BasketBundle/Form/ApiBasketElementTypeTest.php
+++ b/tests/BasketBundle/Form/ApiBasketElementTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\BasketBundle\Tests\Form;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\BasketBundle\Form\ApiBasketElementType;
+use Symfony\Component\Form\FormBuilder;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -23,7 +24,7 @@ class ApiBasketElementTypeTest extends TestCase
     {
         $type = new ApiBasketElementType('my.test.class');
 
-        $builder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $builder = $this->createMock(FormBuilder::class);
         $builder->expects($this->once())->method('create')->will($this->returnSelf());
         $builder->expects($this->once())->method('addModelTransformer');
 

--- a/tests/BasketBundle/Form/ApiBasketTypeTest.php
+++ b/tests/BasketBundle/Form/ApiBasketTypeTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Sonata\BasketBundle\Form\ApiBasketType;
 use Sonata\Component\Currency\CurrencyDataTransformer;
 use Sonata\Component\Currency\CurrencyFormType;
+use Sonata\Component\Currency\CurrencyManagerInterface;
+use Symfony\Component\Form\FormBuilder;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -23,7 +25,7 @@ class ApiBasketTypeTest extends TestCase
 {
     public function testBuildForm()
     {
-        $currencyManager = $this->createMock('Sonata\Component\Currency\CurrencyManagerInterface');
+        $currencyManager = $this->createMock(CurrencyManagerInterface::class);
 
         $currencyDataTransformer = new CurrencyDataTransformer($currencyManager);
 
@@ -31,7 +33,7 @@ class ApiBasketTypeTest extends TestCase
 
         $type = new ApiBasketType('my.test.class', $currencyFormType);
 
-        $builder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $builder = $this->createMock(FormBuilder::class);
         $builder->expects($this->once())->method('create')->will($this->returnSelf());
 
         $type->buildForm($builder, []);

--- a/tests/Component/Basket/BaseBasketFactoryTest.php
+++ b/tests/Component/Basket/BaseBasketFactoryTest.php
@@ -13,8 +13,12 @@ namespace Sonata\Component\Tests\Basket;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BaseBasketFactory;
+use Sonata\Component\Basket\BasketBuilderInterface;
 use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Basket\BasketManagerInterface;
+use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Sonata\Component\Customer\CustomerInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 class BasketFactory extends BaseBasketFactory
 {
@@ -79,10 +83,10 @@ class BaseBasketFactoryTest extends TestCase
 {
     public function testConstruct()
     {
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
+        $session = $this->createMock(Session::class);
 
         $basketFactory = new BasketFactory($basketManager, $basketBuilder, $currencyDetector, $session);
 

--- a/tests/Component/Basket/BasketBuilderTest.php
+++ b/tests/Component/Basket/BasketBuilderTest.php
@@ -13,10 +13,16 @@ namespace Sonata\Component\Tests\Basket;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BasketBuilder;
+use Sonata\Component\Basket\BasketElementInterface;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Customer\AddressManagerInterface;
 use Sonata\Component\Delivery\Pool as DeliveryPool;
 use Sonata\Component\Payment\Pool as PaymentPool;
 use Sonata\Component\Product\Pool as ProductPool;
 use Sonata\Component\Product\ProductDefinition;
+use Sonata\Component\Product\ProductManagerInterface;
+use Sonata\Component\Product\ProductProviderInterface;
 
 class BasketBuilderTest extends TestCase
 {
@@ -31,15 +37,15 @@ class BasketBuilderTest extends TestCase
 
         $paymentPool = new PaymentPool();
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
 
         $basketBuilder = new BasketBuilder($productPool, $addressManager, $deliveryPool, $paymentPool);
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
 
         $basketElements = [$basketElement];
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue($basketElements));
 
         $basketBuilder->build($basket);
@@ -56,16 +62,16 @@ class BasketBuilderTest extends TestCase
 
         $paymentPool = new PaymentPool();
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
 
         $basketBuilder = new BasketBuilder($productPool, $addressManager, $deliveryPool, $paymentPool);
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
         $basketElement->expects($this->exactly(2))->method('getProductCode')->will($this->returnValue('non_existent_product_code'));
 
         $basketElements = [$basketElement];
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue($basketElements));
 
         $basketBuilder->build($basket);
@@ -73,8 +79,8 @@ class BasketBuilderTest extends TestCase
 
     public function testBuild()
     {
-        $productProvider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productProvider = $this->createMock(ProductProviderInterface::class);
+        $productManager = $this->createMock(ProductManagerInterface::class);
 
         $definition = new ProductDefinition($productProvider, $productManager);
 
@@ -84,18 +90,18 @@ class BasketBuilderTest extends TestCase
 
         $paymentPool = new PaymentPool();
 
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $address = $this->createMock(AddressInterface::class);
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->exactly(2))->method('findOneBy')->will($this->returnValue($address));
         $basketBuilder = new BasketBuilder($productPool, $addressManager, $deliveryPool, $paymentPool);
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
         $basketElement->expects($this->exactly(2))->method('getProductCode')->will($this->returnValue('test'));
         $basketElement->expects($this->once())->method('setProductDefinition');
 
         $basketElements = [$basketElement];
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue($basketElements));
 
         $basket->expects($this->once())->method('getDeliveryAddressId')->will($this->returnValue(1));

--- a/tests/Component/Basket/BasketElementManagerTest.php
+++ b/tests/Component/Basket/BasketElementManagerTest.php
@@ -11,6 +11,9 @@
 
 namespace Sonata\Component\Tests\Basket;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BasketElement;
 use Sonata\Component\Basket\BasketElementManager;
@@ -22,27 +25,27 @@ class BasketElementManagerTest extends TestCase
 {
     public function testCreateAndGetClass()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketEm = new BasketElementManager('Sonata\Component\Basket\BasketElement', $registry);
+        $basketEm = new BasketElementManager(BasketElement::class, $registry);
 
-        $this->assertInstanceOf('Sonata\Component\Basket\BasketElement', $basketEm->create());
-        $this->assertEquals('Sonata\Component\Basket\BasketElement', $basketEm->getClass());
+        $this->assertInstanceOf(BasketElement::class, $basketEm->create());
+        $this->assertEquals(BasketElement::class, $basketEm->getClass());
     }
 
     public function testSave()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('persist');
         $em->expects($this->once())->method('flush');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketEm = new BasketElementManager('Sonata\Component\Basket\BasketElement', $registry);
+        $basketEm = new BasketElementManager(BasketElement::class, $registry);
 
         $basketElement = new BasketElement();
         $basketEm->save($basketElement);
@@ -50,17 +53,17 @@ class BasketElementManagerTest extends TestCase
 
     public function testFind()
     {
-        $repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
+        $repository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
         $repository->expects($this->once())->method('findOneBy');
         $repository->expects($this->once())->method('findBy');
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketEm = new BasketElementManager('Sonata\Component\Basket\BasketElement', $registry);
+        $basketEm = new BasketElementManager(BasketElement::class, $registry);
 
         $basketEm->findBy([]);
         $basketEm->findOneBy([]);
@@ -68,14 +71,14 @@ class BasketElementManagerTest extends TestCase
 
     public function testDelete()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('remove');
         $em->expects($this->once())->method('flush');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketEm = new BasketElementManager('Sonata\Component\Basket\BasketElement', $registry);
+        $basketEm = new BasketElementManager(BasketElement::class, $registry);
 
         $basketElement = new BasketElement();
         $basketEm->delete($basketElement);

--- a/tests/Component/Basket/BasketElementTest.php
+++ b/tests/Component/Basket/BasketElementTest.php
@@ -11,12 +11,18 @@
 
 namespace Sonata\Component\Tests\Basket;
 
+use JMS\Serializer\SerializerInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BasketElement;
+use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Currency\Currency;
 use Sonata\Component\Currency\CurrencyPriceCalculator;
 use Sonata\Component\Product\ProductDefinition;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
+use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\ProductBundle\Model\BaseProductProvider;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ProductProviderTest extends BaseProductProvider
 {
@@ -41,7 +47,7 @@ class BasketElementTest extends TestCase
 
     public function getBasketElement($product = null)
     {
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')
+        $product = $this->getMockBuilder(ProductInterface::class)
             ->setMockClassName('BasketTest_Product')
             ->getMock();
         $product->expects($this->any())->method('getId')->will($this->returnValue(42));
@@ -52,10 +58,10 @@ class BasketElementTest extends TestCase
         $product->expects($this->any())->method('getOptions')->will($this->returnValue(['option1' => 'toto']));
         $product->expects($this->any())->method('getDescription')->will($this->returnValue('product description'));
 
-        $productProvider = new ProductProviderTest($this->createMock('JMS\Serializer\SerializerInterface'));
+        $productProvider = new ProductProviderTest($this->createMock(SerializerInterface::class));
         $productProvider->setCurrencyPriceCalculator(new CurrencyPriceCalculator());
-        $productProvider->setEventDispatcher($this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productProvider->setEventDispatcher($this->createMock(EventDispatcherInterface::class));
+        $productManager = $this->createMock(ProductManagerInterface::class);
 
         $productDefinition = new ProductDefinition($productProvider, $productManager);
 
@@ -66,7 +72,7 @@ class BasketElementTest extends TestCase
         $currency = new Currency();
         $currency->setLabel('EUR');
 
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
         $basket->expects($this->any())->method('getCurrency')->will($this->returnValue($currency));
 
         $productProvider->updateComputationPricesFields($basket, $basketElement, $product);
@@ -153,7 +159,7 @@ class BasketElementTest extends TestCase
 
     public function testValidity()
     {
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')
+        $product = $this->getMockBuilder(ProductInterface::class)
             ->setMockClassName('BasketTest_Product')
             ->getMock();
         $product->expects($this->once())->method('getEnabled')->will($this->returnValue(true));
@@ -163,7 +169,7 @@ class BasketElementTest extends TestCase
 
         $this->assertTrue($basketElement->isValid(), 'BasketElement is valid');
 
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')
+        $product = $this->getMockBuilder(ProductInterface::class)
             ->setMockClassName('BasketTest_Product')
             ->getMock();
         $product->expects($this->once())->method('getEnabled')->will($this->returnValue(false));
@@ -174,9 +180,9 @@ class BasketElementTest extends TestCase
 
     public function testGettersSetters()
     {
-        $currency = $this->createMock('Sonata\Component\Currency\Currency');
-        $productProvider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $currency = $this->createMock(Currency::class);
+        $productProvider = $this->createMock(ProductProviderInterface::class);
+        $productManager = $this->createMock(ProductManagerInterface::class);
 
         $productDefinition = new ProductDefinition($productProvider, $productManager);
 
@@ -187,8 +193,8 @@ class BasketElementTest extends TestCase
         $this->assertEquals(0, $basketElement->getUnitPrice($currency));
         $this->assertFalse($basketElement->isValid());
 
-        $provider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
-        $manager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $provider = $this->createMock(ProductProviderInterface::class);
+        $manager = $this->createMock(ProductManagerInterface::class);
 
         $productDefinition = new ProductDefinition($provider, $manager);
 
@@ -199,7 +205,7 @@ class BasketElementTest extends TestCase
 
         $this->assertNull($basketElement->getProduct());
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
         $product->expects($this->any())
             ->method('getId')
             ->will($this->returnValue(42));

--- a/tests/Component/Basket/BasketEntityFactoryTest.php
+++ b/tests/Component/Basket/BasketEntityFactoryTest.php
@@ -12,29 +12,36 @@
 namespace Sonata\Component\Tests\Basket;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\BasketBuilderInterface;
 use Sonata\Component\Basket\BasketEntityFactory;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Basket\BasketManagerInterface;
 use Sonata\Component\Currency\Currency;
+use Sonata\Component\Currency\CurrencyDetectorInterface;
+use Sonata\Component\Customer\CustomerInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class BasketEntityFactoryTest extends TestCase
 {
     public function testLoadWithNoBasket()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('setCustomer');
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('loadBasketPerCustomer')->will($this->returnValue(false));
         $basketManager->expects($this->once())->method('create')->will($this->returnValue($basket));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->exactly(3))->method('getId')->will($this->returnValue(1));
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -46,26 +53,26 @@ class BasketEntityFactoryTest extends TestCase
 
         $basket = $factory->load($customer);
 
-        $this->isInstanceOf('Sonata\Component\Basket\BasketInterface', $basket);
+        $this->isInstanceOf(BasketInterface::class, $basket);
     }
 
     public function testLoadWithNoBasketInDbButBasketInSession()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('setCustomer');
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('loadBasketPerCustomer')->will($this->returnValue(false));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->exactly(3))->method('getId')->will($this->returnValue(1));
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
         $session->expects($this->exactly(1))->method('get')->will($this->returnValue($basket));
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -77,28 +84,28 @@ class BasketEntityFactoryTest extends TestCase
 
         $basket = $factory->load($customer);
 
-        $this->isInstanceOf('Sonata\Component\Basket\BasketInterface', $basket);
+        $this->isInstanceOf(BasketInterface::class, $basket);
     }
 
     public function testLoadWithBasketInDbAndInSession()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
-        $sessionBasket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $sessionBasket = $this->createMock(BasketInterface::class);
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('loadBasketPerCustomer')->will($this->returnValue($basket));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->exactly(2))->method('build');
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->exactly(5))->method('getId')->will($this->returnValue(1));
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
         $session->expects($this->exactly(1))->method('get')->will($this->returnValue($sessionBasket));
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -110,22 +117,22 @@ class BasketEntityFactoryTest extends TestCase
 
         $loadedBasket = $factory->load($customer);
 
-        $this->isInstanceOf('Sonata\Component\Basket\BasketInterface', $loadedBasket);
+        $this->isInstanceOf(BasketInterface::class, $loadedBasket);
     }
 
     public function testSaveExistingCustomer()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getCustomerId')->will($this->returnValue(1));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('save');
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -139,21 +146,21 @@ class BasketEntityFactoryTest extends TestCase
 
     public function testSaveNoExistingCustomer()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getCustomerId')->will($this->returnValue(false));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session = $this->createMock(SessionInterface::class);
         $tester = $this;
         $session->expects($this->once())->method('set')->will($this->returnCallback(function ($key, $value) use ($tester, $basket) {
             $tester->assertEquals($basket, $value);
             $tester->assertEquals('sonata/basket/factory/customer/new', $key);
         }));
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -167,17 +174,17 @@ class BasketEntityFactoryTest extends TestCase
 
     public function testReset()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getCustomerId')->will($this->returnValue(1));
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('delete');
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())

--- a/tests/Component/Basket/BasketManagerTest.php
+++ b/tests/Component/Basket/BasketManagerTest.php
@@ -11,7 +11,11 @@
 
 namespace Sonata\Component\Tests\Basket;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\TestCase;
+use Sonata\BasketBundle\Entity\BaseBasket;
 use Sonata\Component\Basket\Basket;
 use Sonata\Component\Basket\BasketManager;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
@@ -23,27 +27,27 @@ class BasketManagerTest extends TestCase
 {
     public function testCreateAndGetClass()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketMgr = new BasketManager('Sonata\Component\Basket\Basket', $registry);
+        $basketMgr = new BasketManager(Basket::class, $registry);
 
-        $this->assertInstanceOf('Sonata\Component\Basket\Basket', $basketMgr->create());
-        $this->assertEquals('Sonata\Component\Basket\Basket', $basketMgr->getClass());
+        $this->assertInstanceOf(Basket::class, $basketMgr->create());
+        $this->assertEquals(Basket::class, $basketMgr->getClass());
     }
 
     public function testSave()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('persist');
         $em->expects($this->once())->method('flush');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketMgr = new BasketManager('Sonata\Component\Basket\Basket', $registry);
+        $basketMgr = new BasketManager(Basket::class, $registry);
 
         $basket = new Basket();
         $basketMgr->save($basket);
@@ -51,31 +55,31 @@ class BasketManagerTest extends TestCase
 
     public function testFind()
     {
-        $repository = $this->createMock('Doctrine\ORM\EntityRepository');
+        $repository = $this->createMock(EntityRepository::class);
         $repository->expects($this->once())->method('findOneBy');
         $repository->expects($this->once())->method('findBy');
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketMgr = new BasketManager('Sonata\Component\Basket\Basket', $registry);
+        $basketMgr = new BasketManager(Basket::class, $registry);
         $basketMgr->findBy([]);
         $basketMgr->findOneBy([]);
     }
 
     public function testDelete()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('remove');
         $em->expects($this->once())->method('flush');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $basketMgr = new BasketManager('Sonata\Component\Basket\Basket', $registry);
+        $basketMgr = new BasketManager(Basket::class, $registry);
 
         $basket = new Basket();
         $basketMgr->delete($basket);
@@ -139,9 +143,9 @@ class BasketManagerTest extends TestCase
             'locale',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new BasketManager('Sonata\BasketBundle\Entity\BaseBasket', $registry);
+        return new BasketManager(BaseBasket::class, $registry);
     }
 }

--- a/tests/Component/Basket/BasketSessionFactoryTest.php
+++ b/tests/Component/Basket/BasketSessionFactoryTest.php
@@ -12,32 +12,39 @@
 namespace Sonata\Component\Tests\Basket;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\BasketBuilderInterface;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Basket\BasketManagerInterface;
 use Sonata\Component\Basket\BasketSessionFactory;
 use Sonata\Component\Currency\Currency;
+use Sonata\Component\Currency\CurrencyDetectorInterface;
+use Sonata\Component\Customer\CustomerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class BasketSessionFactoryTest extends TestCase
 {
     public function testLoadWithNoBasket()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('setCustomer');
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketManager->expects($this->once())->method('create')->will($this->returnValue($basket));
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -49,26 +56,26 @@ class BasketSessionFactoryTest extends TestCase
 
         $basket = $factory->load($customer);
 
-        $this->isInstanceOf('Sonata\Component\Basket\BasketInterface', $basket);
+        $this->isInstanceOf(BasketInterface::class, $basket);
     }
 
     public function testLoadWithBasket()
     {
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('setCustomer');
 
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $basketBuilder->expects($this->once())->method('build');
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->any())->method('getId')->will($this->returnValue(1));
 
         $session = new Session(new MockArraySessionStorage());
         $session->set('sonata/basket/factory/customer/1', $basket);
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -80,24 +87,24 @@ class BasketSessionFactoryTest extends TestCase
 
         $basket = $factory->load($customer);
 
-        $this->isInstanceOf('Sonata\Component\Basket\BasketInterface', $basket);
+        $this->isInstanceOf(BasketInterface::class, $basket);
     }
 
     public function testSave()
     {
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session = $this->createMock(SessionInterface::class);
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getCustomer')->will($this->returnValue($customer));
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $currency = new Currency();
         $currency->setLabel('EUR');
         $currencyDetector->expects($this->any())
@@ -111,16 +118,16 @@ class BasketSessionFactoryTest extends TestCase
 
     public function testLogout()
     {
-        $basketManager = $this->createMock('Sonata\Component\Basket\BasketManagerInterface');
+        $basketManager = $this->createMock(BasketManagerInterface::class);
 
-        $basketBuilder = $this->createMock('Sonata\Component\Basket\BasketBuilderInterface');
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session = $this->createMock(SessionInterface::class);
         $session->expects($this->once())->method('remove');
 
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
 
         $factory = new BasketSessionFactory($basketManager, $basketBuilder, $currencyDetector, $session);
-        $factory->logout(new Request(), new Response(), $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+        $factory->logout(new Request(), new Response(), $this->createMock(TokenInterface::class));
     }
 }

--- a/tests/Component/Basket/LoaderTest.php
+++ b/tests/Component/Basket/LoaderTest.php
@@ -12,38 +12,40 @@
 namespace Sonata\Component\Tests\Basket;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\BasketFactoryInterface;
+use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Basket\Loader;
+use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Customer\CustomerSelectorInterface;
 
 class LoaderTest extends TestCase
 {
     public function testLoadBasket()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
-        $basketFactory = $this->createMock('Sonata\Component\Basket\BasketFactoryInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $basket = $this->createMock(BasketInterface::class);
+        $basketFactory = $this->createMock(BasketFactoryInterface::class);
         $basketFactory->expects($this->once())->method('load')->will($this->returnValue($basket));
 
-        $customerSelector = $this->createMock('Sonata\Component\Customer\CustomerSelectorInterface');
+        $customerSelector = $this->createMock(CustomerSelectorInterface::class);
         $customerSelector->expects($this->once())->method('get')->will($this->returnValue($customer));
 
         $loader = new Loader($basketFactory, $customerSelector);
 
-        $this->assertInstanceOf('Sonata\Component\Basket\BasketInterface', $loader->getBasket());
+        $this->assertInstanceOf(BasketInterface::class, $loader->getBasket());
     }
 
     public function testExceptionLoadBasket()
     {
         $this->expectException(\RuntimeException::class);
 
-        $this->expectException('RuntimeException');
-
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $basketFactory = $this->createMock('Sonata\Component\Basket\BasketFactoryInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $basketFactory = $this->createMock(BasketFactoryInterface::class);
         $basketFactory->expects($this->once())->method('load')->will($this->returnCallback(function () {
             throw new \RuntimeException();
         }));
 
-        $customerSelector = $this->createMock('Sonata\Component\Customer\CustomerSelectorInterface');
+        $customerSelector = $this->createMock(CustomerSelectorInterface::class);
         $customerSelector->expects($this->once())->method('get')->will($this->returnValue($customer));
 
         $loader = new Loader($basketFactory, $customerSelector);

--- a/tests/Component/Currency/CurrencyDataTransformerTest.php
+++ b/tests/Component/Currency/CurrencyDataTransformerTest.php
@@ -14,6 +14,7 @@ namespace Sonata\Component\Tests\Currency;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Currency\Currency;
 use Sonata\Component\Currency\CurrencyDataTransformer;
+use Sonata\Component\Currency\CurrencyManagerInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -25,7 +26,7 @@ class CurrencyDataTransformerTest extends TestCase
 
     protected function setUp()
     {
-        $this->currencyManager = $this->createMock('Sonata\Component\Currency\CurrencyManagerInterface');
+        $this->currencyManager = $this->createMock(CurrencyManagerInterface::class);
 
         $this->currencyDataTransformer = new CurrencyDataTransformer($this->currencyManager);
     }

--- a/tests/Component/Currency/CurrencyDetectorTest.php
+++ b/tests/Component/Currency/CurrencyDetectorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\Component\Currency\Currency;
 use Sonata\Component\Currency\CurrencyDetector;
 use Sonata\Component\Currency\CurrencyInterface;
+use Sonata\Component\Currency\CurrencyManagerInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -37,13 +38,13 @@ class CurrencyDetectorTest extends TestCase
      */
     protected function setUp()
     {
-        $this->currency = $this->createMock('Sonata\Component\Currency\CurrencyInterface');
+        $this->currency = $this->createMock(CurrencyInterface::class);
         $this->currency->expects($this->any())
             ->method('getLabel')
             ->will($this->returnValue('EUR'))
         ;
 
-        $currencyManager = $this->createMock('Sonata\Component\Currency\CurrencyManagerInterface');
+        $currencyManager = $this->createMock(CurrencyManagerInterface::class);
         $currencyManager->expects($this->any())
             ->method('findOneByLabel')
             ->will($this->returnValue($this->currency))
@@ -68,7 +69,7 @@ class CurrencyDetectorTest extends TestCase
         $currency = new Currency();
         $currency->setLabel('EUR');
 
-        $currencyManager = $this->createMock('Sonata\Component\Currency\CurrencyManagerInterface');
+        $currencyManager = $this->createMock(CurrencyManagerInterface::class);
         $currencyManager->expects($this->any())
             ->method('findOneByLabel')
             ->will($this->returnValue($currency))

--- a/tests/Component/Currency/CurrencyDoctrineTypeTest.php
+++ b/tests/Component/Currency/CurrencyDoctrineTypeTest.php
@@ -11,18 +11,21 @@
 
 namespace Sonata\Component\Tests\Currency;
 
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Currency\Currency;
+use Sonata\Component\Currency\CurrencyDoctrineType;
 
 class CurrencyDoctrineTypeTest extends TestCase
 {
     public function setUp()
     {
         if (Type::hasType('currency')) {
-            Type::overrideType('currency', 'Sonata\Component\Currency\CurrencyDoctrineType');
+            Type::overrideType('currency', CurrencyDoctrineType::class);
         } else {
-            Type::addType('currency', 'Sonata\Component\Currency\CurrencyDoctrineType');
+            Type::addType('currency', CurrencyDoctrineType::class);
         }
     }
 
@@ -93,7 +96,7 @@ class CurrencyDoctrineTypeTest extends TestCase
     }
 }
 
-class MockPlatform extends \Doctrine\DBAL\Platforms\AbstractPlatform
+class MockPlatform extends AbstractPlatform
 {
     /**
      * Gets the SQL Snippet used to declare a BLOB column type.

--- a/tests/Component/Currency/CurrencyFormTypeTest.php
+++ b/tests/Component/Currency/CurrencyFormTypeTest.php
@@ -12,7 +12,9 @@
 namespace Sonata\Component\Tests\Currency;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Currency\CurrencyDataTransformer;
 use Sonata\Component\Currency\CurrencyFormType;
+use Symfony\Component\Form\FormBuilder;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -26,13 +28,13 @@ class CurrencyFormTypeTest extends TestCase
 
     public function setUp()
     {
-        $currencyDataTransformer = $this->createMock('Sonata\Component\Currency\CurrencyDataTransformer');
+        $currencyDataTransformer = $this->createMock(CurrencyDataTransformer::class);
         $this->currencyFormType = new CurrencyFormType($currencyDataTransformer);
     }
 
     public function testBuildForm()
     {
-        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $formBuilder = $this->createMock(FormBuilder::class);
         $formBuilder->expects($this->once())
             ->method('addModelTransformer');
 

--- a/tests/Component/Currency/CurrencyManagerTest.php
+++ b/tests/Component/Currency/CurrencyManagerTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\Component\Tests\Currency;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Currency\Currency;
 use Sonata\Component\Currency\CurrencyManager;
 
 /**
@@ -21,9 +23,9 @@ class CurrencyManagerTest extends TestCase
 {
     public function testFindOneByLabel()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
 
-        $currencyManager = new CurrencyManager('Sonata\Component\Currency\Currency', $registry);
+        $currencyManager = new CurrencyManager(Currency::class, $registry);
 
         $this->assertEquals('EUR', $currencyManager->findOneByLabel('EUR')->getLabel());
     }

--- a/tests/Component/Currency/CurrencyPriceCalculatorTest.php
+++ b/tests/Component/Currency/CurrencyPriceCalculatorTest.php
@@ -14,6 +14,7 @@ namespace Sonata\Component\Tests\Currency;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Currency\Currency;
 use Sonata\Component\Currency\CurrencyPriceCalculator;
+use Sonata\Component\Product\ProductInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -24,7 +25,7 @@ class CurrencyPriceCalculatorTest extends TestCase
     {
         $currencyPriceCalculator = new CurrencyPriceCalculator();
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
         $currency = new Currency();
         $currency->setLabel('EUR');

--- a/tests/Component/Currency/CurrencyTest.php
+++ b/tests/Component/Currency/CurrencyTest.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\Component\Tests\Currency;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\Component\Currency\Currency;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class CurrencyTest extends \PHPUnit\Framework\TestCase
+class CurrencyTest extends TestCase
 {
     public function testGettersSetters()
     {

--- a/tests/Component/Customer/CustomerSelectorTest.php
+++ b/tests/Component/Customer/CustomerSelectorTest.php
@@ -13,9 +13,16 @@ namespace Sonata\Component\Tests\Customer;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\Basket;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Customer\CustomerManagerInterface;
 use Sonata\Component\Customer\CustomerSelector;
+use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class User
 {
@@ -32,23 +39,23 @@ class CustomerSelectorTest extends TestCase
      */
     public function testUserNotConnected()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('create')->will($this->returnValue($customer));
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session = $this->createMock(SessionInterface::class);
 
-        $securityContext = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $securityContext = $this->createMock(SecurityContextInterface::class);
         $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(false));
 
-        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
         $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
 
         $customer = $customerSelector->get();
 
-        $this->assertInstanceOf('Sonata\Component\Customer\CustomerInterface', $customer);
+        $this->assertInstanceOf(CustomerInterface::class, $customer);
     }
 
     public function testInvalidUserType()
@@ -56,18 +63,18 @@ class CustomerSelectorTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('User must be an instance of Symfony\\Component\\Security\\Core\\User\\UserInterface');
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
 
-        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue(new User()));
 
-        $securityContext = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $securityContext = $this->createMock(SecurityContextInterface::class);
         $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
         $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
-        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
         $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
@@ -77,69 +84,69 @@ class CustomerSelectorTest extends TestCase
 
     public function testExistingCustomer()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
 
         $user = new ValidUser();
 
-        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue($user));
 
-        $securityContext = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $securityContext = $this->createMock(SecurityContextInterface::class);
         $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
         $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
-        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
         $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
 
         $customer = $customerSelector->get();
 
-        $this->assertInstanceOf('Sonata\Component\Customer\CustomerInterface', $customer);
+        $this->assertInstanceOf(CustomerInterface::class, $customer);
     }
 
     public function testNonExistingCustomerNonInSession()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue(false));
         $customerManager->expects($this->once())->method('create')->will($this->returnValue($customer));
 
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $session = $this->createMock(Session::class);
 
         $user = new ValidUser();
 
-        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue($user));
 
-        $securityContext = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $securityContext = $this->createMock(SecurityContextInterface::class);
         $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
         $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
-        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
         $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
 
         $customer = $customerSelector->get();
 
-        $this->assertInstanceOf('Sonata\Component\Customer\CustomerInterface', $customer);
+        $this->assertInstanceOf(CustomerInterface::class, $customer);
     }
 
     public function testNonExistingCustomerInSession()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue(false));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->exactly(2))->method('getCustomer')->will($this->returnValue($customer));
 
         $session = new Session(new MockArraySessionStorage());
@@ -147,20 +154,20 @@ class CustomerSelectorTest extends TestCase
 
         $user = new ValidUser();
 
-        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock(TokenInterface::class);
         $token->expects($this->once())->method('getUser')->will($this->returnValue($user));
 
-        $securityContext = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $securityContext = $this->createMock(SecurityContextInterface::class);
         $securityContext->expects($this->once())->method('isGranted')->will($this->returnValue(true));
         $securityContext->expects($this->once())->method('getToken')->will($this->returnValue($token));
 
-        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector->expects($this->once())->method('getLocale')->will($this->returnValue('en'));
 
         $customerSelector = new CustomerSelector($customerManager, $session, $securityContext, $localeDetector);
 
         $customer = $customerSelector->get();
 
-        $this->assertInstanceOf('Sonata\Component\Customer\CustomerInterface', $customer);
+        $this->assertInstanceOf(CustomerInterface::class, $customer);
     }
 }

--- a/tests/Component/Delivery/SelectorTest.php
+++ b/tests/Component/Delivery/SelectorTest.php
@@ -13,9 +13,18 @@ namespace Sonata\Component\Tests\Delivery;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Sonata\Component\Basket\Basket;
+use Sonata\Component\Basket\BasketElement;
+use Sonata\Component\Basket\BasketElementInterface;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Delivery\BaseServiceDelivery;
 use Sonata\Component\Delivery\Pool as DeliveryPool;
 use Sonata\Component\Delivery\Selector;
+use Sonata\Component\Product\DeliveryInterface;
 use Sonata\Component\Product\Pool as ProductPool;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\CustomerBundle\Entity\BaseAddress;
 use Sonata\ProductBundle\Entity\BaseProduct;
 
 class SelectorTest extends TestCase
@@ -34,12 +43,12 @@ class SelectorTest extends TestCase
         $deliveryPool = new DeliveryPool();
         $productPool = new ProductPool();
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue([$basketElement]));
 
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
         $selector = new Selector($deliveryPool, $productPool);
         $this->assertEmpty($selector->getAvailableMethods($basket, $address));
@@ -64,7 +73,7 @@ class SelectorTest extends TestCase
     {
         $deliveryPool = new DeliveryPool();
         $productPool = new ProductPool();
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
+        $basket = $this->createMock(Basket::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue([]));
 
         $selector = new Selector($deliveryPool, $productPool);
@@ -79,9 +88,9 @@ class SelectorTest extends TestCase
         $deliveryPool = new DeliveryPool();
         $productPool = new ProductPool();
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElement');
-        $product = $this->createMock('Sonata\Component\Tests\Delivery\Product');
+        $basket = $this->createMock(Basket::class);
+        $basketElement = $this->createMock(BasketElement::class);
+        $product = $this->createMock(Product::class);
 
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue([$basketElement]));
         $basketElement->expects($this->once())->method('getProduct')->will($this->returnValue($product));
@@ -96,17 +105,17 @@ class SelectorTest extends TestCase
      */
     public function testGetAvailableMethodsWithRequiredAddressDelivery()
     {
-        $deliveryPool = $this->createMock('Sonata\Component\Delivery\Pool');
+        $deliveryPool = $this->createMock(DeliveryPool::class);
         $productPool = new ProductPool();
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElement');
-        $product = $this->createMock('Sonata\Component\Tests\Delivery\Product');
+        $basket = $this->createMock(Basket::class);
+        $basketElement = $this->createMock(BasketElement::class);
+        $product = $this->createMock(Product::class);
 
-        $delivery = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $delivery = $this->createMock(DeliveryInterface::class);
         $delivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
 
-        $serviceDelivery = $this->createMock('Sonata\Component\Delivery\BaseServiceDelivery');
+        $serviceDelivery = $this->createMock(BaseServiceDelivery::class);
         $serviceDelivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
         $serviceDelivery->expects($this->any())->method('getEnabled')->will($this->returnValue(true));
         $serviceDelivery->expects($this->any())->method('isAddressRequired')->will($this->returnValue(true));
@@ -125,17 +134,17 @@ class SelectorTest extends TestCase
      */
     public function testGetAvailableMethodsWithDisabledDelivery()
     {
-        $deliveryPool = $this->createMock('Sonata\Component\Delivery\Pool');
+        $deliveryPool = $this->createMock(DeliveryPool::class);
         $productPool = new ProductPool();
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElement');
-        $product = $this->createMock('Sonata\Component\Tests\Delivery\Product');
+        $basket = $this->createMock(Basket::class);
+        $basketElement = $this->createMock(BasketElement::class);
+        $product = $this->createMock(Product::class);
 
-        $delivery = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $delivery = $this->createMock(DeliveryInterface::class);
         $delivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
 
-        $serviceDelivery = $this->createMock('Sonata\Component\Delivery\BaseServiceDelivery');
+        $serviceDelivery = $this->createMock(BaseServiceDelivery::class);
         $serviceDelivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
         $deliveryPool->expects($this->any())->method('getMethod')->will($this->returnValue($serviceDelivery));
         $serviceDelivery->expects($this->any())->method('getEnabled')->will($this->returnValue(false));
@@ -153,14 +162,14 @@ class SelectorTest extends TestCase
      */
     public function testGetAvailableMethodsWithUndefinedCode()
     {
-        $deliveryPool = $this->createMock('Sonata\Component\Delivery\Pool');
+        $deliveryPool = $this->createMock(DeliveryPool::class);
         $productPool = new ProductPool();
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElement');
-        $product = $this->createMock('Sonata\Component\Tests\Delivery\Product');
+        $basket = $this->createMock(Basket::class);
+        $basketElement = $this->createMock(BasketElement::class);
+        $product = $this->createMock(Product::class);
 
-        $delivery = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $delivery = $this->createMock(DeliveryInterface::class);
         $delivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
 
         $deliveryPool->expects($this->any())->method('getMethod')->will($this->returnValue(null));
@@ -178,18 +187,18 @@ class SelectorTest extends TestCase
      */
     public function testGetAvailableMethodsWithUncoveredCountry()
     {
-        $deliveryPool = $this->createMock('Sonata\Component\Delivery\Pool');
+        $deliveryPool = $this->createMock(DeliveryPool::class);
         $productPool = new ProductPool();
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElement');
-        $product = $this->createMock('Sonata\Component\Tests\Delivery\Product');
+        $basket = $this->createMock(Basket::class);
+        $basketElement = $this->createMock(BasketElement::class);
+        $product = $this->createMock(Product::class);
 
-        $delivery = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $delivery = $this->createMock(DeliveryInterface::class);
         $delivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
         $delivery->expects($this->any())->method('getCountryCode')->will($this->returnValue('US'));
 
-        $serviceDelivery = $this->createMock('Sonata\Component\Delivery\BaseServiceDelivery');
+        $serviceDelivery = $this->createMock(BaseServiceDelivery::class);
         $serviceDelivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
         $serviceDelivery->expects($this->any())->method('getEnabled')->will($this->returnValue(true));
         $serviceDelivery->expects($this->any())->method('isAddressRequired')->will($this->returnValue(true));
@@ -199,7 +208,7 @@ class SelectorTest extends TestCase
         $basketElement->expects($this->once())->method('getProduct')->will($this->returnValue($product));
         $product->expects($this->once())->method('getDeliveries')->will($this->returnValue([$delivery]));
 
-        $address = $this->createMock('Sonata\CustomerBundle\Entity\BaseAddress');
+        $address = $this->createMock(BaseAddress::class);
         $address->expects($this->exactly(2))->method('getCountryCode')->will($this->returnValue('FR'));
 
         $selector = new Selector($deliveryPool, $productPool);
@@ -211,19 +220,19 @@ class SelectorTest extends TestCase
      */
     public function testGetAvailableMethodsWithAlreadySelectedCode()
     {
-        $deliveryPool = $this->createMock('Sonata\Component\Delivery\Pool');
+        $deliveryPool = $this->createMock(DeliveryPool::class);
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElement');
-        $product = $this->createMock('Sonata\Component\Tests\Delivery\Product');
+        $basket = $this->createMock(Basket::class);
+        $basketElement = $this->createMock(BasketElement::class);
+        $product = $this->createMock(Product::class);
 
-        $delivery1 = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $delivery1 = $this->createMock(DeliveryInterface::class);
         $delivery1->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
 
-        $delivery2 = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $delivery2 = $this->createMock(DeliveryInterface::class);
         $delivery2->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
 
-        $serviceDelivery = $this->createMock('Sonata\Component\Delivery\BaseServiceDelivery');
+        $serviceDelivery = $this->createMock(BaseServiceDelivery::class);
         $serviceDelivery->expects($this->any())->method('getCode')->will($this->returnValue('deliveryTest'));
         $serviceDelivery->expects($this->any())->method('getEnabled')->will($this->returnValue(true));
         $serviceDelivery->expects($this->any())->method('isAddressRequired')->will($this->returnValue(false));
@@ -262,25 +271,25 @@ class SelectorTest extends TestCase
 
         $productPool = new ProductPool();
 
-        $productDelivery_low = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $productDelivery_low = $this->createMock(DeliveryInterface::class);
         $productDelivery_low->expects($this->any())->method('getCode')->will($this->returnValue('ups_low'));
 
-        $productDelivery_high = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $productDelivery_high = $this->createMock(DeliveryInterface::class);
         $productDelivery_high->expects($this->any())->method('getCode')->will($this->returnValue('ups_high'));
 
-        $productDelivery_high_bis = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $productDelivery_high_bis = $this->createMock(DeliveryInterface::class);
         $productDelivery_high_bis->expects($this->any())->method('getCode')->will($this->returnValue('ups_high_bis'));
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
         $product->expects($this->once())->method('getDeliveries')->will($this->returnValue([$productDelivery_low, $productDelivery_high, $productDelivery_high_bis]));
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
         $basketElement->expects($this->once())->method('getProduct')->will($this->returnValue($product));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue([$basketElement]));
 
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
         $selector = new Selector($deliveryPool, $productPool);
         $selector->setLogger($this->createMock(LoggerInterface::class));
@@ -293,7 +302,7 @@ class SelectorTest extends TestCase
     }
 }
 
-class ServiceDelivery extends \Sonata\Component\Delivery\BaseServiceDelivery
+class ServiceDelivery extends BaseServiceDelivery
 {
     public function isAddressRequired()
     {

--- a/tests/Component/Delivery/ServiceDeliveryTest.php
+++ b/tests/Component/Delivery/ServiceDeliveryTest.php
@@ -40,7 +40,7 @@ class ServiceDeliveryTest extends TestCase
         $pool->addMethod($delivery);
 
         $this->assertEquals(2, count($pool->getMethods()), 'Pool return 2 elements');
-        $this->assertInstanceOf('Sonata\\Component\\Delivery\\FreeDelivery', $pool->getMethod('free_2'), 'Pool return an FreeDelivery Instance');
+        $this->assertInstanceOf(FreeDelivery::class, $pool->getMethod('free_2'), 'Pool return an FreeDelivery Instance');
     }
 
     public function testGetStatusList()

--- a/tests/Component/Form/BasketValidatorTest.php
+++ b/tests/Component/Form/BasketValidatorTest.php
@@ -12,8 +12,14 @@
 namespace Sonata\Component\Tests\Form;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\BasketElementInterface;
+use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Form\BasketValidator;
+use Sonata\Component\Product\Pool;
+use Sonata\Component\Product\ProductProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ExecutionContext;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -25,24 +31,24 @@ class BasketValidatorTest extends TestCase
      */
     public function testValidate()
     {
-        $provider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
+        $provider = $this->createMock(ProductProviderInterface::class);
         $provider->expects($this->once())->method('validateFormBasketElement');
 
-        $pool = $this->createMock('Sonata\Component\Product\Pool');
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $consValFact = $this->createMock('Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory');
+        $consValFact = $this->createMock(ConstraintValidatorFactory::class);
 
-        $context = $this->createMock('Symfony\Component\Validator\ExecutionContext');
+        $context = $this->createMock(ExecutionContext::class);
         $context->expects($this->once())->method('getViolations')->will($this->returnValue(['violation1']));
         $context->expects($this->once())->method('addViolationAt');
 
         $validator = new BasketValidator($pool, $consValFact);
         $validator->initialize($context);
 
-        $elements = [$this->createMock('Sonata\Component\Basket\BasketElementInterface')];
+        $elements = [$this->createMock(BasketElementInterface::class)];
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('getBasketElements')->will($this->returnValue($elements));
 
         $constraint = new NotBlank();

--- a/tests/Component/Form/EventListener/BasketResizeFormListenerTest.php
+++ b/tests/Component/Form/EventListener/BasketResizeFormListenerTest.php
@@ -12,8 +12,16 @@
 namespace Sonata\Component\Tests\Form\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\BasketElementInterface;
+use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Form\EventListener\BasketResizeFormListener;
+use Sonata\Component\Product\ProductProviderInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormFactoryInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -32,14 +40,14 @@ class BasketResizeFormListenerTest extends TestCase
 
     public function testPreSetData()
     {
-        $builder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $builder = $this->createMock(FormBuilder::class);
 
-        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock(FormFactoryInterface::class);
         $factory->expects($this->any())
             ->method('createNamedBuilder')
             ->will($this->returnValue($builder));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
 
         $formListener = new BasketResizeFormListener($factory, $basket);
 
@@ -48,14 +56,14 @@ class BasketResizeFormListenerTest extends TestCase
 
     public function testPreBind()
     {
-        $builder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $builder = $this->createMock(FormBuilder::class);
 
-        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock(FormFactoryInterface::class);
         $factory->expects($this->any())
             ->method('createNamedBuilder')
             ->will($this->returnValue($builder));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->any())
             ->method('getBasketElements')
             ->will($this->returnValue($this->getBasketElements()));
@@ -66,14 +74,14 @@ class BasketResizeFormListenerTest extends TestCase
 
     public function testPreBindEmpty()
     {
-        $builder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $builder = $this->createMock(FormBuilder::class);
 
-        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock(FormFactoryInterface::class);
         $factory->expects($this->any())
             ->method('createNamedBuilder')
             ->will($this->returnValue($builder));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->any())
             ->method('getBasketElements')
             ->will($this->returnValue($this->getBasketElements(null)));
@@ -84,16 +92,16 @@ class BasketResizeFormListenerTest extends TestCase
 
     public function testPreBindException()
     {
-        $this->expectException(\Symfony\Component\Form\Exception\UnexpectedTypeException::class);
+        $this->expectException(UnexpectedTypeException::class);
 
-        $builder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $builder = $this->createMock(FormBuilder::class);
 
-        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock(FormFactoryInterface::class);
         $factory->expects($this->any())
             ->method('createNamedBuilder')
             ->will($this->returnValue($builder));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->any())
             ->method('getBasketElements')
             ->will($this->returnValue($this->getBasketElements('test')));
@@ -107,7 +115,7 @@ class BasketResizeFormListenerTest extends TestCase
      */
     protected function getFormEvent($preSetData = false, $addIsCalled = true)
     {
-        $formEvent = $this->createMock('Symfony\Component\Form\FormEvent');
+        $formEvent = $this->createMock(FormEvent::class);
         $formEvent->expects($this->once())
             ->method('getForm')
             ->will($this->returnValue($this->getMockedForm($addIsCalled)));
@@ -126,7 +134,7 @@ class BasketResizeFormListenerTest extends TestCase
      */
     protected function getMockedForm($addIsCalled = true)
     {
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         if ($addIsCalled) {
             $form->expects($this->once())->method('add');
         }
@@ -140,10 +148,10 @@ class BasketResizeFormListenerTest extends TestCase
             return $elements;
         }
 
-        $productProvider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
+        $productProvider = $this->createMock(ProductProviderInterface::class);
         $productProvider->expects($this->once())->method('defineBasketElementForm');
 
-        $basketElement = $this->createMock('Sonata\Component\Basket\BasketElementInterface');
+        $basketElement = $this->createMock(BasketElementInterface::class);
         $basketElement->expects($this->exactly(2))->method('getPosition');
         $basketElement->expects($this->once())
             ->method('getProductProvider')

--- a/tests/Component/Form/Transformer/DeliveryMethodTransformerTest.php
+++ b/tests/Component/Form/Transformer/DeliveryMethodTransformerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\Component\Tests\Form\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Delivery\FreeDelivery;
+use Sonata\Component\Delivery\Pool;
 use Sonata\Component\Form\Transformer\DeliveryMethodTransformer;
 
 /**
@@ -22,7 +23,7 @@ class DeliveryMethodTransformerTest extends TestCase
 {
     public function testTransform()
     {
-        $pool = $this->createMock('Sonata\Component\Delivery\Pool');
+        $pool = $this->createMock(Pool::class);
         $transformer = new DeliveryMethodTransformer($pool);
 
         $delivery = new FreeDelivery(false);
@@ -37,7 +38,7 @@ class DeliveryMethodTransformerTest extends TestCase
         $delivery = new FreeDelivery(false);
         $delivery->setCode('deliveryCode');
 
-        $pool = $this->createMock('Sonata\Component\Delivery\Pool');
+        $pool = $this->createMock(Pool::class);
 
         $pool->expects($this->once())
             ->method('getMethod')

--- a/tests/Component/Form/Transformer/PaymentMethodTransformerTest.php
+++ b/tests/Component/Form/Transformer/PaymentMethodTransformerTest.php
@@ -14,6 +14,8 @@ namespace Sonata\Component\Tests\Form\Transformer;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Form\Transformer\PaymentMethodTransformer;
 use Sonata\Component\Payment\PassPayment;
+use Sonata\Component\Payment\Pool;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,10 +24,10 @@ class PaymentMethodTransformerTest extends TestCase
 {
     public function testTransform()
     {
-        $pool = $this->createMock('Sonata\Component\Payment\Pool');
+        $pool = $this->createMock(Pool::class);
         $transformer = new PaymentMethodTransformer($pool);
 
-        $payment = new PassPayment($this->createMock('Symfony\Component\Routing\RouterInterface'));
+        $payment = new PassPayment($this->createMock(RouterInterface::class));
         $payment->setCode('paymentCode');
 
         $this->assertEquals('paymentCode', $transformer->transform($payment));
@@ -34,10 +36,10 @@ class PaymentMethodTransformerTest extends TestCase
 
     public function testReverseTransform()
     {
-        $payment = new PassPayment($this->createMock('Symfony\Component\Routing\RouterInterface'));
+        $payment = new PassPayment($this->createMock(RouterInterface::class));
         $payment->setCode('paymentCode');
 
-        $pool = $this->createMock('Sonata\Component\Payment\Pool');
+        $pool = $this->createMock(Pool::class);
 
         $pool->expects($this->once())
             ->method('getMethod')

--- a/tests/Component/Generator/MustacheTest.php
+++ b/tests/Component/Generator/MustacheTest.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\Component\Tests\Generator;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\Component\Generator\Mustache;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class MustacheTest extends \PHPUnit\Framework\TestCase
+class MustacheTest extends TestCase
 {
     public function testRenderString()
     {

--- a/tests/Component/Generator/MysqlReferenceTest.php
+++ b/tests/Component/Generator/MysqlReferenceTest.php
@@ -11,12 +11,14 @@
 
 namespace Sonata\Component\Tests\Generator;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager as BaseEntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Generator\MysqlReference;
 use Sonata\InvoiceBundle\Entity\BaseInvoice;
 use Sonata\OrderBundle\Entity\BaseOrder;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class EntityManager extends BaseEntityManager
 {
@@ -81,7 +83,7 @@ class MysqlReferenceTest extends TestCase
             $mysqlReference->invoice($invoice);
             $this->fail('->invoice() call should raise a \RuntimeException for a new entity');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e);
+            $this->assertInstanceOf(\RuntimeException::class, $e);
         }
 
         $invoice->setId(12);
@@ -102,7 +104,7 @@ class MysqlReferenceTest extends TestCase
             $mysqlReference->order($order);
             $this->fail('->order() call should raise a \RuntimeException for a new entity');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e);
+            $this->assertInstanceOf(\RuntimeException::class, $e);
         }
 
         $order->setId(12);
@@ -122,9 +124,9 @@ class MysqlReferenceTest extends TestCase
         $metadata = new ClassMetadata('entityName');
         $metadata->table = ['name' => 'tableName'];
 
-        $connection = $this->createMock('Doctrine\DBAL\Connection');
+        $connection = $this->createMock(Connection::class);
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())
             ->method('getClassMetadata')
             ->will($this->returnValue($metadata));
@@ -133,7 +135,7 @@ class MysqlReferenceTest extends TestCase
             ->method('query')
             ->will($this->returnValue(new \PDOStatement()));
 
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->any())->method('getManager')->will($this->returnValue($em));
         $registry->expects($this->any())->method('getConnection')->will($this->returnValue($connection));
 

--- a/tests/Component/Generator/PostgresReferenceTest.php
+++ b/tests/Component/Generator/PostgresReferenceTest.php
@@ -11,9 +11,11 @@
 
 namespace Sonata\Component\Tests\Generator;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Generator\PostgresReference;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * @author Anton Zlotnikov <exp.razor@gmail.com>
@@ -25,7 +27,7 @@ class PostgresReferenceTest extends TestCase
         $invoice = new InvoiceMock();
         $postgresReference = $this->generateNewObject();
 
-        $this->expectException('\RuntimeException', 'The invoice is not persisted into the database');
+        $this->expectException(\RuntimeException::class, 'The invoice is not persisted into the database');
         $postgresReference->invoice($invoice);
 
         $invoice->setId(13);
@@ -42,7 +44,7 @@ class PostgresReferenceTest extends TestCase
         $order = new OrderMock();
         $postgresReference = $this->generateNewObject();
 
-        $this->expectException('\RuntimeException', 'The order is not persisted into the database');
+        $this->expectException(\RuntimeException::class, 'The order is not persisted into the database');
         $postgresReference->order($order);
 
         $order->setId(13);
@@ -62,9 +64,9 @@ class PostgresReferenceTest extends TestCase
         $metadata = new ClassMetadata('entityName');
         $metadata->table = ['name' => 'tableName'];
 
-        $connection = $this->createMock('Doctrine\DBAL\Connection');
+        $connection = $this->createMock(Connection::class);
 
-        $em = $this->createMock('Doctrine\ORM\EntityManager');
+        $em = $this->createMock(EntityManager::class);
         $em->expects($this->any())
             ->method('getClassMetadata')
             ->will($this->returnValue($metadata));
@@ -73,7 +75,7 @@ class PostgresReferenceTest extends TestCase
             ->method('query')
             ->will($this->returnValue(new \PDOStatement()));
 
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->any())->method('getManager')->will($this->returnValue($em));
         $registry->expects($this->any())->method('getConnection')->will($this->returnValue($connection));
 

--- a/tests/Component/Invoice/InvoiceStatusRendererTest.php
+++ b/tests/Component/Invoice/InvoiceStatusRendererTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\Component\Tests\Invoice;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Invoice\InvoiceInterface;
 use Sonata\Component\Invoice\InvoiceStatusRenderer;
 use Sonata\InvoiceBundle\Entity\BaseInvoice;
 
@@ -28,14 +29,14 @@ class InvoiceStatusRendererTest extends TestCase
         $invoice = new \DateTime();
         $this->assertFalse($renderer->handlesObject($invoice));
 
-        $invoice = $this->createMock('Sonata\Component\Invoice\InvoiceInterface');
+        $invoice = $this->createMock(InvoiceInterface::class);
         $this->assertTrue($renderer->handlesObject($invoice));
     }
 
     public function testGetClass()
     {
         $renderer = new InvoiceStatusRenderer();
-        $invoice = $this->createMock('Sonata\Component\Invoice\InvoiceInterface');
+        $invoice = $this->createMock(InvoiceInterface::class);
 
         $invoice->expects($this->once())->method('getStatus')->will($this->returnValue(array_rand(BaseInvoice::getStatusList())));
         $this->assertContains($renderer->getStatusClass($invoice, '', 'error'), ['danger', 'warning', 'success']);

--- a/tests/Component/Order/OrderStatusRendererTest.php
+++ b/tests/Component/Order/OrderStatusRendererTest.php
@@ -13,6 +13,8 @@ namespace Sonata\Component\Tests\Order;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Delivery\BaseServiceDelivery;
+use Sonata\Component\Order\OrderElementInterface;
+use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Order\OrderStatusRenderer;
 use Sonata\OrderBundle\Entity\BaseOrder;
 use Sonata\PaymentBundle\Entity\BaseTransaction;
@@ -29,10 +31,10 @@ class OrderStatusRendererTest extends TestCase
         $order = new \DateTime();
         $this->assertFalse($osRenderer->handlesObject($order));
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $this->assertTrue($osRenderer->handlesObject($order));
 
-        $order = $this->createMock('Sonata\Component\Order\OrderElementInterface');
+        $order = $this->createMock(OrderElementInterface::class);
         $this->assertTrue($osRenderer->handlesObject($order));
 
         foreach (['delivery', 'payment'] as $correctStatusType) {
@@ -46,7 +48,7 @@ class OrderStatusRendererTest extends TestCase
     {
         $osRenderer = new OrderStatusRenderer();
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->once())->method('getStatus')->will($this->returnValue(array_rand(BaseOrder::getStatusList())));
         $order->expects($this->once())->method('getDeliveryStatus')->will($this->returnValue(array_rand(BaseServiceDelivery::getStatusList())));
         $order->expects($this->once())->method('getPaymentStatus')->will($this->returnValue(array_rand(BaseTransaction::getStatusList())));
@@ -60,7 +62,7 @@ class OrderStatusRendererTest extends TestCase
     {
         $osRenderer = new OrderStatusRenderer();
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->once())->method('getStatus')->will($this->returnValue(8));
 
         $this->assertEquals('default_value', $osRenderer->getStatusClass($order, 'toubidou', 'default_value'));

--- a/tests/Component/Payment/BasePaymentTest.php
+++ b/tests/Component/Payment/BasePaymentTest.php
@@ -42,7 +42,7 @@ class BasePaymentTest extends TestCase
         $date = new \DateTime();
         $date->setTimestamp(strtotime('11/30/1981'));
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->once())->method('getReference')->will($this->returnValue('000123'));
         $order->expects($this->exactly(2))->method('getCreatedAt')->will($this->returnValue($date));
         $order->expects($this->once())->method('getId')->will($this->returnValue(2));

--- a/tests/Component/Payment/CheckPaymentTest.php
+++ b/tests/Component/Payment/CheckPaymentTest.php
@@ -12,11 +12,16 @@
 namespace Sonata\Component\Tests\Payment;
 
 use Buzz\Browser;
-use Buzz\Message\Response;
+use Buzz\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Sonata\Component\Basket\Basket;
 use Sonata\Component\Payment\CheckPayment;
+use Sonata\Component\Payment\TransactionInterface;
+use Sonata\Component\Product\ProductInterface;
 use Sonata\OrderBundle\Entity\BaseOrder;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 
 class CheckPaymentTest_Order extends BaseOrder
 {
@@ -36,15 +41,15 @@ class CheckPaymentTest extends TestCase
      */
     public function testPassPayment()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
 
         $browser = new Browser();
         $payment = new CheckPayment($router, $logger, $browser);
         $payment->setCode('free_1');
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $basket = $this->createMock(Basket::class);
+        $product = $this->createMock(ProductInterface::class);
 
         $date = new \DateTime();
         $date->setTimeStamp(strtotime('30/11/1981'));
@@ -53,7 +58,7 @@ class CheckPaymentTest extends TestCase
         $order = new CheckPaymentTest_Order();
         $order->setCreatedAt($date);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->exactly(2))->method('get')->will($this->returnCallback([$this, 'callback']));
         $transaction->expects($this->once())->method('setTransactionId');
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
@@ -64,7 +69,7 @@ class CheckPaymentTest extends TestCase
         $this->assertTrue($payment->isRequestValid($transaction));
         $this->assertTrue($payment->isCallbackValid($transaction));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $payment->handleError($transaction));
+        $this->assertInstanceOf(Response::class, $payment->handleError($transaction));
 
         $this->assertEquals($payment->getOrderReference($transaction), '0001231');
 
@@ -80,12 +85,12 @@ class CheckPaymentTest extends TestCase
         $order = new CheckPaymentTest_Order();
         $order->setCreatedAt($date);
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
         $router->expects($this->exactly(2))->method('generate')->will($this->returnValue('http://foo.bar/ok-url'));
 
         $logger = $this->createMock(LoggerInterface::class);
 
-        $client = $this->createMock('Buzz\Client\ClientInterface');
+        $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())->method('send')->will($this->returnCallback(function ($request, $response) {
             $response->setContent('ok');
         }));
@@ -95,7 +100,7 @@ class CheckPaymentTest extends TestCase
 
         $response = $payment->sendbank($order);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://foo.bar/ok-url', $response->headers->get('Location'));
         $this->assertFalse($response->isCacheable());
@@ -105,10 +110,10 @@ class CheckPaymentTest extends TestCase
     {
         $order = new CheckPaymentTest_Order();
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->exactly(2))->method('getOrder')->will($this->onConsecutiveCalls(null, $order));
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
         $browser = new Browser();
 
@@ -121,7 +126,7 @@ class CheckPaymentTest extends TestCase
 
         // second call : the order is set
         $response = $payment->sendConfirmationReceipt($transaction);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response, '::sendConfirmationReceipt return a Response object');
+        $this->assertInstanceOf(Response::class, $response, '::sendConfirmationReceipt return a Response object');
         $this->assertEquals('ok', $response->getContent(), '::getContent returns ok');
     }
 

--- a/tests/Component/Payment/DebugPaymentTest.php
+++ b/tests/Component/Payment/DebugPaymentTest.php
@@ -12,11 +12,14 @@
 namespace Sonata\Component\Tests\Payment;
 
 use Buzz\Browser;
+use Buzz\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Payment\Debug\DebugPayment;
 use Sonata\Component\Payment\TransactionInterface;
+use Sonata\Component\Payment\TransactionManagerInterface;
 use Sonata\OrderBundle\Entity\BaseOrder;
 use Sonata\PaymentBundle\Entity\BaseTransaction;
+use Symfony\Component\Routing\RouterInterface;
 
 class DebugPaymentTest_Order extends BaseOrder
 {
@@ -83,7 +86,7 @@ class DebugPaymentTest extends TestCase
      */
     protected function getTransactionManager()
     {
-        $transactionManager = $this->createMock('Sonata\Component\Payment\TransactionManagerInterface');
+        $transactionManager = $this->createMock(TransactionManagerInterface::class);
 
         $transactionManager->expects($this->once())
             ->method('create')
@@ -97,9 +100,9 @@ class DebugPaymentTest extends TestCase
      */
     protected function getDebugPayment()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
-        $client = $this->createMock('Buzz\Client\ClientInterface');
+        $client = $this->createMock(ClientInterface::class);
 
         $browser = new Browser($client);
 

--- a/tests/Component/Payment/Ogone/OgonePaymentTest.php
+++ b/tests/Component/Payment/Ogone/OgonePaymentTest.php
@@ -13,9 +13,17 @@ namespace Sonata\Component\Tests\Payment\Ogone;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Sonata\Component\Basket\Basket;
 use Sonata\Component\Currency\Currency;
+use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Payment\Ogone\OgonePayment;
+use Sonata\Component\Payment\TransactionInterface;
+use Sonata\Component\Product\ProductInterface;
 use Sonata\OrderBundle\Entity\BaseOrder;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 
 class OgonePaymentTest_Order extends BaseOrder
 {
@@ -37,8 +45,8 @@ class OgonePaymentTest extends TestCase
     public function testValidPayment()
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $templating = $this->createMock(EngineInterface::class);
+        $router = $this->createMock(RouterInterface::class);
         $router->expects($this->once())->method('generate')->will($this->returnValue('http://www.google.com'));
 
         $payment = new OgonePayment($router, $logger, $templating, true);
@@ -56,8 +64,8 @@ class OgonePaymentTest extends TestCase
             'catalog_url' => '',
         ]);
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $basket = $this->createMock(Basket::class);
+        $product = $this->createMock(ProductInterface::class);
 
         $date = new \DateTime();
         $date->setTimeStamp(strtotime('30/11/1981'));
@@ -69,7 +77,7 @@ class OgonePaymentTest extends TestCase
         $order->setReference('FR');
         $order->setLocale('es');
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('get')->will($this->returnCallback([$this, 'callback']));
         //        $transaction->expects($this->once())->method('setTransactionId');
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
@@ -82,23 +90,23 @@ class OgonePaymentTest extends TestCase
 
         $this->assertTrue($payment->isCallbackValid($transaction));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $payment->handleError($transaction));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $payment->sendConfirmationReceipt($transaction));
+        $this->assertInstanceOf(Response::class, $payment->handleError($transaction));
+        $this->assertInstanceOf(Response::class, $payment->sendConfirmationReceipt($transaction));
     }
 
     public function testValidSendbankPayment()
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock(EngineInterface::class);
         $templating->expects($this->once())->method('renderResponse')->will($this->returnCallback([$this, 'callbackValidsendbank']));
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
         $date = new \DateTime();
         $date->setTimeStamp(strtotime('30/11/1981'));
         $date->setTimezone(new \DateTimeZone('Europe/Paris'));
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
         $order = new OgonePaymentTest_Order();
         $order->setCreatedAt($date);
@@ -128,7 +136,7 @@ class OgonePaymentTest extends TestCase
 
         $response = $payment->sendbank($order);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 
     /**
@@ -137,8 +145,8 @@ class OgonePaymentTest extends TestCase
     public function testEncodeString($data, $expected)
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $templating = $this->createMock(EngineInterface::class);
+        $router = $this->createMock(RouterInterface::class);
 
         $payment = new OgonePayment($router, $logger, $templating, true);
         $payment->setCode('ogone_1');
@@ -177,7 +185,7 @@ class OgonePaymentTest extends TestCase
             throw new \RuntimeException('Invalid ogone orderId');
         }
 
-        return new \Symfony\Component\HttpFoundation\Response();
+        return new Response();
     }
 
     public static function callback($name)
@@ -222,12 +230,12 @@ class OgonePaymentTest extends TestCase
     public function testIsCallbackValid()
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $templating = $this->createMock(EngineInterface::class);
+        $router = $this->createMock(RouterInterface::class);
 
         $payment = new OgonePayment($router, $logger, $templating, true);
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->any())->method('getCreatedAt')->will($this->returnValue(new \DateTime()));
 
         $check = sha1(
@@ -236,18 +244,18 @@ class OgonePaymentTest extends TestCase
             $order->getId()
         );
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->once())->method('getOrder')->will($this->returnValue(null));
 
         $this->assertFalse($payment->isCallbackValid($transaction));
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->exactly(2))->method('getOrder')->will($this->returnValue($order));
         $transaction->expects($this->once())->method('get')->will($this->returnValue($check));
 
         $this->assertTrue($payment->isCallbackValid($transaction));
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->exactly(2))->method('getOrder')->will($this->returnValue($order));
         $transaction->expects($this->once())->method('get')->will($this->returnValue('untest'));
         $transaction->expects($this->once())->method('setState');
@@ -260,12 +268,12 @@ class OgonePaymentTest extends TestCase
     public function testGetOrderReference()
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $templating = $this->createMock(EngineInterface::class);
+        $router = $this->createMock(RouterInterface::class);
 
         $payment = new OgonePayment($router, $logger, $templating, true);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->once())->method('get')->will($this->returnValue('reference'));
 
         $this->assertEquals('reference', $payment->getOrderReference($transaction));
@@ -274,12 +282,12 @@ class OgonePaymentTest extends TestCase
     public function testApplyTransactionId()
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $templating = $this->createMock(EngineInterface::class);
+        $router = $this->createMock(RouterInterface::class);
 
         $payment = new OgonePayment($router, $logger, $templating, true);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->once())->method('setTransactionId');
 
         $payment->applyTransactionId($transaction);

--- a/tests/Component/Payment/PassPaymentTest.php
+++ b/tests/Component/Payment/PassPaymentTest.php
@@ -12,9 +12,15 @@
 namespace Sonata\Component\Tests\Payment;
 
 use Buzz\Browser;
+use Buzz\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\Basket;
 use Sonata\Component\Payment\PassPayment;
+use Sonata\Component\Payment\TransactionInterface;
+use Sonata\Component\Product\ProductInterface;
 use Sonata\OrderBundle\Entity\BaseOrder;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 
 class PassPaymentTest_Order extends BaseOrder
 {
@@ -33,19 +39,19 @@ class PassPaymentTest extends TestCase
      */
     public function testPassPayment()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
         $router->expects($this->exactly(2))->method('generate')->will($this->returnValue('http://foo.bar/ok-url'));
 
-        $client = $this->createMock('Buzz\Client\ClientInterface');
+        $client = $this->createMock(ClientInterface::class);
 
         $browser = new Browser($client);
         $payment = new PassPayment($router, $browser);
         $payment->setCode('free_1');
 
-        $basket = $this->createMock('Sonata\Component\Basket\Basket');
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $basket = $this->createMock(Basket::class);
+        $product = $this->createMock(ProductInterface::class);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->exactly(2))->method('get')->will($this->returnCallback([$this, 'callback']));
         $transaction->expects($this->once())->method('setTransactionId');
 
@@ -67,9 +73,9 @@ class PassPaymentTest extends TestCase
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
 
         $this->assertTrue($payment->isCallbackValid($transaction));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $payment->handleError($transaction));
+        $this->assertInstanceOf(Response::class, $payment->handleError($transaction));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $payment->sendConfirmationReceipt($transaction));
+        $this->assertInstanceOf(Response::class, $payment->sendConfirmationReceipt($transaction));
 
         $response = $payment->sendbank($order);
 

--- a/tests/Component/Payment/PaypalTest.php
+++ b/tests/Component/Payment/PaypalTest.php
@@ -12,8 +12,13 @@
 namespace Sonata\Component\Tests\Payment;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Payment\Paypal;
 use Sonata\Component\Payment\TransactionInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,8 +27,8 @@ class PaypalTest extends TestCase
 {
     public function testSendbank()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $router = $this->createMock(RouterInterface::class);
+        $translator = $this->createMock(TranslatorInterface::class);
 
         $paypal = new Paypal($router, $translator);
         $options = [
@@ -34,27 +39,27 @@ class PaypalTest extends TestCase
         ];
         $paypal->setOptions($options);
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->any())->method('getCreatedAt')->will($this->returnValue(new \DateTime()));
 
         $sendbank = $paypal->sendbank($order);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $sendbank);
+        $this->assertInstanceOf(Response::class, $sendbank);
 
         $this->assertContains('<input type="hidden" name="cmd" value="_s-xclick">', $sendbank->getContent());
     }
 
     public function testIsCallbackValid()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $router = $this->createMock(RouterInterface::class);
+        $translator = $this->createMock(TranslatorInterface::class);
 
         $paypal = new Paypal($router, $translator);
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->any())->method('getCreatedAt')->will($this->returnValue(new \DateTime()));
         $order->expects($this->any())->method('isValidated')->will($this->returnValue(true));
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
 
         $this->assertFalse($paypal->isCallbackValid($transaction), 'Paypal::isCallbackValid false because request invalid');
@@ -68,7 +73,7 @@ class PaypalTest extends TestCase
 
         $this->assertFalse($paypal->isCallbackValid($transaction), 'Paypal::isCallbackValid false because order not validated');
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->any())->method('getCreatedAt')->will($this->returnValue(new \DateTime()));
         $order->expects($this->any())->method('isValidated')->will($this->returnValue(false));
 
@@ -78,13 +83,13 @@ class PaypalTest extends TestCase
             $order->getId()
         );
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
         $transaction->expects($this->any())->method('get')->will($this->returnValue($check));
 
         $this->assertFalse($paypal->isCallbackValid($transaction), 'Paypal::isCallbackValid false because payment_status invalid.');
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
 
         $transaction->expects($this->any())->method('get')->will($this->returnCallback(function () use ($check) {
@@ -99,7 +104,7 @@ class PaypalTest extends TestCase
 
         $this->assertTrue($paypal->isCallbackValid($transaction), 'Paypal::isCallbackValid true because payment_status pending.');
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
 
         $transaction->expects($this->any())->method('get')->will($this->returnCallback(function () use ($check) {
@@ -114,7 +119,7 @@ class PaypalTest extends TestCase
 
         $this->assertTrue($paypal->isCallbackValid($transaction), 'Paypal::isCallbackValid true because payment_status completed.');
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
 
         $transaction->expects($this->any())->method('get')->will($this->returnCallback(function () use ($check) {
@@ -132,40 +137,40 @@ class PaypalTest extends TestCase
 
     public function testHandleError()
     {
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $router = $this->createMock(RouterInterface::class);
+        $translator = $this->createMock(TranslatorInterface::class);
 
         $paypal = new Paypal($router, $translator);
-        $paypal->setLogger($this->createMock('Psr\Log\LoggerInterface'));
+        $paypal->setLogger($this->createMock(LoggerInterface::class));
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->any())->method('getCreatedAt')->will($this->returnValue(new \DateTime()));
         $order->expects($this->any())->method('isValidated')->will($this->returnValue(true));
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
 
         $paypal->handleError($transaction);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
         $transaction->expects($this->any())->method('getStatusCode')->will($this->returnValue(TransactionInterface::STATUS_ORDER_UNKNOWN));
 
         $paypal->handleError($transaction);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
         $transaction->expects($this->any())->method('getStatusCode')->will($this->returnValue(TransactionInterface::STATUS_ERROR_VALIDATION));
 
         $paypal->handleError($transaction);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
         $transaction->expects($this->any())->method('getStatusCode')->will($this->returnValue(TransactionInterface::STATUS_CANCELLED));
 
         $paypal->handleError($transaction);
 
-        $transaction = $this->createMock('Sonata\Component\Payment\TransactionInterface');
+        $transaction = $this->createMock(TransactionInterface::class);
         $transaction->expects($this->any())->method('getOrder')->will($this->returnValue($order));
         $transaction->expects($this->any())->method('getStatusCode')->will($this->returnValue(TransactionInterface::STATUS_PENDING));
         $transaction->expects($this->any())->method('get')->will($this->returnValue(Paypal::PENDING_REASON_ADDRESS));

--- a/tests/Component/Payment/PoolTest.php
+++ b/tests/Component/Payment/PoolTest.php
@@ -14,6 +14,7 @@ namespace Sonata\Component\Tests\Payment;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Payment\PassPayment;
 use Sonata\Component\Payment\Pool;
+use Symfony\Component\Routing\RouterInterface;
 
 class PoolTest extends TestCase
 {
@@ -21,7 +22,7 @@ class PoolTest extends TestCase
     {
         $pool = new Pool();
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
         $payment = new PassPayment($router);
         $payment->setCode('pass_1');
@@ -39,7 +40,7 @@ class PoolTest extends TestCase
         $pool->addMethod($payment);
 
         $this->assertEquals(2, count($pool->getMethods()), 'Pool return 2 elements');
-        $this->assertInstanceOf('Sonata\\Component\\Payment\\PassPayment', $pool->getMethod('pass_2'), 'Pool return an FreeDelivery Instance');
+        $this->assertInstanceOf(PassPayment::class, $pool->getMethod('pass_2'), 'Pool return an FreeDelivery Instance');
     }
 
     public function testAddMethodError()
@@ -49,7 +50,7 @@ class PoolTest extends TestCase
 
         $pool = new Pool();
 
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
         $payment = new PassPayment($router);
 

--- a/tests/Component/Payment/Scellius/NodeScelliusTransactionGeneratorTest.php
+++ b/tests/Component/Payment/Scellius/NodeScelliusTransactionGeneratorTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\Component\Tests\Payment\Scellius;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Payment\Scellius\NodeScelliusTransactionGenerator;
 
 class NodeScelliusTransactionGeneratorTest extends TestCase
 {
     public function testGenerator()
     {
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->never())->method('getReference');
 
         $generator = new NodeScelliusTransactionGenerator();

--- a/tests/Component/Payment/Scellius/OrderScelliusTransactionGeneratorTest.php
+++ b/tests/Component/Payment/Scellius/OrderScelliusTransactionGeneratorTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\Component\Tests\Payment\Scellius;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Payment\Scellius\OrderScelliusTransactionGenerator;
 
 class OrderScelliusTransactionGeneratorTest extends TestCase
 {
     public function testGenerator()
     {
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->any())->method('getReference')->will($this->returnValue('120112000012'));
 
         $generator = new OrderScelliusTransactionGenerator();
@@ -29,7 +30,7 @@ class OrderScelliusTransactionGeneratorTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->any())->method('getReference')->will($this->returnValue('12'));
 
         $generator = new OrderScelliusTransactionGenerator();

--- a/tests/Component/Payment/SelectorTest.php
+++ b/tests/Component/Payment/SelectorTest.php
@@ -11,7 +11,11 @@
 
 namespace Sonata\Component\Tests\Payment;
 
+use PHPUnit\Framework\TestCase;
+use Sonata\Component\Payment\PaymentNotFoundException;
+use Sonata\Component\Payment\Pool as PaymentPool;
 use Sonata\Component\Payment\Selector;
+use Sonata\Component\Product\Pool as ProductPool;
 use Sonata\CustomerBundle\Entity\BaseAddress;
 
 class Address extends BaseAddress
@@ -25,18 +29,18 @@ class Address extends BaseAddress
 /**
  * @author Xavier Coureau <xcoureau@ekino.com>
  */
-class SelectorTest extends \PHPUnit\Framework\TestCase
+class SelectorTest extends TestCase
 {
     public function testGetPaymentPool()
     {
         $paymentPoolMethods = ['first method', 'second method'];
 
-        $paymentPool = $this->getMockBuilder('Sonata\Component\Payment\Pool')->getMock();
+        $paymentPool = $this->getMockBuilder(PaymentPool::class)->getMock();
         $paymentPool->expects($this->any())
             ->method('getMethods')
             ->will($this->returnValue($paymentPoolMethods));
 
-        $productPool = $this->getMockBuilder('Sonata\Component\Product\Pool')->getMock();
+        $productPool = $this->getMockBuilder(ProductPool::class)->getMock();
 
         $selector = new Selector($paymentPool, $productPool);
         $this->assertFalse($selector->getAvailableMethods());
@@ -45,17 +49,17 @@ class SelectorTest extends \PHPUnit\Framework\TestCase
 
     public function testGetPaymentException()
     {
-        $this->expectException(\Sonata\Component\Payment\PaymentNotFoundException::class);
+        $this->expectException(PaymentNotFoundException::class);
         $this->expectExceptionMessage('Payment method with code \'not_existing\' was not found');
 
         $paymentPoolMethods = ['first method', 'second method'];
 
-        $paymentPool = $this->getMockBuilder('Sonata\Component\Payment\Pool')->getMock();
+        $paymentPool = $this->getMockBuilder(PaymentPool::class)->getMock();
         $paymentPool->expects($this->any())
             ->method('getMethods')
             ->will($this->returnValue($paymentPoolMethods));
 
-        $productPool = $this->getMockBuilder('Sonata\Component\Product\Pool')->getMock();
+        $productPool = $this->getMockBuilder(ProductPool::class)->getMock();
 
         $selector = new Selector($paymentPool, $productPool);
 

--- a/tests/Component/Product/BaseProductServiceTest.php
+++ b/tests/Component/Product/BaseProductServiceTest.php
@@ -12,13 +12,21 @@
 namespace Sonata\Component\Tests\Product;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use JMS\Serializer\SerializerInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Entity\BaseCategory;
 use Sonata\ClassificationBundle\Entity\BaseCollection;
 use Sonata\Component\Basket\BasketElement;
+use Sonata\Component\Basket\BasketElementManagerInterface;
 use Sonata\Component\Currency\CurrencyPriceCalculator;
+use Sonata\Component\Order\OrderElementInterface;
 use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Product\ProductDefinition;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
 use Sonata\Component\Tests\Basket\ProductProviderTest;
 use Sonata\OrderBundle\Entity\BaseOrderElement;
 use Sonata\ProductBundle\Entity\BaseDelivery;
@@ -132,14 +140,14 @@ class BaseProductServiceTest extends TestCase
      */
     public function getBaseProvider()
     {
-        $serializer = $this->createMock('JMS\Serializer\SerializerInterface');
+        $serializer = $this->createMock(SerializerInterface::class);
         $serializer->expects($this->any())->method('serialize')->will($this->returnValue('{}'));
 
         $provider = new BaseProductServiceTest_ProductProvider($serializer);
 
-        $basketElementManager = $this->createMock('\Sonata\Component\Basket\BasketElementManagerInterface');
+        $basketElementManager = $this->createMock(BasketElementManagerInterface::class);
         $basketElementManager->expects($this->any())->method('getClass')->will(
-            $this->returnValue('\Sonata\Component\Tests\Product\BaseOrderElementTest_ProductProvider')
+            $this->returnValue(BaseOrderElementTest_ProductProvider::class)
         );
         $provider->setBasketElementManager($basketElementManager);
 
@@ -175,16 +183,16 @@ class BaseProductServiceTest extends TestCase
 
     public function testOrderElement()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
         $product->expects($this->any())->method('getId')->will($this->returnValue(42));
         $product->expects($this->any())->method('getName')->will($this->returnValue('Product name'));
         $product->expects($this->any())->method('getPrice')->will($this->returnValue(9.99));
         $product->expects($this->any())->method('getOptions')->will($this->returnValue(['foo' => 'bar']));
         $product->expects($this->any())->method('getDescription')->will($this->returnValue('product description'));
 
-        $productProvider = new ProductProviderTest($this->createMock('JMS\Serializer\SerializerInterface'));
+        $productProvider = new ProductProviderTest($this->createMock(SerializerInterface::class));
         $productProvider->setCurrencyPriceCalculator(new CurrencyPriceCalculator());
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
 
         $productDefinition = new ProductDefinition($productProvider, $productManager);
 
@@ -196,7 +204,7 @@ class BaseProductServiceTest extends TestCase
 
         $orderElement = $provider->createOrderElement($basketElement);
 
-        $this->assertInstanceOf('Sonata\Component\Order\OrderElementInterface', $orderElement);
+        $this->assertInstanceOf(OrderElementInterface::class, $orderElement);
         $this->assertEquals(OrderInterface::STATUS_PENDING, $orderElement->getStatus());
         $this->assertEquals('Product name', $orderElement->getDesignation());
         $this->assertEquals(1, $orderElement->getQuantity());
@@ -288,15 +296,15 @@ class BaseProductServiceTest extends TestCase
     {
         $provider = $this->getBaseProvider();
 
-        $repository = $this->createMock('Doctrine\ORM\EntityRepository');
+        $repository = $this->createMock(EntityRepository::class);
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $productCategoryManager = new ProductCategoryManager('Sonata\Component\Tests\Product\ProductCategory', $registry);
+        $productCategoryManager = new ProductCategoryManager(ProductCategory::class, $registry);
         $provider->setProductCategoryManager($productCategoryManager);
 
         // create product
@@ -350,15 +358,15 @@ class BaseProductServiceTest extends TestCase
     {
         $provider = $this->getBaseProvider();
 
-        $repository = $this->createMock('Doctrine\ORM\EntityRepository');
+        $repository = $this->createMock(EntityRepository::class);
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $productCollectionManager = new ProductCollectionManager('Sonata\Component\Tests\Product\ProductCollection', $registry);
+        $productCollectionManager = new ProductCollectionManager(ProductCollection::class, $registry);
         $provider->setProductCollectionManager($productCollectionManager);
 
         $product = new Product();

--- a/tests/Component/Product/ProductFinderTest.php
+++ b/tests/Component/Product/ProductFinderTest.php
@@ -13,6 +13,8 @@ namespace Sonata\Component\Tests\Product;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Product\ProductFinder;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -21,14 +23,14 @@ class ProductFinderTest extends TestCase
 {
     public function testGetCrossSellingSimilarProducts()
     {
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())
             ->method('findInSameCollections')
             ->will($this->returnValue([]));
 
         $finder = new ProductFinder($productManager);
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
         $this->assertEquals([], $finder->getCrossSellingSimilarProducts($product));
     }
 }

--- a/tests/Component/Product/ProductPoolTest.php
+++ b/tests/Component/Product/ProductPoolTest.php
@@ -14,17 +14,20 @@ namespace Sonata\Component\Tests\Product;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Product\Pool;
 use Sonata\Component\Product\ProductDefinition;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
+use Sonata\Component\Product\ProductProviderInterface;
 
 class ProductPoolTest extends TestCase
 {
     public function testPool()
     {
-        $productProvider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
-        $productManager1 = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
-        $productManager2 = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productProvider = $this->createMock(ProductProviderInterface::class);
+        $productManager1 = $this->createMock(ProductManagerInterface::class);
+        $productManager2 = $this->createMock(ProductManagerInterface::class);
 
         // we need products from different objects to test ProductPool
-        $product1 = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product1 = $this->createMock(ProductInterface::class);
         $product2 = new Product();
 
         $productManager1->expects($this->any())

--- a/tests/Component/Subscriber/ORMInheritanceSubscriberTest.php
+++ b/tests/Component/Subscriber/ORMInheritanceSubscriberTest.php
@@ -11,6 +11,9 @@
 
 namespace Sonata\Component\Tests\Subscriber;
 
+use Application\Sonata\ProductBundle\Entity\Product;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Subscriber\ORMInheritanceSubscriber;
 
@@ -21,7 +24,7 @@ class ORMInheritanceSubscriberTest extends TestCase
 {
     public function testGetSubscribedEvents()
     {
-        $subscriber = new ORMInheritanceSubscriber([], 'Application\Sonata\ProductBundle\Entity\Product');
+        $subscriber = new ORMInheritanceSubscriber([], Product::class);
         $this->assertCount(1, $subscriber->getSubscribedEvents());
     }
 
@@ -30,8 +33,8 @@ class ORMInheritanceSubscriberTest extends TestCase
         $fakedMetadata = new \stdClass();
         $fakedMetadata->name = 'IncorrectValue';
 
-        $subscriber = new ORMInheritanceSubscriber([], 'Application\Sonata\ProductBundle\Entity\Product');
-        $metadata = $this->createMock('Doctrine\ORM\Event\LoadClassMetadataEventArgs');
+        $subscriber = new ORMInheritanceSubscriber([], Product::class);
+        $metadata = $this->createMock(LoadClassMetadataEventArgs::class);
         $metadata->expects($this->any())
             ->method('getClassMetadata')
             ->will($this->returnValue($fakedMetadata));
@@ -39,9 +42,9 @@ class ORMInheritanceSubscriberTest extends TestCase
         $this->assertNull($subscriber->loadClassMetadata($metadata));
         unset($fakedMetadata);
 
-        $classMetadata = $this->createMock('Doctrine\ORM\Mapping\ClassMetadata');
-        $classMetadata->name = 'Application\Sonata\ProductBundle\Entity\Product';
-        $metadata = $this->createMock('Doctrine\ORM\Event\LoadClassMetadataEventArgs');
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata->name = Product::class;
+        $metadata = $this->createMock(LoadClassMetadataEventArgs::class);
         $metadata->expects($this->any())
             ->method('getClassMetadata')
             ->will($this->returnValue($classMetadata));

--- a/tests/Component/Transformer/BasketTransformerTest.php
+++ b/tests/Component/Transformer/BasketTransformerTest.php
@@ -15,8 +15,16 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Sonata\Component\Basket\Basket;
 use Sonata\Component\Currency\Currency;
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Delivery\ServiceDeliveryInterface;
+use Sonata\Component\Order\OrderInterface;
+use Sonata\Component\Order\OrderManagerInterface;
+use Sonata\Component\Payment\PaymentInterface;
+use Sonata\Component\Product\Pool;
 use Sonata\Component\Transformer\BasketTransformer;
 use Sonata\OrderBundle\Entity\BaseOrder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class BasketTransformerTest_Order extends BaseOrder
 {
@@ -37,13 +45,13 @@ class BasketTransformerTest extends TestCase
     public function getBasketTransform()
     {
         $order = new BasketTransformerTest_Order();
-        $orderManager = $this->createMock('Sonata\Component\Order\OrderManagerInterface');
+        $orderManager = $this->createMock(OrderManagerInterface::class);
         $orderManager->expects($this->any())->method('create')->will($this->returnValue($order));
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(Pool::class);
 
         $logger = $this->createMock(LoggerInterface::class);
-        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $basketTransform = new BasketTransformer($orderManager, $productPool, $eventDispatcher, $logger);
 
         return $basketTransform;
@@ -69,7 +77,7 @@ class BasketTransformerTest extends TestCase
         $this->expectExceptionMessage('Invalid billing address');
 
         $basket = new Basket();
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
         $basket->setCustomer($customer);
 
@@ -86,8 +94,8 @@ class BasketTransformerTest extends TestCase
         $this->expectExceptionMessage('Invalid payment method');
 
         $basket = new Basket();
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $billingAddress = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $billingAddress = $this->createMock(AddressInterface::class);
 
         $currency = new Currency();
         $currency->setLabel('EUR');
@@ -105,9 +113,9 @@ class BasketTransformerTest extends TestCase
         $this->expectExceptionMessage('Invalid delivery method');
 
         $basket = new Basket();
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $billingAddress = $this->createMock('Sonata\Component\Customer\AddressInterface');
-        $paymentMethod = $this->createMock('Sonata\Component\Payment\PaymentInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $billingAddress = $this->createMock(AddressInterface::class);
+        $paymentMethod = $this->createMock(PaymentInterface::class);
 
         $basket->setCustomer($customer);
         $basket->setBillingAddress($billingAddress);
@@ -126,10 +134,10 @@ class BasketTransformerTest extends TestCase
         $this->expectExceptionMessage('Invalid delivery address');
 
         $basket = new Basket();
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $billingAddress = $this->createMock('Sonata\Component\Customer\AddressInterface');
-        $paymentMethod = $this->createMock('Sonata\Component\Payment\PaymentInterface');
-        $deliveryMethod = $this->createMock('Sonata\Component\Delivery\ServiceDeliveryInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $billingAddress = $this->createMock(AddressInterface::class);
+        $paymentMethod = $this->createMock(PaymentInterface::class);
+        $deliveryMethod = $this->createMock(ServiceDeliveryInterface::class);
         $deliveryMethod->expects($this->once())->method('isAddressRequired')->will($this->returnValue(true));
 
         $basket->setCustomer($customer);
@@ -147,12 +155,12 @@ class BasketTransformerTest extends TestCase
     public function testOrder()
     {
         $basket = new Basket();
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $billingAddress = $this->createMock('Sonata\Component\Customer\AddressInterface');
-        $deliveryMethod = $this->createMock('Sonata\Component\Delivery\ServiceDeliveryInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $billingAddress = $this->createMock(AddressInterface::class);
+        $deliveryMethod = $this->createMock(ServiceDeliveryInterface::class);
         $deliveryMethod->expects($this->exactly(2))->method('isAddressRequired')->will($this->returnValue(true));
-        $deliveryAddress = $this->createMock('Sonata\Component\Customer\AddressInterface');
-        $paymentMethod = $this->createMock('Sonata\Component\Payment\PaymentInterface');
+        $deliveryAddress = $this->createMock(AddressInterface::class);
+        $paymentMethod = $this->createMock(PaymentInterface::class);
 
         $basket->setCustomer($customer);
         $basket->setBillingAddress($billingAddress);
@@ -166,6 +174,6 @@ class BasketTransformerTest extends TestCase
 
         $order = $this->getBasketTransform()->transformIntoOrder($basket);
 
-        $this->assertInstanceOf('Sonata\Component\Order\OrderInterface', $order, '::transformIntoOrder() returns an OrderInstance object');
+        $this->assertInstanceOf(OrderInterface::class, $order, '::transformIntoOrder() returns an OrderInstance object');
     }
 }

--- a/tests/Component/Transformer/InvoiceTransformerTest.php
+++ b/tests/Component/Transformer/InvoiceTransformerTest.php
@@ -13,23 +13,30 @@ namespace Sonata\Component\Tests\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Currency\Currency;
+use Sonata\Component\Customer\CustomerInterface;
 use Sonata\Component\Delivery\Pool as DeliveryPool;
+use Sonata\Component\Invoice\InvoiceElementInterface;
+use Sonata\Component\Invoice\InvoiceElementManagerInterface;
+use Sonata\Component\Invoice\InvoiceInterface;
+use Sonata\Component\Order\OrderElementInterface;
+use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Transformer\InvoiceTransformer;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class InvoiceTransformerTest extends TestCase
 {
     public function testTransformFromOrder()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $orderElement = $this->createMock('Sonata\Component\Order\OrderElementInterface');
+        $orderElement = $this->createMock(OrderElementInterface::class);
         $orderElement->expects($this->once())->method('getDescription');
         $orderElement->expects($this->once())->method('getDesignation');
         $orderElement->expects($this->once())->method('getPrice')->will($this->returnValue(42));
         $orderElement->expects($this->once())->method('getQuantity')->will($this->returnValue(3));
         $orderElement->expects($this->once())->method('getVatRate');
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->once())->method('getOrderElements')->will($this->returnValue([$orderElement]));
         $order->expects($this->once())->method('getCustomer')->will($this->returnValue($customer));
 
@@ -52,16 +59,16 @@ class InvoiceTransformerTest extends TestCase
         $order->expects($this->once())->method('getTotalExcl');
         $order->expects($this->once())->method('getTotalInc');
 
-        $invoice = $this->createMock('Sonata\Component\Invoice\InvoiceInterface');
+        $invoice = $this->createMock(InvoiceInterface::class);
 
-        $invoiceElement = $this->createMock('Sonata\Component\Invoice\InvoiceElementInterface');
+        $invoiceElement = $this->createMock(InvoiceElementInterface::class);
 
-        $invoiceElementManager = $this->createMock('Sonata\Component\Invoice\InvoiceElementManagerInterface');
+        $invoiceElementManager = $this->createMock(InvoiceElementManagerInterface::class);
         $invoiceElementManager->expects($this->once())->method('create')->will($this->returnValue($invoiceElement));
 
         $deliveryPool = new DeliveryPool();
 
-        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $invoiceTransformer = new InvoiceTransformer($invoiceElementManager, $deliveryPool, $eventDispatcher);
         $invoiceTransformer->transformFromOrder($order, $invoice);

--- a/tests/Component/Transformer/OrderTransformerTest.php
+++ b/tests/Component/Transformer/OrderTransformerTest.php
@@ -13,38 +13,47 @@ namespace Sonata\Component\Tests\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BasketElement;
+use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Currency\Currency;
+use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Order\OrderElementInterface;
+use Sonata\Component\Order\OrderInterface;
+use Sonata\Component\Product\Pool;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
+use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\Component\Transformer\OrderTransformer;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class OrderTransformerTest extends TestCase
 {
     public function testBasket()
     {
-        $provider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
+        $provider = $this->createMock(ProductProviderInterface::class);
         $provider->expects($this->once())->method('basketAddProduct')->will($this->returnValue(true));
         $provider->expects($this->once())->method('createBasketElement')->will($this->returnValue($basketElement = new BasketElement()));
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $manager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $manager = $this->createMock(ProductManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
 
-        $pool = $this->createMock('Sonata\Component\Product\Pool');
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
         $pool->expects($this->once())->method('getManager')->will($this->returnValue($manager));
 
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $basket = $this->createMock(BasketInterface::class);
         $basket->expects($this->once())->method('reset');
         $basket->expects($this->once())->method('buildPrices');
 
-        $orderElement = $this->createMock('Sonata\Component\Order\OrderElementInterface');
+        $orderElement = $this->createMock(OrderElementInterface::class);
         $orderElement->expects($this->exactly(2))->method('getProductType');
         $orderElement->expects($this->exactly(1))->method('getProductId')->will($this->returnValue(2));
         $orderElement->expects($this->exactly(1))->method('getOptions')->will($this->returnValue([]));
         $orderElement->expects($this->exactly(1))->method('getQuantity')->will($this->returnValue(2));
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->once())->method('getOrderElements')->will($this->returnValue([$orderElement]));
         $order->expects($this->once())->method('getCustomer')->will($this->returnValue($customer));
 
@@ -52,7 +61,7 @@ class OrderTransformerTest extends TestCase
         $currency->setLabel('EUR');
         $order->expects($this->once())->method('getCurrency')->will($this->returnValue($currency));
 
-        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $transformer = new OrderTransformer($pool, $eventDispatcher);
         $transformer->transformIntoBasket($order, $basket);
 

--- a/tests/Component/Transformer/PoolTest.php
+++ b/tests/Component/Transformer/PoolTest.php
@@ -12,9 +12,12 @@
 namespace Sonata\Component\Tests\Transformer;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Order\OrderManagerInterface;
+use Sonata\Component\Product\Pool;
 use Sonata\Component\Transformer\BasketTransformer;
 use Sonata\Component\Transformer\OrderTransformer;
 use Sonata\Component\Transformer\Pool as TransformerPool;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class PoolTest extends TestCase
 {
@@ -23,20 +26,20 @@ class PoolTest extends TestCase
         $pool = new TransformerPool();
 
         $transformer = new BasketTransformer(
-            $this->createMock('Sonata\Component\Order\OrderManagerInterface'),
-            $this->createMock('Sonata\Component\Product\Pool'),
-            $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+            $this->createMock(OrderManagerInterface::class),
+            $this->createMock(Pool::class),
+            $this->createMock(EventDispatcherInterface::class)
         );
 
         $pool->addTransformer('basket', $transformer);
 
         $transformer = new OrderTransformer(
-            $this->createMock('Sonata\Component\Product\Pool'),
-            $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+            $this->createMock(Pool::class),
+            $this->createMock(EventDispatcherInterface::class)
         );
         $pool->addTransformer('order', $transformer);
 
         $this->assertEquals(2, count($pool->getTransformers()), 'Pool return 2 elements');
-        $this->assertInstanceOf('Sonata\\Component\\Transformer\\BasketTransformer', $pool->getTransformer('basket'), 'Pool return an FreeDelivery Instance');
+        $this->assertInstanceOf(BasketTransformer::class, $pool->getTransformer('basket'), 'Pool return an FreeDelivery Instance');
     }
 }

--- a/tests/CustomerBundle/Block/RecentCustomersBlockServiceTest.php
+++ b/tests/CustomerBundle/Block/RecentCustomersBlockServiceTest.php
@@ -12,7 +12,9 @@
 namespace Sonata\CustomerBundle\Tests\Block;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Customer\CustomerManagerInterface;
 use Sonata\CustomerBundle\Block\RecentCustomersBlockService;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 
 /**
  * @author Xavier Coureau <xcoureau@ekino.com>
@@ -21,8 +23,8 @@ class RecentCustomersBlockServiceTest extends TestCase
 {
     public function testGetName()
     {
-        $engineInterfaceMock = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $customerManagerInterfaceMock = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $engineInterfaceMock = $this->createMock(EngineInterface::class);
+        $customerManagerInterfaceMock = $this->createMock(CustomerManagerInterface::class);
         $block = new RecentCustomersBlockService('test', $engineInterfaceMock, $customerManagerInterfaceMock);
 
         $this->assertEquals('Recent Customers', $block->getName());

--- a/tests/CustomerBundle/Controller/Api/AddressControllerTest.php
+++ b/tests/CustomerBundle/Controller/Api/AddressControllerTest.php
@@ -11,9 +11,17 @@
 
 namespace Sonata\CustomerBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Customer\AddressManagerInterface;
 use Sonata\CustomerBundle\Controller\Api\AddressController;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -22,10 +30,10 @@ class AddressControllerTest extends TestCase
 {
     public function testGetAddressesAction()
     {
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -34,14 +42,14 @@ class AddressControllerTest extends TestCase
 
     public function testGetAddressAction()
     {
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
         $this->assertEquals($address, $this->createAddressController($address)->getAddressAction(1));
     }
 
     public function testGetAddressActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Address (42) not found');
 
         $this->createAddressController()->getAddressAction(42);
@@ -49,89 +57,89 @@ class AddressControllerTest extends TestCase
 
     public function testPostAddressAction()
     {
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->once())->method('save')->will($this->returnValue($address));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($address));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createAddressController(null, $addressManager, $formFactory)->postAddressAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostCustomerInvalidAction()
     {
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->never())->method('save')->will($this->returnValue($address));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createAddressController(null, $addressManager, $formFactory)->postAddressAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutAddressAction()
     {
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
         $addressManager->expects($this->once())->method('save')->will($this->returnValue($address));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($address));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createAddressController($address, $addressManager, $formFactory)->putAddressAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutAddressInvalidAction()
     {
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
         $addressManager->expects($this->never())->method('save')->will($this->returnValue($address));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createAddressController($address, $addressManager, $formFactory)->putAddressAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteAddressAction()
     {
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
         $addressManager->expects($this->once())->method('delete');
 
@@ -142,9 +150,9 @@ class AddressControllerTest extends TestCase
 
     public function testDeleteAddressInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue(null));
         $addressManager->expects($this->never())->method('delete');
 
@@ -163,7 +171,7 @@ class AddressControllerTest extends TestCase
     public function createAddressController($address = null, $addressManager = null, $formFactory = null)
     {
         if (null === $addressManager) {
-            $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+            $addressManager = $this->createMock(AddressManagerInterface::class);
 
             if ($address) {
                 $addressManager->expects($this->once())->method('findOneBy')->will($this->returnValue($address));
@@ -171,7 +179,7 @@ class AddressControllerTest extends TestCase
         }
 
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new AddressController($addressManager, $formFactory);

--- a/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
+++ b/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
@@ -11,9 +11,21 @@
 
 namespace Sonata\CustomerBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Customer\AddressManagerInterface;
+use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Customer\CustomerManagerInterface;
+use Sonata\Component\Order\OrderInterface;
+use Sonata\Component\Order\OrderManagerInterface;
 use Sonata\CustomerBundle\Controller\Api\CustomerController;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,10 +34,10 @@ class CustomerControllerTest extends TestCase
 {
     public function testGetCustomersAction()
     {
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -35,13 +47,13 @@ class CustomerControllerTest extends TestCase
 
     public function testGetCustomerAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $this->assertEquals($customer, $this->createCustomerController($customer)->getCustomerAction(1));
     }
 
     public function testGetCustomerActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Customer (42) not found');
 
         $this->createCustomerController()->getCustomerAction(42);
@@ -49,8 +61,8 @@ class CustomerControllerTest extends TestCase
 
     public function testGetCustomerOrdersAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $order = $this->createMock(OrderInterface::class);
 
         $this->assertEquals(
             [$order],
@@ -60,8 +72,8 @@ class CustomerControllerTest extends TestCase
 
     public function testGetCustomerAddressesAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $address = $this->createMock(AddressInterface::class);
         $customer->expects($this->once())->method('getAddresses')->will($this->returnValue([$address]));
 
         $this->assertEquals([$address], $this->createCustomerController($customer)
@@ -70,138 +82,138 @@ class CustomerControllerTest extends TestCase
 
     public function testPostCustomerAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('save')->will($this->returnValue($customer));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($customer));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCustomerController(null, $customerManager, null, $formFactory)
             ->postCustomerAction(new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostCustomerInvalidAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->never())->method('save')->will($this->returnValue($customer));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCustomerController(null, $customerManager, null, $formFactory)
             ->postCustomerAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPostCustomerAddressAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $customer = $this->createMock(CustomerInterface::class);
+        $address = $this->createMock(AddressInterface::class);
         $address->expects($this->once())->method('setCustomer');
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
 
-        $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+        $addressManager = $this->createMock(AddressManagerInterface::class);
         $addressManager->expects($this->once())->method('save')->will($this->returnValue($address));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($address));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCustomerController($customer, $customerManager, $addressManager, $formFactory)
             ->postCustomerAddressAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostCustomerAddressInvalidAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->never())->method('save')->will($this->returnValue($customer));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCustomerController(null, $customerManager, null, $formFactory)
             ->postCustomerAction(new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutCustomerAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
         $customerManager->expects($this->once())->method('save')->will($this->returnValue($customer));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($customer));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCustomerController($customer, $customerManager, null, $formFactory)
             ->putCustomerAction(1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutCustomerInvalidAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
         $customerManager->expects($this->never())->method('save')->will($this->returnValue($customer));
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createCustomerController($customer, $customerManager, null, $formFactory)
             ->putCustomerAction(1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteCustomerAction()
     {
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
         $customerManager->expects($this->once())->method('delete');
 
@@ -212,9 +224,9 @@ class CustomerControllerTest extends TestCase
 
     public function testDeleteCustomerInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+        $customerManager = $this->createMock(CustomerManagerInterface::class);
         $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue(null));
         $customerManager->expects($this->never())->method('delete');
 
@@ -234,22 +246,22 @@ class CustomerControllerTest extends TestCase
     public function createCustomerController($customer = null, $customerManager = null, $addressManager = null, $formFactory = null, $order = null, $orderManager = null)
     {
         if (null === $customerManager) {
-            $customerManager = $this->createMock('Sonata\Component\Customer\CustomerManagerInterface');
+            $customerManager = $this->createMock(CustomerManagerInterface::class);
         }
         if (null !== $customer) {
             $customerManager->expects($this->once())->method('findOneBy')->will($this->returnValue($customer));
         }
         if (null === $orderManager) {
-            $orderManager = $this->createMock('Sonata\Component\Order\OrderManagerInterface');
+            $orderManager = $this->createMock(OrderManagerInterface::class);
         }
         if (null === $addressManager) {
-            $addressManager = $this->createMock('Sonata\Component\Customer\AddressManagerInterface');
+            $addressManager = $this->createMock(AddressManagerInterface::class);
         }
         if (null !== $order) {
             $orderManager->expects($this->once())->method('findBy')->will($this->returnValue([$order]));
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new CustomerController($customerManager, $orderManager, $addressManager, $formFactory);

--- a/tests/CustomerBundle/Entity/AddressManagerTest.php
+++ b/tests/CustomerBundle/Entity/AddressManagerTest.php
@@ -11,9 +11,14 @@
 
 namespace Sonata\CustomerBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Customer\CustomerInterface;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\CustomerBundle\Entity\AddressManager;
+use Sonata\CustomerBundle\Entity\BaseAddress;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,7 +27,7 @@ class AddressManagerTest extends TestCase
 {
     public function testSetCurrent()
     {
-        $currentAddress = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $currentAddress = $this->createMock(AddressInterface::class);
         $currentAddress->expects($this->once())
             ->method('getCurrent')
             ->will($this->returnValue(true));
@@ -30,48 +35,48 @@ class AddressManagerTest extends TestCase
 
         $custAddresses = [$currentAddress];
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->once())->method('getAddressesByType')->will($this->returnValue($custAddresses));
 
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
         $address->expects($this->once())->method('setCurrent');
         $address->expects($this->once())->method('getCustomer')->will($this->returnValue($customer));
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('persist');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $addressManager = new AddressManager('Sonata\Component\Customer\AddressInterface', $registry);
+        $addressManager = new AddressManager(AddressInterface::class, $registry);
 
         $addressManager->setCurrent($address);
     }
 
     public function testDelete()
     {
-        $existingAddress = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $existingAddress = $this->createMock(AddressInterface::class);
         $existingAddress->expects($this->once())->method('setCurrent');
         $existingAddress->expects($this->once())->method('getId')->will($this->returnValue(42));
 
-        $custAddresses = [$existingAddress, $this->createMock('Sonata\Component\Customer\AddressInterface')];
+        $custAddresses = [$existingAddress, $this->createMock(AddressInterface::class)];
 
-        $customer = $this->createMock('Sonata\Component\Customer\CustomerInterface');
+        $customer = $this->createMock(CustomerInterface::class);
         $customer->expects($this->once())
             ->method('getAddressesByType')
             ->will($this->returnValue($custAddresses));
 
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
         $address->expects($this->once())->method('getCurrent')->will($this->returnValue(true));
         $address->expects($this->once())->method('getCustomer')->will($this->returnValue($customer));
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->exactly(1))->method('persist');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $addressManager = new AddressManager('Sonata\Component\Customer\AddressInterface', $registry);
+        $addressManager = new AddressManager(AddressInterface::class, $registry);
 
         $addressManager->delete($address);
     }
@@ -136,9 +141,9 @@ class AddressManagerTest extends TestCase
             'firstname',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new AddressManager('Sonata\CustomerBundle\Entity\BaseAddress', $registry);
+        return new AddressManager(BaseAddress::class, $registry);
     }
 }

--- a/tests/CustomerBundle/Entity/BaseCustomerTest.php
+++ b/tests/CustomerBundle/Entity/BaseCustomerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CustomerBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\CustomerBundle\Entity\BaseAddress;
 use Sonata\CustomerBundle\Entity\BaseCustomer;
@@ -39,7 +40,7 @@ class AddressTest extends BaseAddress
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class BaseCustomerTest extends \PHPUnit\Framework\TestCase
+class BaseCustomerTest extends TestCase
 {
     public function testAddAddress()
     {

--- a/tests/CustomerBundle/Entity/CustomerManagerTest.php
+++ b/tests/CustomerBundle/Entity/CustomerManagerTest.php
@@ -11,8 +11,10 @@
 
 namespace Sonata\CustomerBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\CustomerBundle\Entity\BaseCustomer;
 use Sonata\CustomerBundle\Entity\CustomerManager;
 
 class CustomerManagerTest extends TestCase
@@ -102,9 +104,9 @@ class CustomerManagerTest extends TestCase
             'email',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new CustomerManager('Sonata\CustomerBundle\Entity\BaseCustomer', $registry);
+        return new CustomerManager(BaseCustomer::class, $registry);
     }
 }

--- a/tests/CustomerBundle/Twig/Extension/AddressExtensionTest.php
+++ b/tests/CustomerBundle/Twig/Extension/AddressExtensionTest.php
@@ -12,6 +12,10 @@
 namespace Sonata\CustomerBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Customer\AddressInterface;
+use Sonata\Component\Delivery\ServiceDeliverySelectorInterface;
+use Sonata\CoreBundle\Exception\InvalidParameterException;
 use Sonata\CustomerBundle\Twig\Extension\AddressExtension;
 
 /**
@@ -21,12 +25,12 @@ class AddressExtensionTest extends TestCase
 {
     public function testRenderAddress()
     {
-        $environment = $this->createMock('Twig_Environment');
-        $deliverySelector = $this->createMock('Sonata\Component\Delivery\ServiceDeliverySelectorInterface');
+        $environment = $this->createMock(\Twig_Environment::class);
+        $deliverySelector = $this->createMock(ServiceDeliverySelectorInterface::class);
 
         $environment->expects($this->exactly(4))->method('render');
 
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
+        $address = $this->createMock(AddressInterface::class);
         $address->expects($this->exactly(3))->method('getFullAddressHtml');
 
         $extension = new AddressExtension($deliverySelector);
@@ -51,11 +55,11 @@ class AddressExtensionTest extends TestCase
 
     public function testRenderAddressInvalidParameter()
     {
-        $this->expectException(\Sonata\CoreBundle\Exception\InvalidParameterException::class);
+        $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage('sonata_address_render needs an AddressInterface instance or an array with keys (firstname, lastname, address1, postcode, city, country_code)');
 
         $environment = $this->createMock('Twig_Environment');
-        $deliverySelector = $this->createMock('Sonata\Component\Delivery\ServiceDeliverySelectorInterface');
+        $deliverySelector = $this->createMock(ServiceDeliverySelectorInterface::class);
 
         $address = [];
 
@@ -65,11 +69,11 @@ class AddressExtensionTest extends TestCase
 
     public function testRenderAddressMissingId()
     {
-        $this->expectException(\Sonata\CoreBundle\Exception\InvalidParameterException::class);
+        $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage('sonata_address_render needs \'id\' key to be set to render the edit button');
 
         $environment = $this->createMock('Twig_Environment');
-        $deliverySelector = $this->createMock('Sonata\Component\Delivery\ServiceDeliverySelectorInterface');
+        $deliverySelector = $this->createMock(ServiceDeliverySelectorInterface::class);
 
         $address = [
             'firstname' => '',
@@ -86,11 +90,11 @@ class AddressExtensionTest extends TestCase
 
     public function testIsAddressDeliverable()
     {
-        $address = $this->createMock('Sonata\Component\Customer\AddressInterface');
-        $basket = $this->createMock('Sonata\Component\Basket\BasketInterface');
+        $address = $this->createMock(AddressInterface::class);
+        $basket = $this->createMock(BasketInterface::class);
 
         // Test false
-        $deliverySelector = $this->createMock('Sonata\Component\Delivery\ServiceDeliverySelectorInterface');
+        $deliverySelector = $this->createMock(ServiceDeliverySelectorInterface::class);
         $deliverySelector->expects($this->once())->method('getAvailableMethods')->will($this->returnValue([]));
 
         $extension = new AddressExtension($deliverySelector);
@@ -99,7 +103,7 @@ class AddressExtensionTest extends TestCase
         $this->assertFalse($deliverable);
 
         // Test true
-        $deliverySelector = $this->createMock('Sonata\Component\Delivery\ServiceDeliverySelectorInterface');
+        $deliverySelector = $this->createMock(ServiceDeliverySelectorInterface::class);
         $deliverySelector->expects($this->once())->method('getAvailableMethods')->will($this->returnValue(['paypal']));
 
         $extension = new AddressExtension($deliverySelector);

--- a/tests/InvoiceBundle/Controller/Api/InvoiceControllerTest.php
+++ b/tests/InvoiceBundle/Controller/Api/InvoiceControllerTest.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\InvoiceBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Invoice\InvoiceElementInterface;
+use Sonata\Component\Invoice\InvoiceInterface;
+use Sonata\Component\Invoice\InvoiceManagerInterface;
 use Sonata\InvoiceBundle\Controller\Api\InvoiceController;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -21,10 +26,10 @@ class InvoiceControllerTest extends TestCase
 {
     public function testGetInvoicesAction()
     {
-        $invoiceManager = $this->createMock('Sonata\Component\Invoice\InvoiceManagerInterface');
+        $invoiceManager = $this->createMock(InvoiceManagerInterface::class);
         $invoiceManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -33,13 +38,13 @@ class InvoiceControllerTest extends TestCase
 
     public function testGetInvoiceAction()
     {
-        $invoice = $this->createMock('Sonata\Component\Invoice\InvoiceInterface');
+        $invoice = $this->createMock(InvoiceInterface::class);
         $this->assertEquals($invoice, $this->createInvoiceController($invoice)->getInvoiceAction(1));
     }
 
     public function testGetInvoiceActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Invoice (42) not found');
 
         $this->createInvoiceController()->getInvoiceAction(42);
@@ -47,8 +52,8 @@ class InvoiceControllerTest extends TestCase
 
     public function testGetInvoiceInvoiceelementsAction()
     {
-        $invoice = $this->createMock('Sonata\Component\Invoice\InvoiceInterface');
-        $invoiceElements = $this->createMock('Sonata\Component\Invoice\InvoiceElementInterface');
+        $invoice = $this->createMock(InvoiceInterface::class);
+        $invoiceElements = $this->createMock(InvoiceElementInterface::class);
         $invoice->expects($this->once())->method('getInvoiceElements')->will($this->returnValue([$invoiceElements]));
 
         $this->assertEquals([$invoiceElements], $this->createInvoiceController($invoice)->getInvoiceInvoiceelementsAction(1));
@@ -63,7 +68,7 @@ class InvoiceControllerTest extends TestCase
     public function createInvoiceController($invoice = null, $invoiceManager = null)
     {
         if (null === $invoiceManager) {
-            $invoiceManager = $this->createMock('Sonata\Component\Invoice\InvoiceManagerInterface');
+            $invoiceManager = $this->createMock(InvoiceManagerInterface::class);
         }
         if (null !== $invoice) {
             $invoiceManager->expects($this->once())->method('findOneBy')->will($this->returnValue($invoice));

--- a/tests/InvoiceBundle/Entity/BaseInvoiceTest.php
+++ b/tests/InvoiceBundle/Entity/BaseInvoiceTest.php
@@ -11,7 +11,11 @@
 
 namespace Sonata\InvoiceBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
+use Sonata\BasketBundle\Entity\BaseBasketElement;
 use Sonata\InvoiceBundle\Entity\BaseInvoice;
+use Sonata\InvoiceBundle\Entity\BaseInvoiceElement;
+use Sonata\ProductBundle\Entity\BaseProduct;
 
 class InvoiceTest extends BaseInvoice
 {
@@ -26,23 +30,23 @@ class InvoiceTest extends BaseInvoice
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class BaseInvoiceTest extends \PHPUnit\Framework\TestCase
+class BaseInvoiceTest extends TestCase
 {
     public function testInvoiceElementsVatAmounts()
     {
         $invoice = new InvoiceTest();
 
-        $element1 = $this->getMockBuilder('Sonata\InvoiceBundle\Entity\BaseInvoiceElement')->getMock();
+        $element1 = $this->getMockBuilder(BaseInvoiceElement::class)->getMock();
         $element1->expects($this->any())->method('getVatRate')->will($this->returnValue(20));
         $element1->expects($this->any())->method('getVatAmount')->will($this->returnValue(3));
 
-        $element2 = $this->getMockBuilder('Sonata\InvoiceBundle\Entity\BaseInvoiceElement')->getMock();
+        $element2 = $this->getMockBuilder(BaseInvoiceElement::class)->getMock();
         $element2->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
         $element2->expects($this->any())->method('getVatAmount')->will($this->returnValue(2));
 
-        $element3 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
+        $element3 = $this->getMockBuilder(BaseBasketElement::class)->getMock();
         $element3->expects($this->any())->method('getProduct')->will($this->returnValue(
-            $this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()
+            $this->getMockBuilder(BaseProduct::class)->getMock()
         ));
         $element3->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
         $element3->expects($this->any())->method('getVatAmount')->will($this->returnValue(5));

--- a/tests/InvoiceBundle/Entity/InvoiceManagerTest.php
+++ b/tests/InvoiceBundle/Entity/InvoiceManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\InvoiceBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\InvoiceBundle\Entity\BaseInvoice;
@@ -118,9 +119,9 @@ class InvoiceManagerTest extends TestCase
             'name',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new InvoiceManager('Sonata\InvoiceBundle\Entity\BaseInvoice', $registry);
+        return new InvoiceManager(BaseInvoice::class, $registry);
     }
 }

--- a/tests/OrderBundle/Controller/Api/OrderControllerTest.php
+++ b/tests/OrderBundle/Controller/Api/OrderControllerTest.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\OrderBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Order\OrderElementInterface;
+use Sonata\Component\Order\OrderInterface;
+use Sonata\Component\Order\OrderManagerInterface;
 use Sonata\OrderBundle\Controller\Api\OrderController;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -21,10 +26,10 @@ class OrderControllerTest extends TestCase
 {
     public function testGetOrdersAction()
     {
-        $orderManager = $this->createMock('Sonata\Component\Order\OrderManagerInterface');
+        $orderManager = $this->createMock(OrderManagerInterface::class);
         $orderManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -33,13 +38,13 @@ class OrderControllerTest extends TestCase
 
     public function testGetOrderAction()
     {
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $this->assertEquals($order, $this->createOrderController($order)->getOrderAction(1));
     }
 
     public function testGetOrderActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Order (42) not found');
 
         $this->createOrderController()->getOrderAction(42);
@@ -47,8 +52,8 @@ class OrderControllerTest extends TestCase
 
     public function testGetOrderOrderelementsAction()
     {
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
-        $orderElements = $this->createMock('Sonata\Component\Order\OrderElementInterface');
+        $order = $this->createMock(OrderInterface::class);
+        $orderElements = $this->createMock(OrderElementInterface::class);
         $order->expects($this->once())->method('getOrderElements')->will($this->returnValue([$orderElements]));
 
         $this->assertEquals([$orderElements], $this->createOrderController($order)->getOrderOrderelementsAction(1));
@@ -63,7 +68,7 @@ class OrderControllerTest extends TestCase
     public function createOrderController($order = null, $orderManager = null)
     {
         if (null === $orderManager) {
-            $orderManager = $this->createMock('Sonata\Component\Order\OrderManagerInterface');
+            $orderManager = $this->createMock(OrderManagerInterface::class);
         }
         if (null !== $order) {
             $orderManager->expects($this->once())->method('findOneBy')->will($this->returnValue($order));

--- a/tests/OrderBundle/Entity/BaseOrderTest.php
+++ b/tests/OrderBundle/Entity/BaseOrderTest.php
@@ -11,7 +11,11 @@
 
 namespace Sonata\OrderBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
+use Sonata\BasketBundle\Entity\BaseBasketElement;
 use Sonata\OrderBundle\Entity\BaseOrder;
+use Sonata\OrderBundle\Entity\BaseOrderElement;
+use Sonata\ProductBundle\Entity\BaseProduct;
 
 class OrderTest extends BaseOrder
 {
@@ -26,23 +30,23 @@ class OrderTest extends BaseOrder
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class BaseOrderTest extends \PHPUnit\Framework\TestCase
+class BaseOrderTest extends TestCase
 {
     public function testOrderElementsVatAmounts()
     {
         $order = new OrderTest();
 
-        $element1 = $this->getMockBuilder('Sonata\OrderBundle\Entity\BaseOrderElement')->getMock();
+        $element1 = $this->getMockBuilder(BaseOrderElement::class)->getMock();
         $element1->expects($this->any())->method('getVatRate')->will($this->returnValue(20));
         $element1->expects($this->any())->method('getVatAmount')->will($this->returnValue(3));
 
-        $element2 = $this->getMockBuilder('Sonata\OrderBundle\Entity\BaseOrderElement')->getMock();
+        $element2 = $this->getMockBuilder(BaseOrderElement::class)->getMock();
         $element2->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
         $element2->expects($this->any())->method('getVatAmount')->will($this->returnValue(2));
 
-        $element3 = $this->getMockBuilder('Sonata\BasketBundle\Entity\BaseBasketElement')->getMock();
+        $element3 = $this->getMockBuilder(BaseBasketElement::class)->getMock();
         $element3->expects($this->any())->method('getProduct')->will($this->returnValue(
-            $this->getMockBuilder('Sonata\ProductBundle\Entity\BaseProduct')->getMock()
+            $this->getMockBuilder(BaseProduct::class)->getMock()
         ));
         $element3->expects($this->any())->method('getVatRate')->will($this->returnValue(10));
         $element3->expects($this->any())->method('getVatAmount')->will($this->returnValue(5));

--- a/tests/OrderBundle/Entity/OrderManagerTest.php
+++ b/tests/OrderBundle/Entity/OrderManagerTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\OrderBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\OrderBundle\Entity\BaseOrder;
@@ -34,33 +36,33 @@ class OrderManagerTest extends TestCase
 {
     public function testGetClass()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
-        $order = new OrderManager('Sonata\OrderBundle\Tests\Entity\Order', $registry);
+        $registry = $this->createMock(ManagerRegistry::class);
+        $order = new OrderManager(Order::class, $registry);
 
-        $this->assertEquals('Sonata\OrderBundle\Tests\Entity\Order', $order->getClass());
+        $this->assertEquals(Order::class, $order->getClass());
     }
 
     public function testCreate()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
-        $orderManager = new OrderManager('Sonata\OrderBundle\Tests\Entity\Order', $registry);
+        $registry = $this->createMock(ManagerRegistry::class);
+        $orderManager = new OrderManager(Order::class, $registry);
 
         $order = $orderManager->create();
-        $this->assertInstanceOf('Sonata\OrderBundle\Tests\Entity\Order', $order);
+        $this->assertInstanceOf(Order::class, $order);
     }
 
     public function testSave()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->exactly(2))->method('persist');
         $em->expects($this->once())->method('flush');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $orderManager = new OrderManager('Sonata\OrderBundle\Tests\Entity\Order', $registry);
+        $orderManager = new OrderManager(Order::class, $registry);
 
-        $order = $this->createMock('Sonata\OrderBundle\Tests\Entity\Order');
+        $order = $this->createMock(Order::class);
         $order->expects($this->once())->method('getCustomer');
 
         $orderManager->save($order);
@@ -68,14 +70,14 @@ class OrderManagerTest extends TestCase
 
     public function testDelete()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('remove');
         $em->expects($this->once())->method('flush');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $orderManager = new OrderManager('Sonata\OrderBundle\Tests\Entity\Order', $registry);
+        $orderManager = new OrderManager(Order::class, $registry);
 
         $order = new Order();
         $orderManager->delete($order);
@@ -214,9 +216,9 @@ class OrderManagerTest extends TestCase
             'username',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new OrderManager('Sonata\OrderBundle\Entity\BaseOrder', $registry);
+        return new OrderManager(BaseOrder::class, $registry);
     }
 }

--- a/tests/PaymentBundle/Consumer/PaymentProcessOrderElementConsumerTest.php
+++ b/tests/PaymentBundle/Consumer/PaymentProcessOrderElementConsumerTest.php
@@ -11,10 +11,12 @@
 
 namespace Sonata\PaymentBundle\Tests\Consumer;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Payment\TransactionInterface;
 use Sonata\Component\Product\Pool;
+use Sonata\Component\Tests\Product\OrderElement;
 use Sonata\OrderBundle\Entity\OrderElementManager;
 use Sonata\PaymentBundle\Consumer\PaymentProcessOrderElementConsumer;
 
@@ -33,9 +35,9 @@ class PaymentProcessOrderElementConsumerTest extends TestCase
      */
     protected function getConsumer()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
 
-        $orderElementManager = new OrderElementManager('Sonata\OrderBundle\Tests\Entity\OrderElement', $registry);
+        $orderElementManager = new OrderElementManager(OrderElement::class, $registry);
 
         $pool = new Pool();
 

--- a/tests/PaymentBundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/PaymentBundle/DependencyInjection/ConfigurationTest.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\PaymentBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\PaymentBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @author Anton Zlotnikov <exp.razor@gmail.com>
  */
-class ConfigurationTest extends \PHPUnit\Framework\TestCase
+class ConfigurationTest extends TestCase
 {
     public function testDefaults()
     {

--- a/tests/PaymentBundle/Entity/BaseTransactionTest.php
+++ b/tests/PaymentBundle/Entity/BaseTransactionTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\PaymentBundle\Tests\Entity;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Order\OrderInterface;
 use Sonata\PaymentBundle\Entity\BaseTransaction;
 
 class Transaction extends BaseTransaction
@@ -28,7 +29,7 @@ class BaseTransactionTest extends TestCase
     {
         $transaction = new Transaction();
 
-        $order = $this->createMock('Sonata\Component\Order\OrderInterface');
+        $order = $this->createMock(OrderInterface::class);
         $order->expects($this->once())->method('getId')->will($this->returnValue(123));
         $order->expects($this->once())->method('getReference')->will($this->returnValue('B00120'));
 

--- a/tests/PriceBundle/DependencyInjection/SonataPriceExtensionTest.php
+++ b/tests/PriceBundle/DependencyInjection/SonataPriceExtensionTest.php
@@ -11,13 +11,15 @@
 
 namespace Sonata\PriceBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\PriceBundle\DependencyInjection\SonataPriceExtension;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class SonataPriceExtensionTest extends \PHPUnit\Framework\TestCase
+class SonataPriceExtensionTest extends TestCase
 {
     /**
      * Tests if the configuration is well parsed & parameters are well set.
@@ -40,7 +42,7 @@ class SonataPriceExtensionTest extends \PHPUnit\Framework\TestCase
      */
     public function testCurrencyRequired()
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $configuration = new ContainerBuilder();
         $loader = new SonataPriceExtension();

--- a/tests/ProductBundle/Command/GenerateProductCommandTest.php
+++ b/tests/ProductBundle/Command/GenerateProductCommandTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\ProductBundle\Command\GenerateProductCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @author Xavier Coureau <xcoureau@ekino.com>
@@ -24,7 +25,7 @@ class GenerateProductCommandTest extends TestCase
     public function testConfigure()
     {
         $cmd = $this->getCommandInstance();
-        $this->assertInstanceOf('Sonata\ProductBundle\Command\GenerateProductCommand', $cmd);
+        $this->assertInstanceOf(GenerateProductCommand::class, $cmd);
     }
 
     public function testExecute()
@@ -36,7 +37,7 @@ class GenerateProductCommandTest extends TestCase
             $cmdTester->execute(['command' => $cmd->getName()]);
             $this->fail('The command without arguments should throw a \RuntimeException');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e);
+            $this->assertInstanceOf(\RuntimeException::class, $e);
         }
 
         try {
@@ -46,7 +47,7 @@ class GenerateProductCommandTest extends TestCase
             ]);
             $this->fail('The command without "service_id" argument should throw a \RuntimeException');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e);
+            $this->assertInstanceOf(\RuntimeException::class, $e);
         }
 
         /*
@@ -66,7 +67,7 @@ class GenerateProductCommandTest extends TestCase
      */
     private function getCommandInstance()
     {
-        $kernel = $this->createMock('Symfony\Component\HttpKernel\Kernel');
+        $kernel = $this->createMock(Kernel::class);
         $app = new Application($kernel);
         $app->add(new GenerateProductCommand());
 

--- a/tests/ProductBundle/Controller/Api/ProductControllerTest.php
+++ b/tests/ProductBundle/Controller/Api/ProductControllerTest.php
@@ -11,9 +11,25 @@
 
 namespace Sonata\ProductBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\ClassificationBundle\Model\CollectionInterface;
+use Sonata\Component\Product\DeliveryInterface;
+use Sonata\Component\Product\PackageInterface;
+use Sonata\Component\Product\Pool as ProductPool;
+use Sonata\Component\Product\ProductCategoryInterface;
+use Sonata\Component\Product\ProductCollectionInterface;
+use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
+use Sonata\FormatterBundle\Formatter\Pool as FormatterPool;
 use Sonata\ProductBundle\Controller\Api\ProductController;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,10 +38,10 @@ class ProductControllerTest extends TestCase
 {
     public function testGetProductsAction()
     {
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
-        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock(ParamFetcherInterface::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -34,13 +50,13 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
         $this->assertEquals($product, $this->createProductController($product)->getProductAction(1));
     }
 
     public function testGetProductActionNotFoundException()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Product (42) not found');
 
         $this->createProductController()->getProductAction(42);
@@ -48,8 +64,8 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductProductcategoriesAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $productCategory = $this->createMock('Sonata\Component\Product\ProductCategoryInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $productCategory = $this->createMock(ProductCategoryInterface::class);
         $product->expects($this->once())->method('getProductCategories')->will($this->returnValue([$productCategory]));
 
         $this->assertEquals(
@@ -60,8 +76,8 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductCategoriesAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $category = $this->createMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $category = $this->createMock(CategoryInterface::class);
         $product->expects($this->once())->method('getCategories')->will($this->returnValue([$category]));
 
         $this->assertEquals([$category], $this->createProductController($product)->getProductCategoriesAction(1));
@@ -69,8 +85,8 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductProductcollectionsAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $productCollection = $this->createMock('Sonata\Component\Product\ProductCollectionInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $productCollection = $this->createMock(ProductCollectionInterface::class);
         $product->expects($this->once())->method('getProductCollections')->will($this->returnValue([$productCollection]));
 
         $this->assertEquals(
@@ -81,8 +97,8 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductCollectionsAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $collection = $this->createMock(CollectionInterface::class);
         $product->expects($this->once())->method('getCollections')->will($this->returnValue([$collection]));
 
         $this->assertEquals([$collection], $this->createProductController($product)->getProductCollectionsAction(1));
@@ -90,8 +106,8 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductPackagesAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $package = $this->createMock('Sonata\Component\Product\PackageInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $package = $this->createMock(PackageInterface::class);
         $product->expects($this->once())->method('getPackages')->will($this->returnValue([$package]));
 
         $this->assertEquals([$package], $this->createProductController($product)->getProductPackagesAction(1));
@@ -99,8 +115,8 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductDeliveriesAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $delivery = $this->createMock('Sonata\Component\Product\DeliveryInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $delivery = $this->createMock(DeliveryInterface::class);
         $product->expects($this->once())->method('getDeliveries')->will($this->returnValue([$delivery]));
 
         $this->assertEquals([$delivery], $this->createProductController($product)->getProductDeliveriesAction(1));
@@ -108,8 +124,8 @@ class ProductControllerTest extends TestCase
 
     public function testGetProductVariationsAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
-        $variation = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
+        $variation = $this->createMock(ProductInterface::class);
         $product->expects($this->once())->method('getVariations')->will($this->returnValue([$variation]));
 
         $this->assertEquals([$variation], $this->createProductController($product)->getProductVariationsAction(1));
@@ -117,120 +133,120 @@ class ProductControllerTest extends TestCase
 
     public function testPostProductAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('save')->will($this->returnValue($product));
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(ProductPool::class);
         $productPool->expects($this->once())->method('getManager')->will($this->returnValue($productManager));
 
-        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock(FormatterPool::class);
         $formatterPool->expects($this->exactly(2))->method('transform');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($product));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createProductController(null, $productManager, $productPool, $formFactory, $formatterPool)
             ->postProductAction('my.test.provider', new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPostProductInvalidAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->never())->method('save');
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(ProductPool::class);
         $productPool->expects($this->once())->method('getManager')->will($this->returnValue($productManager));
 
-        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock(FormatterPool::class);
         $formatterPool->expects($this->never())->method('transform');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createProductController(null, $productManager, $productPool, $formFactory, $formatterPool)
             ->postProductAction('my.test.provider', new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testPutProductAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
         $productManager->expects($this->once())->method('save')->will($this->returnValue($product));
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(ProductPool::class);
         $productPool->expects($this->once())->method('getManager')->will($this->returnValue($productManager));
 
-        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock(FormatterPool::class);
         $formatterPool->expects($this->exactly(2))->method('transform');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($product));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createProductController($product, $productManager, $productPool, $formFactory, $formatterPool)
             ->putProductAction(1, 'my.test.provider', new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     public function testPutProductInvalidAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
         $productManager->expects($this->never())->method('save');
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(ProductPool::class);
         $productPool->expects($this->once())->method('getManager')->will($this->returnValue($productManager));
 
-        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock(FormatterPool::class);
         $formatterPool->expects($this->never())->method('transform');
 
-        $form = $this->createMock('Symfony\Component\Form\Form');
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createProductController($product, $productManager, $productPool, $formFactory, $formatterPool)
             ->putProductAction(1, 'my.test.provider', new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteProductAction()
     {
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('delete');
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(ProductPool::class);
         $productPool->expects($this->once())->method('getManager')->will($this->returnValue($productManager));
 
         $view = $this->createProductController($product, $productManager, $productPool)->deleteProductAction(1);
@@ -240,15 +256,15 @@ class ProductControllerTest extends TestCase
 
     public function testDeleteProductInvalidAction()
     {
-        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException(NotFoundHttpException::class);
 
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
 
-        $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+        $productManager = $this->createMock(ProductManagerInterface::class);
         $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue(null));
         $productManager->expects($this->never())->method('delete');
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(ProductPool::class);
         $productPool->expects($this->never())->method('getManager')->will($this->returnValue($productManager));
 
         $view = $this->createProductController($product, $productManager, $productPool)->deleteProductAction(1);
@@ -268,19 +284,19 @@ class ProductControllerTest extends TestCase
     public function createProductController($product = null, $productManager = null, $productPool = null, $formFactory = null, $formatterPool = null)
     {
         if (null === $productManager) {
-            $productManager = $this->createMock('Sonata\Component\Product\ProductManagerInterface');
+            $productManager = $this->createMock(ProductManagerInterface::class);
         }
         if (null !== $product) {
             $productManager->expects($this->once())->method('findOneBy')->will($this->returnValue($product));
         }
         if (null === $productPool) {
-            $productPool = $this->createMock('Sonata\Component\Product\Pool');
+            $productPool = $this->createMock(ProductPool::class);
         }
         if (null === $formFactory) {
-            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock(FormFactoryInterface::class);
         }
         if (null === $formatterPool) {
-            $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
+            $formatterPool = $this->createMock(FormatterPool::class);
         }
 
         return new ProductController($productManager, $productPool, $formFactory, $formatterPool);

--- a/tests/ProductBundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/ProductBundle/DependencyInjection/ConfigurationTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\ProductBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\ProductBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends \PHPUnit\Framework\TestCase
+class ConfigurationTest extends TestCase
 {
     public function testDefaults()
     {

--- a/tests/ProductBundle/Entity/BaseProductTest.php
+++ b/tests/ProductBundle/Entity/BaseProductTest.php
@@ -12,6 +12,9 @@
 namespace Sonata\ProductBundle\Tests\Entity;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Product\ProductCategoryInterface;
+use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\ProductBundle\Entity\BaseProduct;
 
 /**
@@ -42,21 +45,21 @@ class BaseProductTest extends TestCase
         $this->assertNull($product->getImage());
 
         // Test gallery
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $product->setGallery($gallery);
 
         $this->assertNull($product->getImage());
-        $this->assertInstanceOf('Sonata\MediaBundle\Model\GalleryInterface', $product->getGallery());
+        $this->assertInstanceOf(GalleryInterface::class, $product->getGallery());
 
         // Test getImage
-        $image = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $image = $this->createMock(MediaInterface::class);
         $image->expects($this->any())
             ->method('getName')
             ->will($this->returnValue('correctMedia'));
 
         $product->setImage($image);
 
-        $this->assertInstanceOf('Sonata\MediaBundle\Model\MediaInterface', $product->getImage());
+        $this->assertInstanceOf(MediaInterface::class, $product->getImage());
         $this->assertEquals('correctMedia', $product->getImage()->getName());
     }
 
@@ -64,13 +67,13 @@ class BaseProductTest extends TestCase
     {
         $product = new Product();
 
-        $pc = $this->createMock('Sonata\Component\Product\ProductCategoryInterface');
+        $pc = $this->createMock(ProductCategoryInterface::class);
         $pc->expects($this->any())->method('getMain')->will($this->returnValue(true));
 
-        $pc2 = $this->createMock('Sonata\Component\Product\ProductCategoryInterface');
+        $pc2 = $this->createMock(ProductCategoryInterface::class);
         $pc2->expects($this->any())->method('getMain')->will($this->returnValue(true));
 
-        $pc3 = $this->createMock('Sonata\Component\Product\ProductCategoryInterface');
+        $pc3 = $this->createMock(ProductCategoryInterface::class);
         $pc3->expects($this->any())->method('getMain')->will($this->returnValue(true));
 
         $this->assertFalse($product->hasOneMainCategory());

--- a/tests/ProductBundle/Entity/ProductManagerTest.php
+++ b/tests/ProductBundle/Entity/ProductManagerTest.php
@@ -11,8 +11,10 @@
 
 namespace Sonata\ProductBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\ProductBundle\Entity\BaseProduct;
 use Sonata\ProductBundle\Entity\ProductManager;
 
 class ProductManagerTest extends TestCase
@@ -106,9 +108,9 @@ class ProductManagerTest extends TestCase
             'name',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new ProductManager('Sonata\PageBundle\Entity\BaseProduct', $registry);
+        return new ProductManager(BaseProduct::class, $registry);
     }
 }

--- a/tests/ProductBundle/Form/Type/ApiProductTypeTest.php
+++ b/tests/ProductBundle/Form/Type/ApiProductTypeTest.php
@@ -12,7 +12,10 @@
 namespace Sonata\ProductBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Product\Pool;
+use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\ProductBundle\Form\Type\ApiProductType;
+use Symfony\Component\Form\FormBuilder;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -21,14 +24,14 @@ class ApiProductTypeTest extends TestCase
 {
     public function testBuildForm()
     {
-        $provider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
+        $provider = $this->createMock(ProductProviderInterface::class);
 
-        $productPool = $this->createMock('Sonata\Component\Product\Pool');
+        $productPool = $this->createMock(Pool::class);
         $productPool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
         $type = new ApiProductType($productPool);
 
-        $builder = $this->createMock('Symfony\Component\Form\FormBuilder');
+        $builder = $this->createMock(FormBuilder::class);
 
         $type->buildForm($builder, ['provider_name' => 'test.product.provider']);
     }

--- a/tests/ProductBundle/Menu/ProductMenuBuilderTest.php
+++ b/tests/ProductBundle/Menu/ProductMenuBuilderTest.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\ProductBundle\Tests\Menu;
 
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Product\ProductCategoryManagerInterface;
+use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\ProductBundle\Menu\ProductMenuBuilder;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -21,15 +26,15 @@ class ProductMenuBuilderTest extends TestCase
 {
     public function testCreateCategoryMenu()
     {
-        $menu = $this->createMock('Knp\Menu\ItemInterface');
-        $factory = $this->createMock('Knp\Menu\FactoryInterface');
+        $menu = $this->createMock(ItemInterface::class);
+        $factory = $this->createMock(FactoryInterface::class);
 
         $factory->expects($this->once())
             ->method('createItem')
             ->will($this->returnValue($menu));
 
-        $categoryManager = $this->createMock('Sonata\Component\Product\ProductCategoryManagerInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $categoryManager = $this->createMock(ProductCategoryManagerInterface::class);
+        $router = $this->createMock(RouterInterface::class);
 
         $categoryManager->expects($this->once())
             ->method('getCategoryTree')
@@ -39,24 +44,24 @@ class ProductMenuBuilderTest extends TestCase
 
         $genMenu = $builder->createCategoryMenu();
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $genMenu);
+        $this->assertInstanceOf(ItemInterface::class, $genMenu);
     }
 
     public function testCreateFiltersMenu()
     {
-        $menu = $this->createMock('Knp\Menu\ItemInterface');
-        $factory = $this->createMock('Knp\Menu\FactoryInterface');
+        $menu = $this->createMock(ItemInterface::class);
+        $factory = $this->createMock(FactoryInterface::class);
 
         $factory->expects($this->once())
             ->method('createItem')
             ->will($this->returnValue($menu));
 
-        $categoryManager = $this->createMock('Sonata\Component\Product\ProductCategoryManagerInterface');
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $categoryManager = $this->createMock(ProductCategoryManagerInterface::class);
+        $router = $this->createMock(RouterInterface::class);
 
         $builder = new ProductMenuBuilder($factory, $categoryManager, $router);
 
-        $productProvider = $this->createMock('Sonata\Component\Product\ProductProviderInterface');
+        $productProvider = $this->createMock(ProductProviderInterface::class);
 
         $productProvider->expects($this->once())
             ->method('getFilters')
@@ -64,6 +69,6 @@ class ProductMenuBuilderTest extends TestCase
 
         $genMenu = $builder->createFiltersMenu($productProvider);
 
-        $this->assertInstanceOf('Knp\Menu\ItemInterface', $genMenu);
+        $this->assertInstanceOf(ItemInterface::class, $genMenu);
     }
 }

--- a/tests/ProductBundle/Model/BaseProductProviderTest.php
+++ b/tests/ProductBundle/Model/BaseProductProviderTest.php
@@ -11,13 +11,21 @@
 
 namespace Sonata\ProductBundle\Tests\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use JMS\Serializer\Serializer;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BasketElement;
+use Sonata\Component\Basket\BasketElementInterface;
+use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Basket\InvalidProductException;
 use Sonata\Component\Currency\Currency;
 use Sonata\Component\Currency\CurrencyPriceCalculator;
 use Sonata\Component\Product\ProductInterface;
+use Sonata\CoreBundle\Exception\InvalidParameterException;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\ProductBundle\Entity\BaseProduct;
 use Sonata\ProductBundle\Model\BaseProductProvider;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ProductProviderTest extends BaseProductProvider
 {
@@ -65,7 +73,7 @@ class BaseProductProviderTest extends TestCase
     public function testCreateVariation()
     {
         $productProvider = $this->createNewProductProvider();
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')
+        $product = $this->getMockBuilder(ProductInterface::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $product->expects($this->any())
@@ -99,7 +107,7 @@ class BaseProductProviderTest extends TestCase
         $this->assertTrue($basketElement->getOption('test', null));
 
         // Second test with product
-        $product = $this->createMock('Sonata\Component\Product\ProductInterface');
+        $product = $this->createMock(ProductInterface::class);
         $productProvider->buildBasketElement($basketElement, $product, ['test2' => true]);
         $this->assertTrue($basketElement->getOption('test2', null));
         $this->assertNull($basketElement->getOption('test', null));
@@ -108,11 +116,11 @@ class BaseProductProviderTest extends TestCase
     public function testValidateFormBasketElement()
     {
         $productProvider = $this->createNewProductProvider();
-        $errorElement = $this->createMock('Sonata\CoreBundle\Validator\ErrorElement');
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $errorElement = $this->createMock(ErrorElement::class);
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
 
         // With a deleted element
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
         $basketElement->expects($this->any())
             ->method('getDelete')
             ->will($this->returnValue(true));
@@ -120,7 +128,7 @@ class BaseProductProviderTest extends TestCase
         $this->assertNull($productProvider->validateFormBasketElement($errorElement, $basketElement, $basket));
 
         // Without a product
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
         $basketElement->expects($this->any())
             ->method('getProduct')
             ->will($this->returnValue(false));
@@ -128,8 +136,8 @@ class BaseProductProviderTest extends TestCase
         $this->assertNull($productProvider->validateFormBasketElement($errorElement, $basketElement, $basket));
 
         // With a disabled product
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
         $product->expects($this->any())
             ->method('getEnabled')
             ->will($this->returnValue(false));
@@ -140,8 +148,8 @@ class BaseProductProviderTest extends TestCase
         $this->assertNull($productProvider->validateFormBasketElement($errorElement, $basketElement, $basket));
 
         // With a non numeric quantity
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
         $basketElement->expects($this->any())
             ->method('getProduct')
             ->will($this->returnValue($product));
@@ -155,11 +163,11 @@ class BaseProductProviderTest extends TestCase
     public function testBasketAddProduct()
     {
         $productProvider = $this->createNewProductProvider();
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
 
         // Simulate a product already in the basket
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
         $basket->expects($this->any())
             ->method('hasProduct')
             ->will($this->returnValue(true));
@@ -172,7 +180,7 @@ class BaseProductProviderTest extends TestCase
         $this->assertFalse($productProvider->basketAddProduct($basket, $product, $basketElement));
 
         // Test with product having options
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
         $basket->expects($this->any())
             ->method('hasProduct')
             ->will($this->returnValue(false));
@@ -191,24 +199,24 @@ class BaseProductProviderTest extends TestCase
         $this->assertTrue($basketElement->hasOption('even'));
         $this->assertTrue($basketElement->hasOption('more'));
         $this->assertTrue($basketElement->hasOption('tests'));
-        $this->assertInstanceOf('Sonata\Component\Basket\BasketElementInterface', $result);
+        $this->assertInstanceOf(BasketElementInterface::class, $result);
     }
 
     public function testBasketAddProductInvalid()
     {
-        $this->expectException(\Sonata\Component\Basket\InvalidProductException::class);
+        $this->expectException(InvalidProductException::class);
         $this->expectExceptionMessage('You can\'t add \'product_sku\' to the basket as it is a master product with variations.');
 
         $productProvider = $this->createNewProductProvider();
 
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
         $product->expects($this->once())->method('isMaster')->will($this->returnValue(true));
         $product->expects($this->once())->method('getSku')->will($this->returnValue('product_sku'));
         $product->expects($this->once())->method('getVariations')->will($this->returnValue([1]));
 
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
 
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
 
         $productProvider->basketAddProduct($basket, $product, $basketElement);
     }
@@ -216,30 +224,30 @@ class BaseProductProviderTest extends TestCase
     public function testBasketMergeProduct()
     {
         // Test a product not in the basket
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
 
         $currency = new Currency();
         $currency->setLabel('EUR');
 
         $basket->expects($this->any())->method('getCurrency')->will($this->returnValue($currency));
 
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
         $basketElement->expects($this->any())->method('getQuantity')->will($this->returnValue(1));
         $productProvider = $this->createNewProductProvider();
 
         $this->assertFalse($productProvider->basketMergeProduct($basket, $product, $basketElement));
 
         // Test an invalid product ID in the basket
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
 
         $currency = new Currency();
         $currency->setLabel('EUR');
 
         $basket->expects($this->any())->method('getCurrency')->will($this->returnValue($currency));
 
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
         $basketElement->expects($this->any())->method('getQuantity')->will($this->returnValue(1));
         $productProvider = $this->createNewProductProvider();
         $basket->expects($this->any())
@@ -250,21 +258,21 @@ class BaseProductProviderTest extends TestCase
             $productProvider->basketMergeProduct($basket, $product, $basketElement);
             $this->fail('->basketMergeProduct() should throw a \RuntimeException for an invalid product ID');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e);
+            $this->assertInstanceOf(\RuntimeException::class, $e);
         }
 
         // Test a valid workflow
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
 
         $currency = new Currency();
         $currency->setLabel('EUR');
 
         $basket->expects($this->any())->method('getCurrency')->will($this->returnValue($currency));
 
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
         $basketElement->expects($this->any())->method('getQuantity')->will($this->returnValue(1));
-        $newBasketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $newBasketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
         $productProvider = $this->createNewProductProvider();
         $basket->expects($this->any())
             ->method('hasProduct')
@@ -273,7 +281,7 @@ class BaseProductProviderTest extends TestCase
             ->method('getElement')
             ->will($this->returnValue($basketElement));
 
-        $this->assertInstanceOf('Sonata\Component\Basket\BasketElementInterface', $productProvider->basketMergeProduct($basket, $product, $newBasketElement));
+        $this->assertInstanceOf(BasketElementInterface::class, $productProvider->basketMergeProduct($basket, $product, $newBasketElement));
     }
 
     public function testIsValidBasketElement()
@@ -281,15 +289,15 @@ class BaseProductProviderTest extends TestCase
         $productProvider = $this->createNewProductProvider();
 
         // Test invalid product
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
         $basketElement->expects($this->any())
             ->method('getProduct')
             ->will($this->returnValue(false));
         $this->assertFalse($productProvider->isValidBasketElement($basketElement));
 
         // Test valid product
-        $basketElement = $this->getMockBuilder('Sonata\Component\Basket\BasketElementInterface')->getMock();
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
+        $basketElement = $this->getMockBuilder(BasketElementInterface::class)->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
         $basketElement->expects($this->any())
             ->method('getProduct')
             ->will($this->returnValue($product));
@@ -298,8 +306,8 @@ class BaseProductProviderTest extends TestCase
 
     public function testIsAddableToBasket()
     {
-        $basket = $this->getMockBuilder('Sonata\Component\Basket\BasketInterface')->getMock();
-        $product = $this->getMockBuilder('Sonata\Component\Product\ProductInterface')->getMock();
+        $basket = $this->getMockBuilder(BasketInterface::class)->getMock();
+        $product = $this->getMockBuilder(ProductInterface::class)->getMock();
         $productProvider = $this->createNewProductProvider();
 
         $this->assertTrue($productProvider->isAddableToBasket($basket, $product));
@@ -369,7 +377,7 @@ class BaseProductProviderTest extends TestCase
         $provider->setVariationFields(['test']);
 
         $variations = $provider->getEnabledVariations($productMock);
-        $this->assertInstanceOf('\Doctrine\Common\Collections\ArrayCollection', $variations);
+        $this->assertInstanceOf(ArrayCollection::class, $variations);
         $this->assertEquals(0, count($variations));
     }
 
@@ -384,9 +392,9 @@ class BaseProductProviderTest extends TestCase
         $provider->setVariationFields(['test']);
 
         $variations = $provider->getEnabledVariations($productMock);
-        $this->assertInstanceOf('\Doctrine\Common\Collections\ArrayCollection', $variations);
+        $this->assertInstanceOf(ArrayCollection::class, $variations);
         $this->assertEquals(1, count($variations));
-        $this->assertInstanceOf('\Sonata\Component\Product\ProductInterface', $variations[0]);
+        $this->assertInstanceOf(ProductInterface::class, $variations[0]);
     }
 
     public function testGetCheapestEnabledVariationWithNoVariation()
@@ -445,7 +453,7 @@ class BaseProductProviderTest extends TestCase
 
     public function testCalculatePriceException()
     {
-        $this->expectException(\Sonata\CoreBundle\Exception\InvalidParameterException::class);
+        $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage('Expected integer >= 1 for quantity, 4.32 given.');
 
         $product = new ProductTest();
@@ -459,7 +467,7 @@ class BaseProductProviderTest extends TestCase
 
     public function testCalculatePriceExceptionLessThanOne()
     {
-        $this->expectException(\Sonata\CoreBundle\Exception\InvalidParameterException::class);
+        $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage('Expected integer >= 1 for quantity, 0.32 given.');
 
         $product = new ProductTest();
@@ -573,12 +581,12 @@ class BaseProductProviderTest extends TestCase
      */
     private function createNewProductProvider()
     {
-        $serializer = $this->createMock('JMS\Serializer\Serializer');
+        $serializer = $this->createMock(Serializer::class);
 
         $provider = new ProductProviderTest($serializer);
 
         $provider->setCurrencyPriceCalculator(new CurrencyPriceCalculator());
-        $provider->setEventDispatcher($this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface'));
+        $provider->setEventDispatcher($this->createMock(EventDispatcherInterface::class));
 
         return $provider;
     }

--- a/tests/ProductBundle/Seo/Services/FacebookTest.php
+++ b/tests/ProductBundle/Seo/Services/FacebookTest.php
@@ -12,10 +12,14 @@
 namespace Sonata\ProductBundle\Tests\Seo\Services;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Currency\CurrencyDetectorInterface;
+use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Sonata\MediaBundle\Provider\Pool;
 use Sonata\ProductBundle\Entity\BaseProduct;
 use Sonata\ProductBundle\Seo\Services\Facebook;
 use Sonata\SeoBundle\Seo\SeoPage;
 use Sonata\SeoBundle\Twig\Extension\SeoExtension;
+use Symfony\Component\Routing\RouterInterface;
 
 class ProductFbMock extends BaseProduct
 {
@@ -38,13 +42,13 @@ class FacebookTest extends TestCase
 {
     public function testAlterPage()
     {
-        $mediaPool = $this->createMock('Sonata\MediaBundle\Provider\Pool');
+        $mediaPool = $this->createMock(Pool::class);
         $seoPage = new SeoPage('test');
         $extension = new SeoExtension($seoPage, 'UTF-8');
-        $numberHelper = $this->createMock('Sonata\IntlBundle\Templating\Helper\NumberHelper');
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $numberHelper = $this->createMock(NumberHelper::class);
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $product = new ProductFbMock();
-        $router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $router = $this->createMock(RouterInterface::class);
 
         // Check if the header data are correctly registered
         $fbService = new Facebook($router, $mediaPool, $numberHelper, $currencyDetector, 'test', 'test', 'reference');

--- a/tests/ProductBundle/Seo/Services/TwitterTest.php
+++ b/tests/ProductBundle/Seo/Services/TwitterTest.php
@@ -12,6 +12,9 @@
 namespace Sonata\ProductBundle\Tests\Seo\Services;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\Component\Currency\CurrencyDetectorInterface;
+use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Sonata\MediaBundle\Provider\Pool;
 use Sonata\ProductBundle\Entity\BaseProduct;
 use Sonata\ProductBundle\Seo\Services\Twitter;
 use Sonata\SeoBundle\Seo\SeoPage;
@@ -33,11 +36,11 @@ class TwitterTest extends TestCase
 {
     public function testAlterPage()
     {
-        $mediaPool = $this->createMock('Sonata\MediaBundle\Provider\Pool');
+        $mediaPool = $this->createMock(Pool::class);
         $seoPage = new SeoPage('test');
         $extension = new SeoExtension($seoPage, 'UTF-8');
-        $numberHelper = $this->createMock('Sonata\IntlBundle\Templating\Helper\NumberHelper');
-        $currencyDetector = $this->createMock('Sonata\Component\Currency\CurrencyDetectorInterface');
+        $numberHelper = $this->createMock(NumberHelper::class);
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
         $product = new ProductTwitterMock();
 
         $twitterService = new Twitter($mediaPool, $numberHelper, $currencyDetector, 'test', 'test', 'test', 'test', 'reference');


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Fixed
 - Replaced FQCN strings with `::class` constants
```

P.S this one was hard
<img width="200" alt="screen" src="https://user-images.githubusercontent.com/1560126/33979130-b6cc163a-e0ee-11e7-855f-63790bf1ff58.png">
