### PR TITLE
Fix ProductAdmin for SonataAdminBundle ^3.29

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "knplabs/knp-paginator-bundle": "^2.6",
         "kriswallsmith/buzz": "^0.15",
         "nelmio/api-doc-bundle": "^2.13",
-        "sonata-project/admin-bundle": "^3.28",
+        "sonata-project/admin-bundle": "^3.29",
         "sonata-project/block-bundle": "^3.8",
         "sonata-project/classification-bundle": "^3.3",
         "sonata-project/comment-bundle": "^3.1",
@@ -47,7 +47,7 @@
         "symfony/validator": "^2.8"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.3 || ^4.0"
+        "symfony/phpunit-bridge": "^3.4 || ^4.0"
     },
     "conflict": {
         "jms/serializer": "<0.13",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,10 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/ProductBundle/Admin/ProductAdmin.php
+++ b/src/ProductBundle/Admin/ProductAdmin.php
@@ -61,32 +61,27 @@ class ProductAdmin extends AbstractAdmin
     /**
      * @return string
      */
-    public function getClass()
-    {
-        if ($this->hasSubject()) {
-            return get_class($this->getSubject());
-        } elseif ($class = $this->getProductClass()) {
-            return $class;
-        }
-
-        return parent::getClass();
-    }
-
-    /**
-     * @return string
-     */
     public function getProductType()
     {
         return $this->getRequest()->get('provider');
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Returns the product class from the provided request.
      *
      * @return string
+     *
+     * @deprecated since 2.2, will be removed in 3.0
      */
     public function getProductClass()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0.',
+            E_USER_DEPRECATED
+        );
+
         if ($this->hasRequest()) {
             $code = $this->getProductType();
 

--- a/tests/ProductBundle/Admin/ProductAdminTest.php
+++ b/tests/ProductBundle/Admin/ProductAdminTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Tests\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\ProductBundle\Admin\ProductAdmin;
+use Sonata\ProductBundle\Entity\BaseProduct;
+
+/**
+ * @author Anton Zlotnikov <exp.razor@gmail.com>
+ */
+class ProductAdminTest extends TestCase
+{
+    /** @var ProductAdmin */
+    private $productAdmin;
+
+    protected function setUp()
+    {
+        $this->productAdmin = new ProductAdmin(
+            null,
+            BaseProduct::class,
+            'SonataProductBundle:ProductAdmin'
+        );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The Sonata\ProductBundle\Admin\ProductAdmin::getProductClass method is deprecated since version 2.2 and will be removed in 3.0.
+     */
+    public function testGetProductClassIsDeprecated()
+    {
+        $this->productAdmin->getProductClass();
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed compatibility with SonataAdminBundle ^3.29
### Deprecated
- Deprecated `ProductAdmin::getProductClass` method
```

## Subject

After sonata-project/SonataAdminBundle#4824 `ProductAdmin::getClass`causes an infinite loop and is not needed anymore. I checked - on 3.29 it resolves different product providers correctly without overriding this method.
`ProductAdmin::getProductClass` method is also not needed anymore, so I deprecated it.