### PR TITLE
Fix resetting full basket stored in session

### DIFF
--- a/src/Component/Basket/BasketEntityFactory.php
+++ b/src/Component/Basket/BasketEntityFactory.php
@@ -68,8 +68,12 @@ class BasketEntityFactory extends BaseBasketFactory
      */
     public function reset(BasketInterface $basket, $full = true)
     {
-        if ($full && $basket->getCustomerId()) {
-            $this->basketManager->delete($basket);
+        if ($full) {
+            if ($basket->getCustomerId()) {
+                $this->basketManager->delete($basket);
+            } else {
+                $this->clearSession($basket->getCustomer());
+            }
         } else {
             $basket->reset($full);
             $this->save($basket);

--- a/src/Component/Basket/BasketSessionFactory.php
+++ b/src/Component/Basket/BasketSessionFactory.php
@@ -74,7 +74,11 @@ class BasketSessionFactory extends BaseBasketFactory
      */
     public function reset(BasketInterface $basket, $full = true)
     {
-        $basket->reset($full);
-        $this->save($basket);
+        if ($full) {
+            $this->clearSession($basket->getCustomer());
+        } else {
+            $basket->reset($full);
+            $this->save($basket);
+        }
     }
 }

--- a/src/Component/Basket/BasketSessionFactory.php
+++ b/src/Component/Basket/BasketSessionFactory.php
@@ -11,46 +11,10 @@
 
 namespace Sonata\Component\Basket;
 
-use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Sonata\Component\Customer\CustomerInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class BasketSessionFactory extends BaseBasketFactory
 {
-    /**
-     * @var \Sonata\Component\Basket\BasketManagerInterface
-     */
-    protected $basketManager;
-
-    /**
-     * @var \Sonata\Component\Basket\BasketBuilderInterface
-     */
-    protected $basketBuilder;
-
-    /**
-     * @var \Sonata\Component\Currency\CurrencyDetectorInterface
-     */
-    protected $currencyDetector;
-
-    /**
-     * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
-     */
-    protected $session;
-
-    /**
-     * @param BasketManagerInterface    $basketManager
-     * @param BasketBuilderInterface    $basketBuilder
-     * @param CurrencyDetectorInterface $currencyDetector
-     * @param SessionInterface          $session
-     */
-    public function __construct(BasketManagerInterface $basketManager, BasketBuilderInterface $basketBuilder, CurrencyDetectorInterface $currencyDetector, SessionInterface $session)
-    {
-        $this->basketManager = $basketManager;
-        $this->basketBuilder = $basketBuilder;
-        $this->currencyDetector = $currencyDetector;
-        $this->session = $session;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/tests/Component/Basket/BaseBasketFactoryTest.php
+++ b/tests/Component/Basket/BaseBasketFactoryTest.php
@@ -18,7 +18,7 @@ use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Basket\BasketManagerInterface;
 use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Sonata\Component\Customer\CustomerInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class BasketFactory extends BaseBasketFactory
 {
@@ -47,7 +47,7 @@ class BasketFactory extends BaseBasketFactory
     }
 
     /**
-     * @return \Symfony\Component\HttpFoundation\Session\Session
+     * @return \Symfony\Component\HttpFoundation\Session\SessionInterface
      */
     public function getSession()
     {
@@ -86,7 +86,7 @@ class BaseBasketFactoryTest extends TestCase
         $basketManager = $this->createMock(BasketManagerInterface::class);
         $basketBuilder = $this->createMock(BasketBuilderInterface::class);
         $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
-        $session = $this->createMock(Session::class);
+        $session = $this->createMock(SessionInterface::class);
 
         $basketFactory = new BasketFactory($basketManager, $basketBuilder, $currencyDetector, $session);
 

--- a/tests/Component/Basket/BasketSessionFactoryTest.php
+++ b/tests/Component/Basket/BasketSessionFactoryTest.php
@@ -130,4 +130,39 @@ class BasketSessionFactoryTest extends TestCase
         $factory = new BasketSessionFactory($basketManager, $basketBuilder, $currencyDetector, $session);
         $factory->logout(new Request(), new Response(), $this->createMock(TokenInterface::class));
     }
+
+    public function testResetFullBasket()
+    {
+        $basket = $this->createMock(BasketInterface::class);
+        $basket->expects($this->once())->method('setCustomer');
+
+        $basketManager = $this->createMock(BasketManagerInterface::class);
+
+        $basketBuilder = $this->createMock(BasketBuilderInterface::class);
+        $basketBuilder->expects($this->once())->method('build');
+
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->expects($this->any())->method('getId')->will($this->returnValue(1));
+        $basket->expects($this->any())->method('getCustomer')->will($this->returnValue($customer));
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('sonata/basket/factory/customer/1', $basket);
+
+        $currencyDetector = $this->createMock(CurrencyDetectorInterface::class);
+        $currency = new Currency();
+        $currency->setLabel('EUR');
+        $currencyDetector->expects($this->any())
+            ->method('getCurrency')
+            ->will($this->returnValue($currency))
+        ;
+
+        $factory = new BasketSessionFactory($basketManager, $basketBuilder, $currencyDetector, $session);
+
+        $basket = $factory->load($customer);
+
+        $factory->reset($basket, true);
+
+        $this->assertNull($session->get('sonata/basket/factory/customer/1'));
+        $this->assertNull($session->get('sonata/basket/factory/customer/new'));
+    }
 }


### PR DESCRIPTION
I am targeting this branch, because it's a bug fix.

Closes #450 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed resetting full basket stored in session
- Removed duplicated code from `BasketSessionFactory`
```

## Subject

The reason of this bug is described in my message in #450 