### PR TITLE
Fix php doc, fix types mismatches

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -32,3 +32,6 @@ If you have implemented custom `CustomerSelector` you must adapt constructor arg
 
 ## ProductInterface
 `ProductInterface::validateOneMainCategory` now uses `Symfony\Component\Validator\Context\ExecutionContextInterface` instead of `Symfony\Component\Validator\ExecutionContextInterface`
+
+## ProductManagerInterface
+`ProductManagerInterface::findInSameCollections`, `ProductManagerInterface::findParentsInSameCollections` signatures were updated.

--- a/src/BasketBundle/DependencyInjection/SonataBasketExtension.php
+++ b/src/BasketBundle/DependencyInjection/SonataBasketExtension.php
@@ -65,8 +65,8 @@ class SonataBasketExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param $config
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
     public function registerParameters(ContainerBuilder $container, array $config): void
     {

--- a/src/BasketBundle/Entity/BaseBasket.php
+++ b/src/BasketBundle/Entity/BaseBasket.php
@@ -21,6 +21,7 @@ abstract class BaseBasket extends Basket
 {
     public function __construct()
     {
+        parent::__construct();
         $this->reset(true);
     }
 

--- a/src/BasketBundle/Entity/BaseBasketElement.php
+++ b/src/BasketBundle/Entity/BaseBasketElement.php
@@ -19,14 +19,12 @@ use Sonata\Component\Basket\BasketInterface;
 abstract class BaseBasketElement extends BasketElement
 {
     /**
-     * @var \Sonata\Component\Basket\BasketInterface
+     * @var BasketInterface
      */
     protected $basket;
 
     /**
-     * Get basket.
-     *
-     * @return \Sonata\Component\Basket\BasketInterface $basket
+     * @return BasketInterface $basket
      */
     public function getBasket()
     {
@@ -34,9 +32,7 @@ abstract class BaseBasketElement extends BasketElement
     }
 
     /**
-     * Set basket.
-     *
-     * @param \Sonata\Component\Basket\BasketInterface $basket
+     * @param BasketInterface $basket
      */
     public function setBasket(BasketInterface $basket): void
     {

--- a/src/BasketBundle/Twig/GlobalVariables.php
+++ b/src/BasketBundle/Twig/GlobalVariables.php
@@ -13,22 +13,36 @@ declare(strict_types=1);
 
 namespace Sonata\BasketBundle\Twig;
 
+use Sonata\Component\Basket\Basket;
+use Sonata\Component\Customer\CustomerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class GlobalVariables
 {
+    /**
+     * @var ContainerInterface
+     */
     protected $container;
 
+    /**
+     * @param ContainerInterface $container
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }
 
+    /**
+     * @return Basket
+     */
     public function getBasket()
     {
         return $this->container->get('sonata.basket');
     }
 
+    /**
+     * @return CustomerInterface
+     */
     public function getCustomer()
     {
         return $this->getBasket()->getCustomer();

--- a/src/Component/Basket/BaseBasketFactory.php
+++ b/src/Component/Basket/BaseBasketFactory.php
@@ -29,22 +29,22 @@ abstract class BaseBasketFactory implements BasketFactoryInterface, LogoutHandle
     public const SESSION_BASE_NAME = 'sonata/basket/factory/customer/';
 
     /**
-     * @var \Sonata\Component\Basket\BasketManagerInterface
+     * @var BasketManagerInterface
      */
     protected $basketManager;
 
     /**
-     * @var \Sonata\Component\Basket\BasketBuilderInterface
+     * @var BasketBuilderInterface
      */
     protected $basketBuilder;
 
     /**
-     * @var \Sonata\Component\Currency\CurrencyDetectorInterface
+     * @var CurrencyDetectorInterface
      */
     protected $currencyDetector;
 
     /**
-     * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
+     * @var SessionInterface
      */
     protected $session;
 
@@ -121,7 +121,7 @@ abstract class BaseBasketFactory implements BasketFactoryInterface, LogoutHandle
     /**
      * Get the name of the session variable.
      *
-     * @param \Sonata\Component\Customer\CustomerInterface $customer
+     * @param CustomerInterface $customer
      *
      * @return string
      */

--- a/src/Component/Basket/Basket.php
+++ b/src/Component/Basket/Basket.php
@@ -27,7 +27,7 @@ use Sonata\Component\Product\ProductInterface;
 class Basket implements \Serializable, BasketInterface
 {
     /**
-     * @var array
+     * @var BasketElementInterface[]
      */
     protected $basketElements;
 

--- a/src/Component/Basket/BasketBuilder.php
+++ b/src/Component/Basket/BasketBuilder.php
@@ -21,33 +21,37 @@ use Sonata\Component\Product\Pool;
 class BasketBuilder implements BasketBuilderInterface
 {
     /**
-     * @var \Sonata\Component\Product\Pool
+     * @var Pool
      */
     protected $productPool;
 
     /**
-     * @var \Sonata\Component\Customer\AddressManagerInterface
+     * @var AddressManagerInterface
      */
     protected $addressManager;
 
     /**
-     * @var \Sonata\Component\Delivery\Pool
+     * @var DeliveryPool
      */
     protected $deliveryPool;
 
     /**
-     * @var \Sonata\Component\Payment\Pool
+     * @var PaymentPool
      */
     protected $paymentPool;
 
     /**
-     * @param \Sonata\Component\Product\Pool                     $productPool
-     * @param \Sonata\Component\Customer\AddressManagerInterface $addressManager
-     * @param \Sonata\Component\Delivery\Pool                    $deliveryPool
-     * @param \Sonata\Component\Payment\Pool                     $paymentPool
+     * @param Pool                    $productPool
+     * @param AddressManagerInterface $addressManager
+     * @param DeliveryPool            $deliveryPool
+     * @param PaymentPool             $paymentPool
      */
-    public function __construct(Pool $productPool, AddressManagerInterface $addressManager, DeliveryPool $deliveryPool, PaymentPool $paymentPool)
-    {
+    public function __construct(
+        Pool $productPool,
+        AddressManagerInterface $addressManager,
+        DeliveryPool $deliveryPool,
+        PaymentPool $paymentPool
+    ) {
         $this->productPool = $productPool;
         $this->addressManager = $addressManager;
         $this->deliveryPool = $deliveryPool;
@@ -57,7 +61,7 @@ class BasketBuilder implements BasketBuilderInterface
     /**
      * Build a basket.
      *
-     * @param \Sonata\Component\Basket\BasketInterface $basket
+     * @param BasketInterface $basket
      *
      * @throws \RuntimeException
      */

--- a/src/Component/Basket/BasketBuilderInterface.php
+++ b/src/Component/Basket/BasketBuilderInterface.php
@@ -18,7 +18,7 @@ interface BasketBuilderInterface
     /**
      * Build a basket.
      *
-     * @param \Sonata\Component\Basket\BasketInterface $basket
+     * @param BasketInterface $basket
      */
     public function build(BasketInterface $basket);
 }

--- a/src/Component/Basket/BasketElementInterface.php
+++ b/src/Component/Basket/BasketElementInterface.php
@@ -16,6 +16,8 @@ namespace Sonata\Component\Basket;
 use Sonata\Component\Product\PriceComputableInterface;
 use Sonata\Component\Product\ProductDefinition;
 use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductManagerInterface;
+use Sonata\Component\Product\ProductProviderInterface;
 
 interface BasketElementInterface extends PriceComputableInterface
 {
@@ -152,17 +154,17 @@ interface BasketElementInterface extends PriceComputableInterface
     public function getDelete();
 
     /**
-     * @param \Sonata\Component\Product\ProductDefinition $productDefinition
+     * @param ProductDefinition $productDefinition
      */
     public function setProductDefinition(ProductDefinition $productDefinition);
 
     /**
-     * @return \Sonata\Component\Product\ProductManagerInterface
+     * @return ProductManagerInterface
      */
     public function getProductManager();
 
     /**
-     * @return \Sonata\Component\Product\ProductProviderInterface
+     * @return ProductProviderInterface
      */
     public function getProductProvider();
 

--- a/src/Component/Basket/BasketFactoryInterface.php
+++ b/src/Component/Basket/BasketFactoryInterface.php
@@ -20,16 +20,16 @@ interface BasketFactoryInterface
     /**
      * Load the basket.
      *
-     * @param \Sonata\Component\Customer\CustomerInterface
+     * @param CustomerInterface $customer
      *
-     * @return \Sonata\Component\Basket\BasketInterface
+     * @return BasketInterface
      */
     public function load(CustomerInterface $customer);
 
     /**
      * Save the basket.
      *
-     * @param \Sonata\Component\Basket\BasketInterface
+     * @param BasketInterface $basket
      */
     public function save(BasketInterface $basket);
 

--- a/src/Component/Basket/BasketInterface.php
+++ b/src/Component/Basket/BasketInterface.php
@@ -24,12 +24,12 @@ use Sonata\Component\Product\ProductInterface;
 interface BasketInterface
 {
     /**
-     * @param \Sonata\Component\Product\Pool $pool
+     * @param Pool $pool
      */
     public function setProductPool(Pool $pool);
 
     /**
-     * @return \Sonata\Component\Product\Pool
+     * @return Pool
      */
     public function getProductPool();
 
@@ -52,8 +52,6 @@ interface BasketInterface
     public function isValid($elementsOnly = false);
 
     /**
-     * set the Delivery method.
-     *
      * @param ServiceDeliveryInterface $method
      */
     public function setDeliveryMethod(ServiceDeliveryInterface $method = null);
@@ -64,61 +62,53 @@ interface BasketInterface
     public function getDeliveryMethod();
 
     /**
-     * set the Delivery address.
-     *
-     * @param \Sonata\Component\Customer\AddressInterface $address
+     * @param AddressInterface $address
      */
     public function setDeliveryAddress(AddressInterface $address = null);
 
     /**
-     * @return \Sonata\Component\Customer\AddressInterface
+     * @return AddressInterface
      */
     public function getDeliveryAddress();
 
     /**
-     * set Payment method.
-     *
-     * @param \Sonata\Component\Payment\PaymentInterface $method
+     * @param PaymentInterface $method
      */
     public function setPaymentMethod(PaymentInterface $method = null);
 
     /**
-     * @return \Sonata\Component\Payment\PaymentInterface
+     * @return PaymentInterface
      */
     public function getPaymentMethod();
 
     /**
-     * set the Payment address.
-     *
-     * @param \Sonata\Component\Customer\AddressInterface $address
+     * @param AddressInterface $address
      */
     public function setBillingAddress(AddressInterface $address = null);
 
     /**
-     * @return \Sonata\Component\Customer\AddressInterface
+     * @return AddressInterface
      */
     public function getBillingAddress();
 
     /**
      * Check if the product can be added to the basket.
      *
-     * @param \Sonata\Component\Product\ProductInterface $product
+     * @param ProductInterface $product
      *
      * @return bool
      */
     public function isAddable(ProductInterface $product);
 
     /**
-     * reset basket.
+     * Reset basket.
      *
      * @param bool $full
      */
     public function reset($full = true);
 
     /**
-     * return BasketElements.
-     *
-     * @return \Sonata\Component\Basket\BasketElementInterface[]
+     * @return BasketElementInterface[]
      */
     public function getBasketElements();
 
@@ -293,12 +283,12 @@ interface BasketInterface
     public function getDeliveryMethodCode();
 
     /**
-     * @param \Sonata\Component\Customer\CustomerInterface $customer
+     * @param CustomerInterface $customer
      */
     public function setCustomer(CustomerInterface $customer = null);
 
     /**
-     * @param \Sonata\Component\Customer\CustomerInterface
+     * @param CustomerInterface
      */
     public function getCustomer();
 

--- a/src/Component/Basket/BasketManagerInterface.php
+++ b/src/Component/Basket/BasketManagerInterface.php
@@ -20,7 +20,7 @@ use Sonata\CoreBundle\Model\PageableManagerInterface;
 interface BasketManagerInterface extends ManagerInterface, PageableManagerInterface
 {
     /**
-     * @param \Sonata\Component\Customer\CustomerInterface $customer
+     * @param CustomerInterface $customer
      *
      * @return BasketInterface|null
      */

--- a/src/Component/Basket/Loader.php
+++ b/src/Component/Basket/Loader.php
@@ -18,23 +18,23 @@ use Sonata\Component\Customer\CustomerSelectorInterface;
 class Loader
 {
     /**
-     * @var \Sonata\Component\Basket\BasketFactoryInterface
+     * @var BasketFactoryInterface
      */
     protected $basketFactory;
 
     /**
-     * @var \Sonata\Component\Customer\CustomerSelectorInterface
+     * @var CustomerSelectorInterface
      */
     protected $customerSelector;
 
     /**
-     * @var \Sonata\Component\Basket\BasketInterface
+     * @var BasketInterface
      */
     protected $basket;
 
     /**
-     * @param \Sonata\Component\Basket\BasketFactoryInterface      $basketFactory
-     * @param \Sonata\Component\Customer\CustomerSelectorInterface $customerSelector
+     * @param BasketFactoryInterface    $basketFactory
+     * @param CustomerSelectorInterface $customerSelector
      */
     public function __construct(BasketFactoryInterface $basketFactory, CustomerSelectorInterface $customerSelector)
     {
@@ -47,7 +47,7 @@ class Loader
      *
      * @throws \Exception|\RuntimeException
      *
-     * @return \Sonata\Component\Basket\BasketInterface
+     * @return BasketInterface
      */
     public function getBasket()
     {

--- a/src/Component/Currency/Currency.php
+++ b/src/Component/Currency/Currency.php
@@ -24,10 +24,8 @@ class Currency implements CurrencyInterface
     protected $label;
 
     /**
-     * @var string
+     * @return string
      */
-    //     protected $symbol;
-
     public function __toString()
     {
         return $this->getLabel();
@@ -43,6 +41,8 @@ class Currency implements CurrencyInterface
 
     /**
      * @param string $label
+     *
+     * @return Currency
      */
     public function setLabel($label)
     {
@@ -62,21 +62,4 @@ class Currency implements CurrencyInterface
 
         return $this->getLabel() === $currency->getLabel();
     }
-
-    /*
-     * {@inheritdoc}
-     */
-//     public function getSymbol()
-//     {
-//         return $this->symbol;
-//     }
-
-    /*
-     * @param string $symbol
-     */
-//     public function setSymbol($symbol)
-//     {
-//         $this->symbol = $symbol;
-//         return $this;
-//     }
 }

--- a/src/Component/Currency/CurrencyInterface.php
+++ b/src/Component/Currency/CurrencyInterface.php
@@ -33,11 +33,4 @@ interface CurrencyInterface
      * @return bool
      */
     public function equals($currency);
-
-    /*
-     * Returns currency's symbol
-     *
-     * @return string
-     */
-//     public function getSymbol();
 }

--- a/src/Component/Currency/UnavailableForCurrencyException.php
+++ b/src/Component/Currency/UnavailableForCurrencyException.php
@@ -20,6 +20,10 @@ use Sonata\Component\Product\ProductInterface;
  */
 class UnavailableForCurrencyException extends \Exception
 {
+    /**
+     * @param ProductInterface  $product
+     * @param CurrencyInterface $currency
+     */
     public function __construct(ProductInterface $product, CurrencyInterface $currency)
     {
         parent::__construct(sprintf("Product '%s' is not available for currency '%s'", $product->getName(), $currency->getLabel()));

--- a/src/Component/Customer/AddressInterface.php
+++ b/src/Component/Customer/AddressInterface.php
@@ -22,83 +22,77 @@ interface AddressInterface
     public function getId();
 
     /**
-     * @return string return the address name
+     * @return string
      */
     public function getName();
 
     /**
-     * @return string return the address firstname
+     * @return string
      */
     public function getFirstname();
 
     /**
-     * @return string return the address lastname
+     * @return string
      */
     public function getLastname();
 
     /**
-     * @return string return the address (line 1)
+     * @return string
      */
     public function getAddress1();
 
     /**
-     * @return string return the address (line 2)
+     * @return string
      */
     public function getAddress2();
 
     /**
-     * @return string return the address (line 3)
+     * @return string
      */
     public function getAddress3();
 
     /**
-     * @return string return the postcode
+     * @return string
      */
     public function getPostcode();
 
     /**
-     * @return string return the city
+     * @return string
      */
     public function getCity();
 
     /**
-     * @return string return the ISO country code
+     * @return string
      */
     public function getCountryCode();
 
     /**
-     * @return string return the phone number linked to the address
+     * @return string
      */
     public function getPhone();
 
     /**
-     * @return bool Is it the current address?
+     * @return bool
      */
     public function getCurrent();
 
     /**
-     * Sets if this address is the current.
-     *
      * @param bool $current
      */
     public function setCurrent($current);
 
     /**
-     * Gets address' customer.
-     *
      * @return CustomerInterface
      */
     public function getCustomer();
 
     /**
-     * Sets address' customer.
-     *
      * @param CustomerInterface $customer
      */
     public function setCustomer(CustomerInterface $customer);
 
     /**
-     * @return int Address' type
+     * @return int
      */
     public function getType();
 

--- a/src/Component/Customer/CustomerInterface.php
+++ b/src/Component/Customer/CustomerInterface.php
@@ -18,86 +18,62 @@ use Symfony\Component\Security\Core\User\UserInterface;
 interface CustomerInterface
 {
     /**
-     * Set createdAt.
-     *
      * @param \DateTime|null $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
-     * Get createdAt.
-     *
      * @return \DateTime createdAt
      */
     public function getCreatedAt();
 
     /**
-     * Set firstname.
-     *
      * @param string $firstname
      */
     public function setFirstname($firstname);
 
     /**
-     * Get firstname.
-     *
-     * @return string $firstname
+     * @return string
      */
     public function getFirstname();
 
     /**
-     * Get full name.
-     *
      * @return string
      */
     public function getFullname();
 
     /**
-     * Set lastname.
-     *
      * @param string $lastname
      */
     public function setLastname($lastname);
 
     /**
-     * Get lastname.
-     *
-     * @return string $lastname
+     * @return string
      */
     public function getLastname();
 
     /**
-     * Set updatedAt.
-     *
      * @param \DateTime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
-     * Get updatedAt.
-     *
-     * @return \DateTime $updatedAt
+     * @return \DateTime
      */
     public function getUpdatedAt();
 
     /**
-     * Set user.
-     *
      * @param UserInterface $user
      */
     public function setUser(UserInterface $user);
 
     /**
-     * Get user.
-     *
-     * @return UserInterface $user
+     * @return UserInterface
      */
     public function getUser();
 
     /**
-     * Get id.
-     *
-     * @return int $id
+     * @return int
      */
     public function getId();
 
@@ -117,14 +93,14 @@ interface CustomerInterface
     public function setLocale($locale);
 
     /**
-     * @param $type
+     * @param int $type
      *
-     * @return array
+     * @return AddressInterface[]
      */
     public function getAddressesByType($type);
 
     /**
-     * @return array
+     * @return AddressInterface[]
      */
     public function getAddresses();
 }

--- a/src/Component/Customer/CustomerSelector.php
+++ b/src/Component/Customer/CustomerSelector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Customer;
 
+use Sonata\Component\Basket\BasketInterface;
 use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -22,12 +23,12 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class CustomerSelector implements CustomerSelectorInterface
 {
     /**
-     * @var \Sonata\Component\Customer\CustomerManagerInterface
+     * @var CustomerManagerInterface
      */
     private $customerManager;
 
     /**
-     * @var \Symfony\Component\HttpFoundation\Session\Session
+     * @var SessionInterface
      */
     private $session;
 
@@ -72,7 +73,7 @@ class CustomerSelector implements CustomerSelectorInterface
      *
      * @throws \RuntimeException
      *
-     * @return \Sonata\Component\Customer\CustomerInterface
+     * @return CustomerInterface
      */
     public function get()
     {
@@ -116,7 +117,7 @@ class CustomerSelector implements CustomerSelectorInterface
     }
 
     /**
-     * @return \Sonata\Component\Basket\BasketInterface
+     * @return BasketInterface
      */
     private function getBasket()
     {

--- a/src/Component/Customer/CustomerSelectorInterface.php
+++ b/src/Component/Customer/CustomerSelectorInterface.php
@@ -18,7 +18,7 @@ interface CustomerSelectorInterface
     /**
      * Get the customer.
      *
-     * @return \Sonata\Component\Customer\CustomerInterface
+     * @return CustomerInterface
      */
     public function get();
 }

--- a/src/Component/Delivery/Selector.php
+++ b/src/Component/Delivery/Selector.php
@@ -40,8 +40,8 @@ class Selector implements ServiceDeliverySelectorInterface
     protected $logger;
 
     /**
-     * @param \Sonata\Component\Delivery\Pool $deliveryPool
-     * @param \Sonata\Component\Product\Pool  $productPool
+     * @param DeliveryPool $deliveryPool
+     * @param ProductPool  $productPool
      */
     public function __construct(DeliveryPool $deliveryPool, ProductPool $productPool)
     {

--- a/src/Component/Delivery/ServiceDeliverySelectorInterface.php
+++ b/src/Component/Delivery/ServiceDeliverySelectorInterface.php
@@ -19,8 +19,8 @@ use Sonata\Component\Customer\AddressInterface;
 interface ServiceDeliverySelectorInterface
 {
     /**
-     * @param null|\Sonata\Component\Basket\BasketInterface    $basket
-     * @param null|\Sonata\Component\Customer\AddressInterface $deliveryAddress
+     * @param null|BasketInterface  $basket
+     * @param null|AddressInterface $deliveryAddress
      */
     public function getAvailableMethods(BasketInterface $basket = null, AddressInterface $deliveryAddress = null);
 }

--- a/src/Component/Event/AddBasketElementEvent.php
+++ b/src/Component/Event/AddBasketElementEvent.php
@@ -50,8 +50,12 @@ class AddBasketElementEvent extends Event
      * @param ProductInterface         $product
      * @param ProductProviderInterface $productProvider
      */
-    public function __construct(BasketInterface $basket, BasketElementInterface $basketElement, ProductInterface $product, ProductProviderInterface $productProvider)
-    {
+    public function __construct(
+        BasketInterface $basket,
+        BasketElementInterface $basketElement,
+        ProductInterface $product,
+        ProductProviderInterface $productProvider
+    ) {
         $this->basket = $basket;
         $this->basketElement = $basketElement;
         $this->product = $product;
@@ -59,7 +63,7 @@ class AddBasketElementEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Basket\BasketInterface
+     * @return BasketInterface
      */
     public function getBasket()
     {
@@ -67,7 +71,7 @@ class AddBasketElementEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Basket\BasketElementInterface
+     * @return BasketElementInterface
      */
     public function getBasketElement()
     {
@@ -75,7 +79,7 @@ class AddBasketElementEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Product\ProductInterface
+     * @return ProductInterface
      */
     public function getProduct()
     {
@@ -83,7 +87,7 @@ class AddBasketElementEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Product\ProductProviderInterface
+     * @return ProductProviderInterface
      */
     public function getProductProvider()
     {

--- a/src/Component/Event/BasketTransformEvent.php
+++ b/src/Component/Event/BasketTransformEvent.php
@@ -35,7 +35,7 @@ class BasketTransformEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Basket\BasketInterface
+     * @return BasketInterface
      */
     public function getBasket()
     {

--- a/src/Component/Event/BeforeCalculatePriceEvent.php
+++ b/src/Component/Event/BeforeCalculatePriceEvent.php
@@ -57,7 +57,7 @@ class BeforeCalculatePriceEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Currency\CurrencyInterface
+     * @return CurrencyInterface
      */
     public function getCurrency()
     {
@@ -65,7 +65,7 @@ class BeforeCalculatePriceEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Product\ProductInterface
+     * @return ProductInterface
      */
     public function getProduct()
     {

--- a/src/Component/Event/OrderTransformEvent.php
+++ b/src/Component/Event/OrderTransformEvent.php
@@ -35,7 +35,7 @@ class OrderTransformEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     public function getOrder()
     {

--- a/src/Component/Event/PaymentEvent.php
+++ b/src/Component/Event/PaymentEvent.php
@@ -51,7 +51,7 @@ class PaymentEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     public function getOrder()
     {
@@ -59,7 +59,7 @@ class PaymentEvent extends Event
     }
 
     /**
-     * @return \Sonata\Component\Payment\TransactionInterface
+     * @return TransactionInterface
      */
     public function getTransaction()
     {
@@ -67,7 +67,7 @@ class PaymentEvent extends Event
     }
 
     /**
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getResponse()
     {

--- a/src/Component/Form/EventListener/BasketResizeFormListener.php
+++ b/src/Component/Form/EventListener/BasketResizeFormListener.php
@@ -80,7 +80,7 @@ class BasketResizeFormListener implements EventSubscriberInterface
      * @param $form
      * @param $basketElements
      *
-     * @throws \Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @throws UnexpectedTypeException
      */
     private function buildBasketElements($form, $basketElements): void
     {

--- a/src/Component/Form/Transformer/QuantityTransformer.php
+++ b/src/Component/Form/Transformer/QuantityTransformer.php
@@ -25,7 +25,7 @@ class QuantityTransformer implements DataTransformerInterface
     /**
      * (non-PHPdoc).
      *
-     * @see \Symfony\Component\Form\DataTransformerInterface::transform()
+     * @see DataTransformerInterface::transform()
      */
     public function transform($quantity)
     {
@@ -35,7 +35,7 @@ class QuantityTransformer implements DataTransformerInterface
     /**
      * (non-PHPdoc).
      *
-     * @see \Symfony\Component\Form\DataTransformerInterface::reverseTransform()
+     * @see DataTransformerInterface::reverseTransform()
      */
     public function reverseTransform($quantity)
     {

--- a/src/Component/Generator/MysqlReference.php
+++ b/src/Component/Generator/MysqlReference.php
@@ -64,7 +64,7 @@ class MysqlReference implements ReferenceInterface
      *
      * @throws \Exception
      *
-     * @return Exception|string
+     * @return \Exception|string
      */
     protected function generateReference($object, $tableName)
     {

--- a/src/Component/Generator/ReferenceInterface.php
+++ b/src/Component/Generator/ReferenceInterface.php
@@ -21,8 +21,7 @@ interface ReferenceInterface
     /**
      * Append a valid reference number to the invoice, the order must be persisted first.
      *
-     *
-     * @param \Sonata\Component\Invoice\InvoiceInterface $invoice
+     * @param InvoiceInterface $invoice
      *
      * @throws \RuntimeException
      */
@@ -31,8 +30,7 @@ interface ReferenceInterface
     /**
      * Append a valid reference number to the order, the order must be persisted first.
      *
-     *
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      *
      * @throws \RuntimeException
      */

--- a/src/Component/Invoice/InvoiceElementInterface.php
+++ b/src/Component/Invoice/InvoiceElementInterface.php
@@ -47,71 +47,51 @@ interface InvoiceElementInterface extends PriceComputableInterface
     public function getUnitPriceInc();
 
     /**
-     * Set invoiceId.
-     *
      * @param InvoiceInterface $invoice
      */
     public function setInvoice(InvoiceInterface $invoice);
 
     /**
-     * Get invoice.
-     *
      * @return InvoiceInterface $invoice
      */
     public function getInvoice();
 
     /**
-     * Set orderElement.
-     *
      * @param OrderElementInterface $orderElement
      */
     public function setOrderElement(OrderElementInterface $orderElement);
 
     /**
-     * Get orderElement.
-     *
      * @return OrderElementInterface $orderElement
      */
     public function getOrderElement();
 
     /**
-     * Set total.
-     *
      * @param float $total
      */
     public function setTotal($total);
 
     /**
-     * Get total.
-     *
      * @return float $total
      */
     public function getTotal();
 
     /**
-     * Set designation.
-     *
      * @param string $designation
      */
     public function setDesignation($designation);
 
     /**
-     * Get designation.
-     *
      * @return string $designation
      */
     public function getDesignation();
 
     /**
-     * Set description.
-     *
      * @param string $description
      */
     public function setDescription($description);
 
     /**
-     * Get description.
-     *
      * @return string $description
      */
     public function getDescription();

--- a/src/Component/Invoice/InvoiceInterface.php
+++ b/src/Component/Invoice/InvoiceInterface.php
@@ -23,9 +23,7 @@ interface InvoiceInterface
     public const STATUS_CONFLICT = 2; // there is a conflict about this invoice
 
     /**
-     * Returns id.
-     *
-     * @return int $id
+     * @return int
      */
     public function getId();
 
@@ -40,288 +38,206 @@ interface InvoiceInterface
     public function setCreatedAt(\DateTime $createdAt);
 
     /**
-     * Set payment method.
-     *
      * @param string $paymentMethod
      */
     public function setPaymentMethod($paymentMethod);
 
     /**
-     * Get payment method.
-     *
      * @return string
      */
     public function getPaymentMethod();
 
     /**
-     * Set reference.
-     *
      * @param string $reference
      */
     public function setReference($reference);
 
     /**
-     * Get reference.
-     *
-     * @return string $reference
+     * @return string
      */
     public function getReference();
 
     /**
-     * Set currency.
-     *
      * @param CurrencyInterface $currency
      */
     public function setCurrency(CurrencyInterface $currency);
 
     /**
-     * Get currency.
-     *
-     * @return CurrencyInterface $currency
+     * @return CurrencyInterface
      */
     public function getCurrency();
 
     /**
-     * Set status.
-     *
      * @param int $status
      */
     public function setStatus($status);
 
     /**
-     * Get status.
-     *
-     * @return int $status
+     * @return int
      */
     public function getStatus();
 
     /**
-     * Set totalInc.
-     *
      * @param float $totalInc
      */
     public function setTotalInc($totalInc);
 
     /**
-     * Get totalInc.
-     *
-     * @return float $totalInc
+     * @return float
      */
     public function getTotalInc();
 
     /**
-     * Set totalExcl.
-     *
      * @param float $totalExcl
      */
     public function setTotalExcl($totalExcl);
 
     /**
-     * Get totalExcl.
-     *
-     * @return float $totalExcl
+     * @return float
      */
     public function getTotalExcl();
 
     /**
-     * Set name.
-     *
      * @param string $name
      */
     public function setName($name);
 
     /**
-     * Get name.
-     *
-     * @return string $name
+     * @return string
      */
     public function getName();
 
     /**
-     * Set phone.
-     *
      * @param string $phone
      */
     public function setPhone($phone);
 
     /**
-     * Get phone.
-     *
-     * @return string $phone
+     * @return string
      */
     public function getPhone();
 
     /**
-     * Set address1.
-     *
      * @param string $address1
      */
     public function setAddress1($address1);
 
     /**
-     * Get address1.
-     *
-     * @return string $address1
+     * @return string
      */
     public function getAddress1();
 
     /**
-     * Set address2.
-     *
      * @param string $address2
      */
     public function setAddress2($address2);
 
     /**
-     * Get address2.
-     *
-     * @return string $address2
+     * @return string
      */
     public function getAddress2();
 
     /**
-     * Set address3.
-     *
      * @param string $address3
      */
     public function setAddress3($address3);
 
     /**
-     * Get address3.
-     *
-     * @return string $address3
+     * @return string
      */
     public function getAddress3();
 
     /**
-     * Set city.
-     *
      * @param string $city
      */
     public function setCity($city);
 
     /**
-     * Get city.
-     *
-     * @return string $city
+     * @return string
      */
     public function getCity();
 
     /**
-     * Set postcode.
-     *
      * @param string $postcode
      */
     public function setPostcode($postcode);
 
     /**
-     * Get postcode.
-     *
-     * @return string $postcode
+     * @return string
      */
     public function getPostcode();
 
     /**
-     * Set country.
-     *
      * @param string $country
      */
     public function setCountry($country);
 
     /**
-     * Get country.
-     *
-     * @return string $country
+     * @return string
      */
     public function getCountry();
 
     /**
-     * Set fax.
-     *
      * @param string $fax
      */
     public function setFax($fax);
 
     /**
-     * Get fax.
-     *
-     * @return string $fax
+     * @return string
      */
     public function getFax();
 
     /**
-     * Set email.
-     *
      * @param string $email
      */
     public function setEmail($email);
 
     /**
-     * Get email.
-     *
-     * @return string $email
+     * @return string
      */
     public function getEmail();
 
     /**
-     * Set mobile.
-     *
      * @param string $mobile
      */
     public function setMobile($mobile);
 
     /**
-     * Get mobile.
-     *
-     * @return string $mobile
+     * @return string
      */
     public function getMobile();
 
     /**
-     * Set user.
-     *
      * @param CustomerInterface $customer
      */
     public function setCustomer(CustomerInterface $customer);
 
     /**
-     * Get user.
-     *
      * @return CustomerInterface
      */
     public function getCustomer();
 
     /**
-     * Gets the locale.
-     *
      * @return string
      */
     public function getLocale();
 
     /**
-     * Sets the locale.
-     *
      * @param string $locale
      */
     public function setLocale($locale);
 
     /**
-     * Returns all the invoice elements.
-     *
-     * @return array
+     * @return InvoiceElementInterface[]
      */
     public function getInvoiceElements();
 
     /**
-     * Adds an invoice element to the invoice.
-     *
      * @param InvoiceElementInterface $element
      */
     public function addInvoiceElement(InvoiceElementInterface $element);
 
     /**
-     * Sets the invoice elements collection.
-     *
      * @param array $elements
      */
     public function setInvoiceElements(array $elements);

--- a/src/Component/Order/OrderElementInterface.php
+++ b/src/Component/Order/OrderElementInterface.php
@@ -19,123 +19,91 @@ use Sonata\Component\Product\ProductInterface;
 interface OrderElementInterface extends PriceComputableInterface
 {
     /**
-     * Set order.
-     *
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      */
     public function setOrder(OrderInterface $order);
 
     /**
-     * Get order.
-     *
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     public function getOrder();
 
     /**
-     * Set designation.
-     *
      * @param string $designation
      */
     public function setDesignation($designation);
 
     /**
-     * Get designation.
-     *
-     * @return string $designation
+     * @return string
      */
     public function getDesignation();
 
     /**
-     * Set description.
-     *
      * @param string $description
      */
     public function setDescription($description);
 
     /**
-     * Get description.
-     *
-     * @return string $description
+     * @return string
      */
     public function getDescription();
 
     /**
-     * Set serialize.
-     *
-     * @param string $options
+     * @param array $options
      */
     public function setOptions($options);
 
     /**
-     * Get serialize.
-     *
-     * @return string $options
+     * @return array
      */
     public function getOptions();
 
     /**
-     * @param string $rawProduct
+     * @param array $rawProduct
      */
     public function setRawProduct($rawProduct);
 
     /**
-     * @return string
+     * @return array
      */
     public function getRawProduct();
 
     /**
-     * Set status.
-     *
      * @param int $status
      */
     public function setStatus($status);
 
     /**
-     * Get status.
-     *
-     * @return int $status
+     * @return int
      */
     public function getStatus();
 
     /**
-     * Set delivery_status.
-     *
      * @param int $deliveryStatus
      */
     public function setDeliveryStatus($deliveryStatus);
 
     /**
-     * Get delivery_status.
-     *
-     * @return int $deliveryStatus
+     * @return int
      */
     public function getDeliveryStatus();
 
     /**
-     * Set validated_at.
-     *
-     * @param \Datetime $validatedAt
+     * @param \Datetime|null $validatedAt
      */
     public function setValidatedAt(\DateTime $validatedAt = null);
 
     /**
-     * Get validated_at.
-     *
-     * @return \Datetime $validatedAt
+     * @return \Datetime
      */
     public function getValidatedAt();
 
     /**
-     * Add product.
-     *
      * @param ProductInterface $product
      */
     public function setProduct(ProductInterface $product);
 
     /**
-     * Get product.
-     *
      * @return ProductInterface $product
      */
     public function getProduct();
@@ -146,16 +114,12 @@ interface OrderElementInterface extends PriceComputableInterface
     public function getProductId();
 
     /**
-     * Set product_type.
-     *
      * @param string $productType
      */
     public function setProductType($productType);
 
     /**
-     * Get product_type.
-     *
-     * @return string $productType
+     * @return string
      */
     public function getProductType();
 
@@ -170,7 +134,7 @@ interface OrderElementInterface extends PriceComputableInterface
     public function getCreatedAt();
 
     /**
-     * @param \Datetime
+     * @param \Datetime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 

--- a/src/Component/Order/OrderInterface.php
+++ b/src/Component/Order/OrderInterface.php
@@ -26,63 +26,47 @@ interface OrderInterface
     public const STATUS_STOPPED = 5; // use if the subscription has been cancelled/stopped
 
     /**
-     * @return int the order id
+     * @return int
      */
     public function getId();
 
     /**
-     * Set reference.
-     *
      * @param string $reference
      */
     public function setReference($reference);
 
     /**
-     * Get reference.
-     *
-     * @return string $reference
+     * @return string
      */
     public function getReference();
 
     /**
-     * Set payment method.
-     *
      * @param string $paymentMethod
      */
     public function setPaymentMethod($paymentMethod);
 
     /**
-     * Get payment method.
-     *
      * @return string
      */
     public function getPaymentMethod();
 
     /**
-     * Set delivery method.
-     *
      * @param string $deliveryMethod
      */
     public function setDeliveryMethod($deliveryMethod);
 
     /**
-     * Get delivery method.
-     *
-     * @return string $deliveryMethod
+     * @return string
      */
     public function getDeliveryMethod();
 
     /**
-     * Set currency.
-     *
      * @param CurrencyInterface $currency
      */
     public function setCurrency(CurrencyInterface $currency);
 
     /**
-     * Get currency.
-     *
-     * @return CurrencyInterface $currency
+     * @return CurrencyInterface
      */
     public function getCurrency();
 
@@ -97,100 +81,72 @@ interface OrderInterface
     public function setLocale($locale);
 
     /**
-     * Set status.
-     *
      * @param int $status
      */
     public function setStatus($status);
 
     /**
-     * Get status.
-     *
-     * @return int $status
+     * @return int
      */
     public function getStatus();
 
     /**
-     * Set payment status.
-     *
      * @param int $paymentStatus
      */
     public function setPaymentStatus($paymentStatus);
 
     /**
-     * Get payment status.
-     *
-     * @return int $paymentStatus
+     * @return int
      */
     public function getPaymentStatus();
 
     /**
-     * Set delivery status.
-     *
      * @param int $deliveryStatus
      */
     public function setDeliveryStatus($deliveryStatus);
 
     /**
-     * Get delivery status.
-     *
-     * @return int $deliveryStatus
+     * @return int
      */
     public function getDeliveryStatus();
 
     /**
-     * Set validated at.
-     *
-     * @param \Datetime $validatedAt
+     * @param \Datetime|null $validatedAt
      */
     public function setValidatedAt(\DateTime $validatedAt = null);
 
     /**
-     * Get validated at.
-     *
-     * @return \Datetime $validatedAt
+     * @return \Datetime
      */
     public function getValidatedAt();
 
     /**
-     * Set username.
-     *
      * @param string $username
      */
     public function setUsername($username);
 
     /**
-     * Get username.
-     *
-     * @return string $username
+     * @return string
      */
     public function getUsername();
 
     /**
-     * Set totalInc.
-     *
      * @param float $totalInc
      */
     public function setTotalInc($totalInc);
 
     /**
-     * Get totalInc.
-     *
-     * @return float $totalInc
+     * @return float
      */
     public function getTotalInc();
 
     /**
-     * Set totalExcl.
-     *
      * @param float $totalExcl
      */
     public function setTotalExcl($totalExcl);
 
     /**
-     * Get totalExcl.
-     *
-     * @return float $totalExcl
+     * @return float
      */
     public function getTotalExcl();
 
@@ -202,336 +158,242 @@ interface OrderInterface
     public function setDeliveryCost($deliveryCost);
 
     /**
-     * Get delivery cost.
-     *
-     * @return float $deliveryCost
+     * @return float
      */
     public function getDeliveryCost();
 
     /**
-     * Set delivery VAT.
-     *
      * @param float $deliveryVat
      */
     public function setDeliveryVat($deliveryVat);
 
     /**
-     * Get delivery VAT.
-     *
-     * @return float $deliveryVat
+     * @return float
      */
     public function getDeliveryVat();
 
     /**
-     * Set billing name.
-     *
      * @param string $billingName
      */
     public function setBillingName($billingName);
 
     /**
-     * Get billing name.
-     *
-     * @return string $billingName
+     * @return string
      */
     public function getBillingName();
 
     /**
-     * Set billing phone.
-     *
      * @param string $billingPhone
      */
     public function setBillingPhone($billingPhone);
 
     /**
-     * Get billing phone.
-     *
-     * @return string $billingPhone
+     * @return string
      */
     public function getBillingPhone();
 
     /**
-     * Set billing address1.
-     *
      * @param string $billingAddress1
      */
     public function setBillingAddress1($billingAddress1);
 
     /**
-     * Get billing address1.
-     *
-     * @return string $billingAddress1
+     * @return string
      */
     public function getBillingAddress1();
 
     /**
-     * Set billing address2.
-     *
      * @param string $billingAddress2
      */
     public function setBillingAddress2($billingAddress2);
 
     /**
-     * Get billing address2.
-     *
-     * @return string $billingAddress2
+     * @return string
      */
     public function getBillingAddress2();
 
     /**
-     * Set billing address3.
-     *
      * @param string $billingAddress3
      */
     public function setBillingAddress3($billingAddress3);
 
     /**
-     * Get billing address3.
-     *
-     * @return string $billingAddress3
+     * @return string
      */
     public function getBillingAddress3();
 
     /**
-     * Set billing city.
-     *
      * @param string $billingCity
      */
     public function setBillingCity($billingCity);
 
     /**
-     * Get billing city.
-     *
-     * @return string $billingCity
+     * @return string
      */
     public function getBillingCity();
 
     /**
-     * Set billing postcode.
-     *
      * @param string $billingPostcode
      */
     public function setBillingPostcode($billingPostcode);
 
     /**
-     * Get billing postcode.
-     *
-     * @return string $billingPostcode
+     * @return string
      */
     public function getBillingPostcode();
 
     /**
-     * Set billing country code.
-     *
      * @param string $billingCountryCode
      */
     public function setBillingCountryCode($billingCountryCode);
 
     /**
-     * Get billing country.
-     *
-     * @return string $billingCountryCode
+     * @return string
      */
     public function getBillingCountryCode();
 
     /**
-     * Set billing fax.
-     *
      * @param string $billingFax
      */
     public function setBillingFax($billingFax);
 
     /**
-     * Get billing fax.
-     *
-     * @return string $billingFax
+     * @return string
      */
     public function getBillingFax();
 
     /**
-     * Set billing email.
-     *
      * @param string $billingEmail
      */
     public function setBillingEmail($billingEmail);
 
     /**
-     * Get billing email.
-     *
-     * @return string $billingEmail
+     * @return string
      */
     public function getBillingEmail();
 
     /**
-     * Set billing mobile.
-     *
      * @param string $billingMobile
      */
     public function setBillingMobile($billingMobile);
 
     /**
-     * Get billing mobile.
-     *
-     * @return string $billingMobile
+     * @return string
      */
     public function getBillingMobile();
 
     /**
-     * Set shipping name.
-     *
      * @param string $shippingName
      */
     public function setShippingName($shippingName);
 
     /**
-     * Get shipping name.
-     *
-     * @return string $shippingName
+     * @return string
      */
     public function getShippingName();
 
     /**
-     * Set shipping phone.
-     *
      * @param string $shippingPhone
      */
     public function setShippingPhone($shippingPhone);
 
     /**
-     * Get shipping phone.
-     *
-     * @return string $shippingPhone
+     * @return string
      */
     public function getShippingPhone();
 
     /**
-     * Set shipping address1.
-     *
      * @param string $shippingAddress1
      */
     public function setShippingAddress1($shippingAddress1);
 
     /**
-     * Get shipping address1.
-     *
-     * @return string $shippingAddress1
+     * @return string
      */
     public function getShippingAddress1();
 
     /**
-     * Set shipping address2.
-     *
      * @param string $shippingAddress2
      */
     public function setShippingAddress2($shippingAddress2);
 
     /**
-     * Get shipping address2.
-     *
-     * @return string $shippingAddress2
+     * @return string
      */
     public function getShippingAddress2();
 
     /**
-     * Set shipping address3.
-     *
      * @param string $shippingAddress3
      */
     public function setShippingAddress3($shippingAddress3);
 
     /**
-     * Get shipping address3.
-     *
-     * @return string $shippingAddress3
+     * @return string
      */
     public function getShippingAddress3();
 
     /**
-     * Set shipping city.
-     *
      * @param string $shippingCity
      */
     public function setShippingCity($shippingCity);
 
     /**
-     * Get shipping city.
-     *
-     * @return string $shippingCity
+     * @return string
      */
     public function getShippingCity();
 
     /**
-     * Set shipping postcode.
-     *
      * @param string $shippingPostcode
      */
     public function setShippingPostcode($shippingPostcode);
 
     /**
-     * Get shipping postcode.
-     *
-     * @return string $shippingPostcode
+     * @return string
      */
     public function getShippingPostcode();
 
     /**
-     * Set shipping country.
-     *
      * @param string $shippingCountryCode
      */
     public function setShippingCountryCode($shippingCountryCode);
 
     /**
-     * Get shipping country.
-     *
-     * @return string $shippingCountry
+     * @return string
      */
     public function getShippingCountryCode();
 
     /**
-     * Set shipping fax.
-     *
      * @param string $shippingFax
      */
     public function setShippingFax($shippingFax);
 
     /**
-     * Get shipping fax.
-     *
-     * @return string $shippingFax
+     * @return string
      */
     public function getShippingFax();
 
     /**
-     * Set shipping email.
-     *
      * @param string $shippingEmail
      */
     public function setShippingEmail($shippingEmail);
 
     /**
-     * Get shipping email.
-     *
-     * @return string $shippingEmail
+     * @return string
      */
     public function getShippingEmail();
 
     /**
-     * Set shipping mobile.
-     *
      * @param string $shippingMobile
      */
     public function setShippingMobile($shippingMobile);
 
     /**
-     * Get shipping mobile.
-     *
-     * @return string $shippingMobile
+     * @return string
      */
     public function getShippingMobile();
 
     /**
-     * @return array
+     * @return OrderElementInterface[]
      */
     public function getOrderElements();
 
@@ -563,8 +425,6 @@ interface OrderInterface
     public function isPending();
 
     /**
-     * Return true if the order is open.
-     *
      * @return bool
      */
     public function isOpen();
@@ -597,16 +457,12 @@ interface OrderInterface
     public function getUpdatedAt();
 
     /**
-     * Add order elements.
-     *
      * @param OrderElementInterface $orderElements
      */
     public function addOrderElements(OrderElementInterface $orderElements);
 
     /**
      * @param array $orderElements
-     *
-     * @return array
      */
     public function setOrderElements($orderElements);
 

--- a/src/Component/Payment/BasePayment.php
+++ b/src/Component/Payment/BasePayment.php
@@ -39,7 +39,7 @@ abstract class BasePayment implements PaymentInterface
     protected $transformers;
 
     /**
-     * @var \Psr\Log\LoggerInterface;
+     * @var LoggerInterface;
      */
     protected $logger;
 
@@ -54,7 +54,7 @@ abstract class BasePayment implements PaymentInterface
     protected $enabled;
 
     /**
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      *
      * @throws \RuntimeException
      *

--- a/src/Component/Payment/BasePaypal.php
+++ b/src/Component/Payment/BasePaypal.php
@@ -57,8 +57,8 @@ abstract class BasePaypal extends BasePayment
     protected $webConnectorProvider = null;
 
     /**
-     * @param \Symfony\Component\Routing\RouterInterface              $router
-     * @param null|\Symfony\Component\Translation\TranslatorInterface $translator
+     * @param RouterInterface          $router
+     * @param null|TranslatorInterface $translator
      */
     public function __construct(RouterInterface $router, TranslatorInterface $translator = null)
     {
@@ -120,7 +120,7 @@ abstract class BasePaypal extends BasePayment
     /**
      * Check openssl configuration, throw an RuntimeException if something is wrong.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function checkPaypalFiles(): void
     {
@@ -201,7 +201,6 @@ abstract class BasePaypal extends BasePayment
     /**
      * Encrypt paypal information using openssl with a buffer.
      *
-     *
      * @param $hash
      *
      * @throws \RuntimeException
@@ -261,7 +260,6 @@ abstract class BasePaypal extends BasePayment
 
     /**
      * Encrypt paypal information using openssl with a temporary file.
-     *
      *
      * @param $hash
      *

--- a/src/Component/Payment/PassPayment.php
+++ b/src/Component/Payment/PassPayment.php
@@ -34,8 +34,8 @@ class PassPayment extends BasePayment
     protected $browser;
 
     /**
-     * @param \Symfony\Component\Routing\RouterInterface $router
-     * @param \Buzz\Browser                              $browser
+     * @param RouterInterface $router
+     * @param Browser         $browser
      */
     public function __construct(RouterInterface $router, Browser $browser = null)
     {

--- a/src/Component/Payment/PaymentHandler.php
+++ b/src/Component/Payment/PaymentHandler.php
@@ -69,8 +69,14 @@ class PaymentHandler implements PaymentHandlerInterface
      * @param BackendInterface            $notificationBackend
      * @param EventDispatcherInterface    $eventDispatcher
      */
-    public function __construct(OrderManagerInterface $orderManager, PaymentSelectorInterface $paymentSelector, ReferenceInterface $referenceGenerator, TransactionManagerInterface $transactionManager, BackendInterface $notificationBackend, EventDispatcherInterface $eventDispatcher)
-    {
+    public function __construct(
+        OrderManagerInterface $orderManager,
+        PaymentSelectorInterface $paymentSelector,
+        ReferenceInterface $referenceGenerator,
+        TransactionManagerInterface $transactionManager,
+        BackendInterface $notificationBackend,
+        EventDispatcherInterface $eventDispatcher
+    ) {
         $this->orderManager = $orderManager;
         $this->paymentSelector = $paymentSelector;
         $this->referenceGenerator = $referenceGenerator;
@@ -194,10 +200,10 @@ class PaymentHandler implements PaymentHandlerInterface
      *
      * @param TransactionInterface $transaction The request's transaction (will be linked to the order in the process)
      *
-     * @throws \Doctrine\ORM\EntityNotFoundException
+     * @throws EntityNotFoundException
      * @throws InvalidTransactionException
      *
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     protected function getValidOrder(TransactionInterface $transaction)
     {
@@ -233,7 +239,7 @@ class PaymentHandler implements PaymentHandlerInterface
      *
      * @throws PaymentNotFoundException
      *
-     * @return \Sonata\Component\Payment\TransactionInterface
+     * @return TransactionInterface
      */
     protected function createTransaction(Request $request)
     {

--- a/src/Component/Payment/PaymentHandlerInterface.php
+++ b/src/Component/Payment/PaymentHandlerInterface.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Payment;
 
+use Doctrine\ORM\EntityNotFoundException;
 use Sonata\Component\Basket\BasketInterface;
+use Sonata\Component\Order\OrderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 interface PaymentHandlerInterface
 {
@@ -24,10 +27,10 @@ interface PaymentHandlerInterface
      * @param Request         $request
      * @param BasketInterface $basket
      *
-     * @throws \Doctrine\ORM\EntityNotFoundException
+     * @throws EntityNotFoundException
      * @throws InvalidTransactionException
      *
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     public function handleError(Request $request, BasketInterface $basket);
 
@@ -36,10 +39,10 @@ interface PaymentHandlerInterface
      *
      * @param Request $request
      *
-     * @throws \Doctrine\ORM\EntityNotFoundException
+     * @throws EntityNotFoundException
      * @throws InvalidTransactionException
      *
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     public function handleConfirmation(Request $request);
 
@@ -48,7 +51,7 @@ interface PaymentHandlerInterface
      *
      * @param BasketInterface $basket
      *
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     public function getSendbankOrder(BasketInterface $basket);
 
@@ -57,7 +60,7 @@ interface PaymentHandlerInterface
      *
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getPaymentCallbackResponse(Request $request);
 }

--- a/src/Component/Payment/PaymentInterface.php
+++ b/src/Component/Payment/PaymentInterface.php
@@ -35,9 +35,9 @@ interface PaymentInterface
      * Send information to the bank, this method should handle
      * everything when called.
      *
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function sendbank(OrderInterface $order);
 
@@ -49,7 +49,7 @@ interface PaymentInterface
     public function callback(TransactionInterface $transaction);
 
     /**
-     * @param \Sonata\Component\Payment\TransactionInterface $transaction
+     * @param TransactionInterface $transaction
      *
      * @return bool true if callback ok else false
      */
@@ -58,18 +58,18 @@ interface PaymentInterface
     /**
      * Method called when an error occurs.
      *
-     * @param \Sonata\Component\Payment\TransactionInterface $transaction
+     * @param TransactionInterface $transaction
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function handleError(TransactionInterface $transaction);
 
     /**
      * Send post back confirmation to the bank when the bank callback the site.
      *
-     * @param \Sonata\Component\Payment\TransactionInterface $transaction
+     * @param TransactionInterface $transaction
      *
-     * @return \Symfony\Component\HttpFoundation\Response, false otherwise
+     * @return Response, false otherwise
      */
     public function sendConfirmationReceipt(TransactionInterface $transaction);
 
@@ -78,7 +78,7 @@ interface PaymentInterface
      *
      * WARNING : this methods does not check if the callback is valid
      *
-     * @param \Sonata\Component\Payment\TransactionInterface $transaction
+     * @param TransactionInterface $transaction
      *
      * @return bool true if all parameter are ok
      */
@@ -87,7 +87,7 @@ interface PaymentInterface
     /**
      * return true is the basket is valid for the current bank gateway.
      *
-     * @param \Sonata\Component\Basket\BasketInterface $basket
+     * @param BasketInterface $basket
      *
      * @return bool
      */
@@ -96,15 +96,15 @@ interface PaymentInterface
     /**
      * return true if the product can be added to the basket.
      *
-     * @param \Sonata\Component\Basket\BasketInterface   $basket
-     * @param \Sonata\Component\Product\ProductInterface $product
+     * @param BasketInterface  $basket
+     * @param ProductInterface $product
      */
     public function isAddableProduct(BasketInterface $basket, ProductInterface $product);
 
     /**
      * return the transaction id from the bank.
      *
-     * @param \Sonata\Component\Payment\TransactionInterface $transaction
+     * @param TransactionInterface $transaction
      */
     public function applyTransactionId(TransactionInterface $transaction);
 
@@ -120,7 +120,7 @@ interface PaymentInterface
     /**
      * return the order reference from the transaction.
      *
-     * @param \Sonata\Component\Payment\TransactionInterface $transaction
+     * @param TransactionInterface $transaction
      *
      * @return string
      */

--- a/src/Component/Payment/Scellius/NodeScelliusTransactionGenerator.php
+++ b/src/Component/Payment/Scellius/NodeScelliusTransactionGenerator.php
@@ -21,7 +21,7 @@ use Sonata\Component\Order\OrderInterface;
 class NodeScelliusTransactionGenerator implements ScelliusTransactionGeneratorInterface
 {
     /**
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      *
      * @return string
      */

--- a/src/Component/Payment/Scellius/OrderScelliusTransactionGenerator.php
+++ b/src/Component/Payment/Scellius/OrderScelliusTransactionGenerator.php
@@ -22,7 +22,7 @@ use Sonata\Component\Order\OrderInterface;
 class OrderScelliusTransactionGenerator implements ScelliusTransactionGeneratorInterface
 {
     /**
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      *
      * @throws \RuntimeException
      *

--- a/src/Component/Payment/Scellius/ScelliusPayment.php
+++ b/src/Component/Payment/Scellius/ScelliusPayment.php
@@ -412,7 +412,7 @@ class ScelliusPayment extends BasePayment
     }
 
     /**
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      *
      * @return string
      */

--- a/src/Component/Payment/Scellius/ScelliusTransactionGeneratorInterface.php
+++ b/src/Component/Payment/Scellius/ScelliusTransactionGeneratorInterface.php
@@ -18,7 +18,7 @@ use Sonata\Component\Order\OrderInterface;
 interface ScelliusTransactionGeneratorInterface
 {
     /**
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      *
      * @return string
      */

--- a/src/Component/Payment/Selector.php
+++ b/src/Component/Payment/Selector.php
@@ -68,7 +68,7 @@ class Selector implements PaymentSelectorInterface
     }
 
     /**
-     * @return \Sonata\Component\Product\Pool
+     * @return ProductPool
      */
     public function getProductPool()
     {

--- a/src/Component/Payment/TransactionInterface.php
+++ b/src/Component/Payment/TransactionInterface.php
@@ -42,12 +42,12 @@ interface TransactionInterface
     public const STATUS_ORDER_NOT_OPEN = 12; // the order is not open (so a previous transaction already alter the order)
 
     /**
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * @param OrderInterface $order
      */
     public function setOrder(OrderInterface $order);
 
     /**
-     * @return \Sonata\Component\Order\OrderInterface
+     * @return OrderInterface
      */
     public function getOrder();
 
@@ -105,8 +105,6 @@ interface TransactionInterface
     public function getStatusCode();
 
     /**
-     * return status list.
-     *
      * @return array
      */
     public static function getStatusList();

--- a/src/Component/Product/AddBasket.php
+++ b/src/Component/Product/AddBasket.php
@@ -41,7 +41,7 @@ class AddBasket
     private $quantity;
 
     /**
-     * @return int the product id
+     * @return int
      */
     public function getProductId()
     {
@@ -51,7 +51,7 @@ class AddBasket
     /**
      * The product id is only set if there is not product attached to this object.
      *
-     * @param int $productId the product id
+     * @param int $productId
      */
     public function setProductId($productId): void
     {
@@ -64,8 +64,6 @@ class AddBasket
     }
 
     /**
-     * Set the related product.
-     *
      * @param ProductInterface $product
      */
     public function setProduct(ProductInterface $product): void
@@ -75,8 +73,6 @@ class AddBasket
     }
 
     /**
-     * Set the quantity.
-     *
      * @param int $quantity
      */
     public function setQuantity($quantity): void
@@ -85,7 +81,7 @@ class AddBasket
     }
 
     /**
-     * @return the quantity
+     * @return int
      */
     public function getQuantity()
     {

--- a/src/Component/Product/DeliveryInterface.php
+++ b/src/Component/Product/DeliveryInterface.php
@@ -16,114 +16,82 @@ namespace Sonata\Component\Product;
 interface DeliveryInterface
 {
     /**
-     * Set product.
-     *
      * @param ProductInterface $product
      */
     public function setProduct(ProductInterface $product);
 
     /**
-     * Get product.
-     *
      * @return ProductInterface
      */
     public function getProduct();
 
     /**
-     * Set class_name.
-     *
      * @param string $code
      */
     public function setCode($code);
 
     /**
-     * Get class_name.
-     *
-     * @return string $className
+     * @return string
      */
     public function getCode();
 
     /**
-     * Set per_item.
-     *
      * @param bool $perItem
      */
     public function setPerItem($perItem);
 
     /**
-     * Get per_item.
-     *
-     * @return bool $perItem
+     * @return bool
      */
     public function getPerItem();
 
     /**
-     * Set country code.
-     *
      * @param string $countryCode
      */
     public function setCountryCode($countryCode);
 
     /**
-     * Get country.
-     *
-     * @return string $country
+     * @return string
      */
     public function getCountryCode();
 
     /**
-     * Set zone.
-     *
      * @param string $zone
      */
     public function setZone($zone);
 
     /**
-     * Get zone.
-     *
-     * @return string $zone
+     * @return string
      */
     public function getZone();
 
     /**
-     * Set enabled.
-     *
      * @param bool $enabled
      */
     public function setEnabled($enabled);
 
     /**
-     * Get enabled.
-     *
-     * @return bool $enabled
+     * @return bool
      */
     public function getEnabled();
 
     /**
-     * Set updatedAt.
-     *
-     * @param \Datetime $updatedAt
+     * @param \Datetime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
-     * Get updatedAt.
-     *
-     * @return \Datetime $updatedAt
+     * @return \Datetime
      */
     public function getUpdatedAt();
 
     /**
-     * Set createdAt.
-     *
-     * @param \Datetime $createdAt
+     * @param \Datetime|null $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
-     * Get createdAt.
-     *
-     * @return \Datetime $createdAt
+     * @return \Datetime
      */
     public function getCreatedAt();
 

--- a/src/Component/Product/PackageInterface.php
+++ b/src/Component/Product/PackageInterface.php
@@ -16,114 +16,82 @@ namespace Sonata\Component\Product;
 interface PackageInterface
 {
     /**
-     * Set productId.
-     *
      * @param ProductInterface $product
      */
     public function setProduct(ProductInterface $product);
 
     /**
-     * Get productId.
-     *
      * @return ProductInterface
      */
     public function getProduct();
 
     /**
-     * Set width.
-     *
      * @param float $width
      */
     public function setWidth($width);
 
     /**
-     * Get width.
-     *
-     * @return float $width
+     * @return float
      */
     public function getWidth();
 
     /**
-     * Set height.
-     *
      * @param float $height
      */
     public function setHeight($height);
 
     /**
-     * Get height.
-     *
-     * @return float $height
+     * @return float
      */
     public function getHeight();
 
     /**
-     * Set length.
-     *
      * @param float $length
      */
     public function setLength($length);
 
     /**
-     * Get length.
-     *
-     * @return float $length
+     * @return float
      */
     public function getLength();
 
     /**
-     * Set weight.
-     *
      * @param float $weight
      */
     public function setWeight($weight);
 
     /**
-     * Get weight.
-     *
-     * @return float $weight
+     * @return float
      */
     public function getWeight();
 
     /**
-     * Set enabled.
-     *
      * @param bool $enabled
      */
     public function setEnabled($enabled);
 
     /**
-     * Get enabled.
-     *
-     * @return bool $enabled
+     * @return bool
      */
     public function getEnabled();
 
     /**
-     * Set updatedAt.
-     *
-     * @param \Datetime $updatedAt
+     * @param \Datetime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
-     * Get updatedAt.
-     *
-     * @return \Datetime $updatedAt
+     * @return \Datetime
      */
     public function getUpdatedAt();
 
     /**
-     * Set createdAt.
-     *
-     * @param \Datetime $createdAt
+     * @param \Datetime|null $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
-     * Get createdAt.
-     *
-     * @return \Datetime $createdAt
+     * @return \Datetime
      */
     public function getCreatedAt();
 }

--- a/src/Component/Product/Pool.php
+++ b/src/Component/Product/Pool.php
@@ -23,8 +23,8 @@ class Pool
     /**
      * add a delivery method into the pool.
      *
-     * @param string                                      $code
-     * @param \Sonata\Component\Product\ProductDefinition $productDescription
+     * @param string            $code
+     * @param ProductDefinition $productDescription
      */
     public function addProduct($code, ProductDefinition $productDescription): void
     {
@@ -36,7 +36,7 @@ class Pool
      *
      * @throws \RuntimeException
      *
-     * @return \Sonata\Component\Product\ProductProviderInterface
+     * @return ProductProviderInterface
      */
     public function getProvider($code)
     {
@@ -56,7 +56,7 @@ class Pool
      *
      * @throws \RuntimeException
      *
-     * @return \Sonata\Component\Product\ProductManagerInterface
+     * @return ProductManagerInterface
      */
     public function getManager($code)
     {
@@ -113,7 +113,7 @@ class Pool
      *
      * @throws \RuntimeException
      *
-     * @return \Sonata\Component\Product\ProductDefinition
+     * @return ProductDefinition
      */
     public function getProduct($code)
     {

--- a/src/Component/Product/PriceComputableInterface.php
+++ b/src/Component/Product/PriceComputableInterface.php
@@ -34,8 +34,6 @@ interface PriceComputableInterface
     public function getUnitPrice($vat = false);
 
     /**
-     * Sets price.
-     *
      * @param float $price
      */
     public function setPrice($price);
@@ -50,30 +48,22 @@ interface PriceComputableInterface
     public function getPrice($vat = false);
 
     /**
-     * Sets VAT rate.
-     *
      * @param float $vatRate
      */
     public function setVatRate($vatRate);
 
     /**
-     * Gets VAT rate.
-     *
      * @return float
      */
     public function getVatRate();
 
     /**
-     * Sets quantity.
-     *
      * @param int $quantity
      */
     public function setQuantity($quantity);
 
     /**
-     * Gets quantity.
-     *
-     * @return int $quantity
+     * @return int
      */
     public function getQuantity();
 }

--- a/src/Component/Product/ProductCategoryInterface.php
+++ b/src/Component/Product/ProductCategoryInterface.php
@@ -18,16 +18,12 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 interface ProductCategoryInterface
 {
     /**
-     * Set enabled.
-     *
      * @param bool $enabled
      */
     public function setEnabled($enabled);
 
     /**
-     * Get enabled.
-     *
-     * @return bool $enabled
+     * @return bool
      */
     public function getEnabled();
 
@@ -41,21 +37,17 @@ interface ProductCategoryInterface
     /**
      * Get if product category is the main category.
      *
-     * @return bool $main
+     * @return bool
      */
     public function getMain();
 
     /**
-     * Set updatedAt.
-     *
-     * @param \DateTime $updatedAt
+     * @param \DateTime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
-     * Get updatedAt.
-     *
-     * @return \DateTime $updatedAt
+     * @return \DateTime
      */
     public function getUpdatedAt();
 
@@ -67,37 +59,27 @@ interface ProductCategoryInterface
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
-     * Get createdAt.
-     *
-     * @return \Datetime $createdAt
+     * @return \Datetime
      */
     public function getCreatedAt();
 
     /**
-     * Set Product.
-     *
      * @param ProductInterface $product
      */
     public function setProduct(ProductInterface $product);
 
     /**
-     * Get Product.
-     *
      * @return ProductInterface
      */
     public function getProduct();
 
     /**
-     * Set Category.
-     *
      * @param CategoryInterface $category
      */
     public function setCategory(CategoryInterface $category);
 
     /**
-     * Get Category.
-     *
-     * @return CategoryInterface $category
+     * @return CategoryInterface
      */
     public function getCategory();
 }

--- a/src/Component/Product/ProductCategoryManagerInterface.php
+++ b/src/Component/Product/ProductCategoryManagerInterface.php
@@ -46,6 +46,7 @@ interface ProductCategoryManagerInterface extends ManagerInterface
      * Returns the number of products in $category (maxed by $limit).
      *
      * @param CategoryInterface $category
+     * @param int               $limit
      *
      * @return int
      */

--- a/src/Component/Product/ProductCollectionInterface.php
+++ b/src/Component/Product/ProductCollectionInterface.php
@@ -27,72 +27,52 @@ use Sonata\ClassificationBundle\Model\CollectionInterface;
 interface ProductCollectionInterface
 {
     /**
-     * Set enabled.
-     *
      * @param bool $enabled
      */
     public function setEnabled($enabled);
 
     /**
-     * Get enabled.
-     *
-     * @return bool $enabled
+     * @return bool
      */
     public function getEnabled();
 
     /**
-     * Set updatedAt.
-     *
-     * @param \DateTime $updatedAt
+     * @param \DateTime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
-     * Get updatedAt.
-     *
-     * @return \DateTime $updatedAt
+     * @return \DateTime
      */
     public function getUpdatedAt();
 
     /**
-     * Set createdAt.
-     *
-     * @param \DateTime $createdAt
+     * @param \DateTime|null $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
-     * Get createdAt.
-     *
-     * @return \Datetime $createdAt
+     * @return \Datetime
      */
     public function getCreatedAt();
 
     /**
-     * Set Product.
-     *
      * @param ProductInterface $product
      */
     public function setProduct(ProductInterface $product);
 
     /**
-     * Get Product.
-     *
      * @return ProductInterface
      */
     public function getProduct();
 
     /**
-     * Set Collection.
-     *
      * @param CollectionInterface $collection
      */
     public function setCollection(CollectionInterface $collection);
 
     /**
-     * Get Collection.
-     *
-     * @return CollectionInterface $collection
+     * @return CollectionInterface
      */
     public function getCollection();
 }

--- a/src/Component/Product/ProductInterface.php
+++ b/src/Component/Product/ProductInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Component\Product;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;

--- a/src/Component/Product/ProductManagerInterface.php
+++ b/src/Component/Product/ProductManagerInterface.php
@@ -21,20 +21,22 @@ interface ProductManagerInterface extends ManagerInterface, PageableManagerInter
     /**
      * Returns the products in the same collections as those specified in $productCollections.
      *
-     * @param mixed $productCollections
+     * @param mixed    $productCollections
+     * @param int|null $limit
      *
      * @return array
      */
-    public function findInSameCollections($productCollections);
+    public function findInSameCollections($productCollections, $limit = null);
 
     /**
      * Returns the parent products in the same collections as those specified in $productCollections.
      *
-     * @param mixed $productCollections
+     * @param mixed    $productCollections
+     * @param int|null $limit
      *
      * @return array
      */
-    public function findParentsInSameCollections($productCollections);
+    public function findParentsInSameCollections($productCollections, $limit = null);
 
     /**
      * Retrieve an active product from its id and its slug.

--- a/src/Component/Product/ProductProviderInterface.php
+++ b/src/Component/Product/ProductProviderInterface.php
@@ -27,12 +27,12 @@ use Symfony\Component\Form\FormBuilderInterface;
 interface ProductProviderInterface
 {
     /**
-     * @param \Sonata\Component\Basket\BasketElementManagerInterface $basketElementManager
+     * @param BasketElementManagerInterface $basketElementManager
      */
     public function setBasketElementManager(BasketElementManagerInterface $basketElementManager);
 
     /**
-     * @return \Sonata\Component\Basket\BasketElementManagerInterface
+     * @return BasketElementManagerInterface
      */
     public function getBasketElementManager();
 
@@ -62,40 +62,40 @@ interface ProductProviderInterface
     public function getBaseControllerName();
 
     /**
-     * @param \Sonata\Component\Product\ProductInterface $product      A Sonata product instance
-     * @param \Symfony\Component\Form\FormBuilder        $formBuilder  Symfony form builder
-     * @param bool                                       $showQuantity Specifies if quantity field will be displayed (default true)
-     * @param array                                      $options      An options array
+     * @param ProductInterface $product      A Sonata product instance
+     * @param FormBuilder      $formBuilder  Symfony form builder
+     * @param bool             $showQuantity Specifies if quantity field will be displayed (default true)
+     * @param array            $options      An options array
      */
     public function defineAddBasketForm(ProductInterface $product, FormBuilder $formBuilder, $showQuantity = true, array $options = []);
 
     /**
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement
-     * @param \Symfony\Component\Form\FormBuilder             $formBuilder
-     * @param array                                           $options
+     * @param BasketElementInterface $basketElement
+     * @param FormBuilder            $formBuilder
+     * @param array                  $options
      */
     public function defineBasketElementForm(BasketElementInterface $basketElement, FormBuilder $formBuilder, array $options = []);
 
     /**
      * return true if the basket element is still valid.
      *
-     * @param \Sonata\Component\Basket\BasketInterface        $basket
-     * @param ProductInterface                                $product
-     * @param \Sonata\Component\Basket\BasketElementInterface $newBasketElement
+     * @param BasketInterface        $basket
+     * @param ProductInterface       $product
+     * @param BasketElementInterface $newBasketElement
      */
     public function basketAddProduct(BasketInterface $basket, ProductInterface $product, BasketElementInterface $newBasketElement);
 
     /**
      * Merge a product with another when the product is already present into the basket.
      *
-     * @param \Sonata\Component\Basket\BasketInterface        $basket
-     * @param ProductInterface                                $product
-     * @param \Sonata\Component\Basket\BasketElementInterface $newBasketElement
+     * @param BasketInterface        $basket
+     * @param ProductInterface       $product
+     * @param BasketElementInterface $newBasketElement
      */
     public function basketMergeProduct(BasketInterface $basket, ProductInterface $product, BasketElementInterface $newBasketElement);
 
     /**
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement
+     * @param BasketElementInterface $basketElement
      *
      * @return bool true if the basket element is still valid
      */
@@ -125,9 +125,9 @@ interface ProductProviderInterface
     /**
      * Return true if the product can be added to the provided basket.
      *
-     * @param \Sonata\Component\Basket\BasketInterface   $basket
-     * @param \Sonata\Component\Product\ProductInterface $product
-     * @param array                                      $options
+     * @param BasketInterface  $basket
+     * @param ProductInterface $product
+     * @param array            $options
      *
      * @return bool
      */
@@ -142,7 +142,7 @@ interface ProductProviderInterface
     public function createBasketElement(ProductInterface $product = null, array $options = []);
 
     /**
-     * @param \Sonata\AdminBundle\Show\ShowMapper $showMapper
+     * @param ShowMapper $showMapper
      */
     public function configureShowFields(ShowMapper $showMapper);
 
@@ -167,9 +167,9 @@ interface ProductProviderInterface
     public function buildCreateForm(FormMapper $formMapper);
 
     /**
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement
-     * @param null|\Sonata\Component\Product\ProductInterface $product
-     * @param array                                           $options
+     * @param BasketElementInterface $basketElement
+     * @param null|ProductInterface  $product
+     * @param array                  $options
      */
     public function buildBasketElement(BasketElementInterface $basketElement, ProductInterface $product = null, array $options = []);
 
@@ -179,9 +179,9 @@ interface ProductProviderInterface
      *
      * If the basket is valid it will then replace the one in session
      *
-     * @param \Sonata\CoreBundle\Validator\ErrorElement       $errorElement
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement
-     * @param \Sonata\Component\Basket\BasketInterface        $basket
+     * @param ErrorElement           $errorElement
+     * @param BasketElementInterface $basketElement
+     * @param BasketInterface        $basket
      */
     public function validateFormBasketElement(ErrorElement $errorElement, BasketElementInterface $basketElement, BasketInterface $basket);
 
@@ -193,7 +193,7 @@ interface ProductProviderInterface
      *
      * @throws \RuntimeException
      *
-     * @return \Sonata\Component\Product\ProductInterface
+     * @return ProductInterface
      */
     public function createVariation(ProductInterface $product, $copyDependencies = true);
 
@@ -284,7 +284,7 @@ interface ProductProviderInterface
     /**
      * return the stock available for the current product.
      *
-     * @param \Sonata\Component\Product\ProductInterface $product
+     * @param ProductInterface $product
      *
      * @return int the stock available
      */

--- a/src/Component/Subscriber/ORMInheritanceSubscriber.php
+++ b/src/Component/Subscriber/ORMInheritanceSubscriber.php
@@ -16,6 +16,7 @@ namespace Sonata\Component\Subscriber;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\MappingException;
 
 class ORMInheritanceSubscriber implements EventSubscriber
 {
@@ -47,6 +48,8 @@ class ORMInheritanceSubscriber implements EventSubscriber
 
     /**
      * @param LoadClassMetadataEventArgs $eventArgs
+     *
+     * @throws MappingException
      */
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
     {

--- a/src/Component/Transformer/BaseTransformer.php
+++ b/src/Component/Transformer/BaseTransformer.php
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface;
 abstract class BaseTransformer
 {
     /**
-     * @var the transformer option
+     * @var array
      */
     protected $options;
 

--- a/src/Component/Transformer/BasketTransformer.php
+++ b/src/Component/Transformer/BasketTransformer.php
@@ -47,7 +47,7 @@ class BasketTransformer extends BaseTransformer
     protected $productPool;
 
     /**
-     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     * @var EventDispatcherInterface
      */
     protected $eventDispatcher;
 
@@ -57,8 +57,12 @@ class BasketTransformer extends BaseTransformer
      * @param EventDispatcherInterface $eventDispatcher
      * @param LoggerInterface          $logger
      */
-    public function __construct(OrderManagerInterface $orderManager, ProductPool $productPool, EventDispatcherInterface $eventDispatcher, LoggerInterface $logger = null)
-    {
+    public function __construct(
+        OrderManagerInterface $orderManager,
+        ProductPool $productPool,
+        EventDispatcherInterface $eventDispatcher,
+        LoggerInterface $logger = null
+    ) {
         $this->productPool = $productPool;
         $this->orderManager = $orderManager;
         $this->logger = $logger;
@@ -68,12 +72,11 @@ class BasketTransformer extends BaseTransformer
     /**
      * transform a basket into order.
      *
-     *
-     * @param null|\Sonata\Component\Basket\BasketInterface $basket
+     * @param null|BasketInterface $basket
      *
      * @throws \RuntimeException
      *
-     * @return null|\Sonata\Component\Order\OrderInterface
+     * @return null|OrderInterface
      */
     public function transformIntoOrder(BasketInterface $basket)
     {

--- a/src/Component/Transformer/InvoiceTransformer.php
+++ b/src/Component/Transformer/InvoiceTransformer.php
@@ -40,7 +40,7 @@ class InvoiceTransformer extends BaseTransformer
     protected $deliveryPool;
 
     /**
-     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     * @var EventDispatcherInterface
      */
     protected $eventDispatcher;
 
@@ -136,7 +136,7 @@ class InvoiceTransformer extends BaseTransformer
      *
      * @param OrderElementInterface $orderElement
      *
-     * @return \Sonata\Component\Invoice\InvoiceElementInterface
+     * @return InvoiceElementInterface
      */
     protected function createInvoiceElementFromOrderElement(OrderElementInterface $orderElement)
     {

--- a/src/Component/Transformer/Pool.php
+++ b/src/Component/Transformer/Pool.php
@@ -31,15 +31,15 @@ class Pool
      */
     public function addTransformer($type, BaseTransformer $instance): void
     {
-        $this->methods[$type] = $instance;
+        $this->transformer[$type] = $instance;
     }
 
     /**
-     * @return array of transformer methods
+     * @return array
      */
     public function getTransformers()
     {
-        return $this->methods;
+        return $this->transformer;
     }
 
     /**
@@ -51,6 +51,6 @@ class Pool
      */
     public function getTransformer($type)
     {
-        return isset($this->methods[$type]) ? $this->methods[$type] : null;
+        return isset($this->transformer[$type]) ? $this->transformer[$type] : null;
     }
 }

--- a/src/CustomerBundle/Admin/AddressAdmin.php
+++ b/src/CustomerBundle/Admin/AddressAdmin.php
@@ -36,7 +36,7 @@ class AddressAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Form\FormMapper $formMapper
+     * {@inheritdoc}
      */
     public function configureFormFields(FormMapper $formMapper): void
     {
@@ -81,7 +81,7 @@ class AddressAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Datagrid\ListMapper $list
+     * {@inheritdoc}
      */
     public function configureListFields(ListMapper $list): void
     {

--- a/src/CustomerBundle/Admin/CustomerAdmin.php
+++ b/src/CustomerBundle/Admin/CustomerAdmin.php
@@ -37,7 +37,7 @@ class CustomerAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Form\FormMapper $formMapper
+     * {@inheritdoc}
      */
     public function configureFormFields(FormMapper $formMapper): void
     {
@@ -71,7 +71,7 @@ class CustomerAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Datagrid\ListMapper $list
+     * {@inheritdoc}
      */
     public function configureListFields(ListMapper $list): void
     {
@@ -86,7 +86,7 @@ class CustomerAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Show\ShowMapper $filter
+     * {@inheritdoc}
      */
     public function configureShowFields(ShowMapper $filter): void
     {
@@ -110,7 +110,7 @@ class CustomerAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $filter
+     * {@inheritdoc}
      */
     public function configureDatagridFilters(DatagridMapper $filter): void
     {

--- a/src/CustomerBundle/Block/RecentCustomersBlockService.php
+++ b/src/CustomerBundle/Block/RecentCustomersBlockService.php
@@ -35,6 +35,7 @@ class RecentCustomersBlockService extends AbstractAdminBlockService
      * @param string                   $name
      * @param EngineInterface          $templating
      * @param CustomerManagerInterface $manager
+     * @param Pool|null                $adminPool
      */
     public function __construct($name, EngineInterface $templating, CustomerManagerInterface $manager, Pool $adminPool = null)
     {

--- a/src/CustomerBundle/DependencyInjection/Configuration.php
+++ b/src/CustomerBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addModelSection(ArrayNodeDefinition $node): void
     {

--- a/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
+++ b/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
@@ -64,8 +64,8 @@ class SonataCustomerExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param array                                                   $config
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
     public function registerParameters(ContainerBuilder $container, array $config): void
     {

--- a/src/CustomerBundle/Entity/BaseAddress.php
+++ b/src/CustomerBundle/Entity/BaseAddress.php
@@ -79,17 +79,17 @@ abstract class BaseAddress implements AddressInterface
     protected $phone;
 
     /**
-     * @var datetime
+     * @var \DateTime
      */
     protected $updatedAt;
 
     /**
-     * @var datetime
+     * @var \DateTime
      */
     protected $createdAt;
 
     /**
-     * @var
+     * @var CustomerInterface
      */
     protected $customer;
 
@@ -98,6 +98,9 @@ abstract class BaseAddress implements AddressInterface
         $this->setCurrent(false);
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return $this->getName();
@@ -166,6 +169,9 @@ abstract class BaseAddress implements AddressInterface
         $this->setUpdatedAt(new \DateTime());
     }
 
+    /**
+     * @return array
+     */
     public static function getTypesList()
     {
         return [
@@ -176,9 +182,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set current.
-     *
-     * @param bool $current
+     * {@inheritdoc}
      */
     public function setCurrent($current): void
     {
@@ -186,9 +190,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get current.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function getCurrent()
     {
@@ -196,8 +198,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set type.
-     *
      * @param int $type
      */
     public function setType($type): void
@@ -205,6 +205,9 @@ abstract class BaseAddress implements AddressInterface
         $this->type = $type;
     }
 
+    /**
+     * @return string|null
+     */
     public function getTypeCode()
     {
         $types = self::getTypesList();
@@ -213,9 +216,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get type.
-     *
-     * @return int $type
+     * {@inheritdoc}
      */
     public function getType()
     {
@@ -223,8 +224,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set firstname.
-     *
      * @param string $firstname
      */
     public function setFirstname($firstname): void
@@ -233,9 +232,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get firstname.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getFirstname()
     {
@@ -243,8 +240,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set lastname.
-     *
      * @param string $lastname
      */
     public function setLastname($lastname): void
@@ -253,9 +248,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get lastname.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getLastname()
     {
@@ -263,8 +256,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set address1.
-     *
      * @param string $address1
      */
     public function setAddress1($address1): void
@@ -273,9 +264,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get address1.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getAddress1()
     {
@@ -283,8 +272,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set address2.
-     *
      * @param string $address2
      */
     public function setAddress2($address2): void
@@ -293,9 +280,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get address2.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getAddress2()
     {
@@ -303,8 +288,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set address3.
-     *
      * @param string $address3
      */
     public function setAddress3($address3): void
@@ -313,9 +296,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get address3.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getAddress3()
     {
@@ -323,8 +304,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set postcode.
-     *
      * @param string $postcode
      */
     public function setPostcode($postcode): void
@@ -333,9 +312,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get postcode.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getPostcode()
     {
@@ -343,8 +320,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set city.
-     *
      * @param string $city
      */
     public function setCity($city): void
@@ -353,9 +328,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get city.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getCity()
     {
@@ -363,8 +336,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set countryCode.
-     *
      * @param string $countryCode
      */
     public function setCountryCode($countryCode): void
@@ -373,9 +344,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get countryCode.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getCountryCode()
     {
@@ -383,8 +352,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set phone.
-     *
      * @param string $phone
      */
     public function setPhone($phone): void
@@ -393,9 +360,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get phone.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getPhone()
     {
@@ -403,9 +368,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set updatedAt.
-     *
-     * @param \Datetime $updatedAt
+     * @param \Datetime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null): void
     {
@@ -413,8 +376,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get updatedAt.
-     *
      * @return \Datetime
      */
     public function getUpdatedAt()
@@ -423,9 +384,7 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Set createdAt.
-     *
-     * @param \Datetime $createdAt
+     * @param \Datetime|null $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt = null): void
     {
@@ -433,8 +392,6 @@ abstract class BaseAddress implements AddressInterface
     }
 
     /**
-     * Get createdAt.
-     *
      * @return \Datetime
      */
     public function getCreatedAt()
@@ -442,11 +399,17 @@ abstract class BaseAddress implements AddressInterface
         return $this->createdAt;
     }
 
+    /**
+     * @param string $name
+     */
     public function setName($name): void
     {
         $this->name = $name;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return $this->name;
@@ -489,11 +452,17 @@ abstract class BaseAddress implements AddressInterface
         return $this->getFullAddress('<br/>');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setCustomer(CustomerInterface $customer): void
     {
         $this->customer = $customer;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCustomer()
     {
         return $this->customer;

--- a/src/CustomerBundle/Entity/BaseCustomer.php
+++ b/src/CustomerBundle/Entity/BaseCustomer.php
@@ -16,6 +16,7 @@ namespace Sonata\CustomerBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Customer\CustomerInterface;
+use Sonata\Component\Order\OrderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class BaseCustomer implements CustomerInterface
@@ -85,15 +86,18 @@ abstract class BaseCustomer implements CustomerInterface
     protected $user;
 
     /**
-     * @var \Doctrine\Common\Collections\ArrayCollection
+     * @var ArrayCollection|AddressInterface[]
      */
     protected $addresses;
 
     /**
-     * @var \Doctrine\Common\Collections\ArrayCollection
+     * @var ArrayCollection|OrderInterface[]
      */
     protected $orders;
 
+    /**
+     * @var string
+     */
     protected $locale;
 
     /**
@@ -110,7 +114,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function __toString()
     {
@@ -128,13 +132,16 @@ abstract class BaseCustomer implements CustomerInterface
         $this->setUpdatedAt(new \DateTime());
     }
 
+    /**
+     * @return string
+     */
     public function getAdminTitle()
     {
         return $this->getFullname();
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getTitle()
     {
@@ -142,7 +149,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $title
      */
     public function setTitle($title): void
     {
@@ -164,8 +171,6 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * Get title name.
-     *
      * @return string
      */
     public function getTitleName()
@@ -224,7 +229,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $email
      */
     public function setEmail($email): void
     {
@@ -232,7 +237,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return \DateTime
      */
     public function getBirthDate()
     {
@@ -240,7 +245,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param \DateTime|null $birthDate
      */
     public function setBirthDate(\DateTime $birthDate = null): void
     {
@@ -248,7 +253,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getBirthPlace()
     {
@@ -256,7 +261,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $birthPlace
      */
     public function setBirthPlace($birthPlace): void
     {
@@ -264,7 +269,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getPhoneNumber()
     {
@@ -272,7 +277,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $phoneNumber
      */
     public function setPhoneNumber($phoneNumber): void
     {
@@ -288,7 +293,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $mobileNumber
      */
     public function setMobileNumber($mobileNumber): void
     {
@@ -296,7 +301,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string string
      */
     public function getFaxNumber()
     {
@@ -304,7 +309,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $faxNumber
      */
     public function setFaxNumber($faxNumber): void
     {
@@ -360,7 +365,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param AddressInterface $address
      */
     public function addAddress(AddressInterface $address): void
     {
@@ -408,7 +413,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param ArrayCollection|OrderInterface[] $orders
      */
     public function setOrders($orders): void
     {
@@ -416,7 +421,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return ArrayCollection|OrderInterface[]
      */
     public function getOrders()
     {
@@ -424,7 +429,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param bool $isFake
      */
     public function setIsFake($isFake): void
     {
@@ -432,7 +437,7 @@ abstract class BaseCustomer implements CustomerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function getIsFake()
     {

--- a/src/DeliveryBundle/DependencyInjection/Configuration.php
+++ b/src/DeliveryBundle/DependencyInjection/Configuration.php
@@ -45,7 +45,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addDeliverySection(ArrayNodeDefinition $node): void
     {
@@ -99,7 +99,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addModelSection(ArrayNodeDefinition $node): void
     {

--- a/src/InvoiceBundle/DependencyInjection/Configuration.php
+++ b/src/InvoiceBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addModelSection(ArrayNodeDefinition $node): void
     {

--- a/src/InvoiceBundle/DependencyInjection/SonataInvoiceExtension.php
+++ b/src/InvoiceBundle/DependencyInjection/SonataInvoiceExtension.php
@@ -57,8 +57,8 @@ class SonataInvoiceExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param array                                                   $config
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
     public function registerParameters(ContainerBuilder $container, array $config): void
     {

--- a/src/InvoiceBundle/Entity/BaseInvoice.php
+++ b/src/InvoiceBundle/Entity/BaseInvoice.php
@@ -128,7 +128,7 @@ abstract class BaseInvoice implements InvoiceInterface
     protected $locale;
 
     /**
-     * @var array
+     * @var InvoiceElementInterface[]
      */
     protected $invoiceElements = [];
 
@@ -175,7 +175,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * @param \DateTime $createdAt
+     * {@inheritdoc}
      */
     public function setCreatedAt(\DateTime $createdAt): void
     {
@@ -183,7 +183,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * @return \DateTime
+     * {@inheritdoc}
      */
     public function getCreatedAt()
     {
@@ -207,9 +207,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set reference.
-     *
-     * @param string $reference
+     * {@inheritdoc}
      */
     public function setReference($reference): void
     {
@@ -217,9 +215,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get reference.
-     *
-     * @return string $reference
+     * {@inheritdoc}
      */
     public function getReference()
     {
@@ -227,10 +223,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set userId
-     *R.
-     *
-     * @param CustomerInterface $customer
+     * {@inheritdoc}
      */
     public function setCustomer(CustomerInterface $customer = null): void
     {
@@ -238,9 +231,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get userId.
-     *
-     * @return int $customer
+     * {@inheritdoc}
      */
     public function getCustomer()
     {
@@ -248,9 +239,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set currency.
-     *
-     * @param CurrencyInterface $currency
+     * {@inheritdoc}
      */
     public function setCurrency(CurrencyInterface $currency): void
     {
@@ -258,9 +247,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get currency.
-     *
-     * @return CurrencyInterface $currency
+     * {@inheritdoc}
      */
     public function getCurrency()
     {
@@ -268,9 +255,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set status.
-     *
-     * @param int $status
+     * {@inheritdoc}
      */
     public function setStatus($status): void
     {
@@ -278,9 +263,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get status.
-     *
-     * @return int $status
+     * {@inheritdoc}
      */
     public function getStatus()
     {
@@ -288,9 +271,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set totalInc.
-     *
-     * @param float $totalInc
+     * {@inheritdoc}
      */
     public function setTotalInc($totalInc): void
     {
@@ -298,9 +279,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get totalInc.
-     *
-     * @return float $totalInc
+     * {@inheritdoc}
      */
     public function getTotalInc()
     {
@@ -308,9 +287,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set totalExcl.
-     *
-     * @param float $totalExcl
+     * {@inheritdoc}
      */
     public function setTotalExcl($totalExcl): void
     {
@@ -318,9 +295,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get totalExcl.
-     *
-     * @return float $totalExcl
+     * {@inheritdoc}
      */
     public function getTotalExcl()
     {
@@ -358,9 +333,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set name.
-     *
-     * @param string $name
+     * {@inheritdoc}
      */
     public function setName($name): void
     {
@@ -368,9 +341,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get name.
-     *
-     * @return string $name
+     * {@inheritdoc}
      */
     public function getName()
     {
@@ -378,9 +349,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set phone.
-     *
-     * @param string $phone
+     * {@inheritdoc}
      */
     public function setPhone($phone): void
     {
@@ -388,9 +357,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get phone.
-     *
-     * @return string $phone
+     * {@inheritdoc}
      */
     public function getPhone()
     {
@@ -398,9 +365,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set address1.
-     *
-     * @param string $address1
+     * {@inheritdoc}
      */
     public function setAddress1($address1): void
     {
@@ -408,9 +373,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get address1.
-     *
-     * @return string $address1
+     * {@inheritdoc}
      */
     public function getAddress1()
     {
@@ -418,9 +381,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set address2.
-     *
-     * @param string $address2
+     * {@inheritdoc}
      */
     public function setAddress2($address2): void
     {
@@ -428,9 +389,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get address2.
-     *
-     * @return string $address2
+     * {@inheritdoc}
      */
     public function getAddress2()
     {
@@ -438,9 +397,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set address3.
-     *
-     * @param string $address3
+     * {@inheritdoc}
      */
     public function setAddress3($address3): void
     {
@@ -448,9 +405,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get address3.
-     *
-     * @return string $address3
+     * {@inheritdoc}
      */
     public function getAddress3()
     {
@@ -458,9 +413,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set city.
-     *
-     * @param string $city
+     * {@inheritdoc}
      */
     public function setCity($city): void
     {
@@ -468,9 +421,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get city.
-     *
-     * @return string $city
+     * {@inheritdoc}
      */
     public function getCity()
     {
@@ -478,9 +429,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set postcode.
-     *
-     * @param string $postcode
+     * {@inheritdoc}
      */
     public function setPostcode($postcode): void
     {
@@ -488,9 +437,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get postcode.
-     *
-     * @return string $postcode
+     * {@inheritdoc}
      */
     public function getPostcode()
     {
@@ -498,9 +445,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set country.
-     *
-     * @param string $country
+     * {@inheritdoc}
      */
     public function setCountry($country): void
     {
@@ -508,9 +453,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get country.
-     *
-     * @return string $country
+     * {@inheritdoc}
      */
     public function getCountry()
     {
@@ -518,9 +461,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set fax.
-     *
-     * @param string $fax
+     * {@inheritdoc}
      */
     public function setFax($fax): void
     {
@@ -528,9 +469,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get fax.
-     *
-     * @return string $fax
+     * {@inheritdoc}
      */
     public function getFax()
     {
@@ -538,9 +477,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set email.
-     *
-     * @param string $email
+     * {@inheritdoc}
      */
     public function setEmail($email): void
     {
@@ -548,9 +485,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get email.
-     *
-     * @return string $email
+     * {@inheritdoc}
      */
     public function getEmail()
     {
@@ -558,9 +493,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set mobile.
-     *
-     * @param string $mobile
+     * {@inheritdoc}
      */
     public function setMobile($mobile): void
     {
@@ -568,9 +501,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get mobile.
-     *
-     * @return string $mobile
+     * {@inheritdoc}
      */
     public function getMobile()
     {
@@ -578,8 +509,6 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Set user.
-     *
      * @param UserInterface $user
      */
     public function setUser(UserInterface $user): void
@@ -588,8 +517,6 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Get user.
-     *
      * @return UserInterface $user
      */
     public function getUser()
@@ -632,9 +559,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Gets the locale.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getLocale()
     {
@@ -642,9 +567,7 @@ abstract class BaseInvoice implements InvoiceInterface
     }
 
     /**
-     * Sets the locale.
-     *
-     * @param string $locale
+     * {@inheritdoc}
      */
     public function setLocale($locale): void
     {

--- a/src/InvoiceBundle/Entity/BaseInvoiceElement.php
+++ b/src/InvoiceBundle/Entity/BaseInvoiceElement.php
@@ -16,6 +16,7 @@ namespace Sonata\InvoiceBundle\Entity;
 use Sonata\Component\Invoice\InvoiceElementInterface;
 use Sonata\Component\Invoice\InvoiceInterface;
 use Sonata\Component\Order\OrderElementInterface;
+use Sonata\Component\Tests\Product\OrderElement;
 
 abstract class BaseInvoiceElement implements InvoiceElementInterface
 {
@@ -70,9 +71,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     protected $description;
 
     /**
-     * Set invoiceId.
-     *
-     * @param InvoiceInterface $invoice
+     * {@inheritdoc}
      */
     public function setInvoice(InvoiceInterface $invoice): void
     {
@@ -80,9 +79,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Get invoiceId.
-     *
-     * @return int $invoiceId
+     * {@inheritdoc}
      */
     public function getInvoice()
     {
@@ -90,9 +87,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Set orderElement.
-     *
-     * @param OrderElementInterface $orderElement
+     * {@inheritdoc}
      */
     public function setOrderElement(OrderElementInterface $orderElement): void
     {
@@ -100,9 +95,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Get orderElement.
-     *
-     * @return OrderElementInterface $orderElement
+     * {@inheritdoc}
      */
     public function getOrderElement()
     {
@@ -164,8 +157,6 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Set total.
-     *
      * @param float $total
      */
     public function setTotal($total): void
@@ -214,11 +205,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Get total.
-     *
-     * @param bool $vat
-     *
-     * @return float $total
+     * {@inheritdoc}
      */
     public function getTotal($vat = true)
     {
@@ -236,9 +223,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Set designation.
-     *
-     * @param string $designation
+     * {@inheritdoc}
      */
     public function setDesignation($designation): void
     {
@@ -246,9 +231,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Get designation.
-     *
-     * @return string $designation
+     * {@inheritdoc}
      */
     public function getDesignation()
     {
@@ -256,9 +239,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Set description.
-     *
-     * string $description
+     * {@inheritdoc}
      */
     public function setDescription($description): void
     {
@@ -266,9 +247,7 @@ abstract class BaseInvoiceElement implements InvoiceElementInterface
     }
 
     /**
-     * Get description.
-     *
-     * @return string $description
+     * {@inheritdoc}
      */
     public function getDescription()
     {

--- a/src/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/OrderBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addModelSection(ArrayNodeDefinition $node): void
     {

--- a/src/OrderBundle/DependencyInjection/SonataOrderExtension.php
+++ b/src/OrderBundle/DependencyInjection/SonataOrderExtension.php
@@ -63,8 +63,8 @@ class SonataOrderExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param array                                                   $config
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
     public function registerParameters(ContainerBuilder $container, array $config): void
     {

--- a/src/OrderBundle/Entity/BaseOrder.php
+++ b/src/OrderBundle/Entity/BaseOrder.php
@@ -60,7 +60,7 @@ abstract class BaseOrder implements OrderInterface
     protected $deliveryStatus;
 
     /**
-     * @var datetime
+     * @var \DateTime
      */
     protected $validatedAt;
 
@@ -199,14 +199,29 @@ abstract class BaseOrder implements OrderInterface
      */
     protected $shippingMobile;
 
+    /**
+     * @var ArrayCollection|OrderElementInterface[]
+     */
     protected $orderElements;
 
+    /**
+     * @var \DateTime
+     */
     protected $createdAt;
 
+    /**
+     * @var \DateTime
+     */
     protected $updatedAt;
 
+    /**
+     * @var CustomerInterface
+     */
     protected $customer;
 
+    /**
+     * @var string
+     */
     protected $locale;
 
     public function __construct()
@@ -215,7 +230,7 @@ abstract class BaseOrder implements OrderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function __toString()
     {
@@ -272,6 +287,9 @@ abstract class BaseOrder implements OrderInterface
         return BaseAddress::formatAddress($this->getBillingAsArray(), $sep);
     }
 
+    /**
+     * @return array
+     */
     public function getBillingAsArray()
     {
         return [
@@ -497,9 +515,7 @@ abstract class BaseOrder implements OrderInterface
     }
 
     /**
-     * Set delivery VAT.
-     *
-     * @param float $deliveryVat
+     * {@inheritdoc}
      */
     public function setDeliveryVat($deliveryVat): void
     {
@@ -507,9 +523,7 @@ abstract class BaseOrder implements OrderInterface
     }
 
     /**
-     * Get delivery VAT.
-     *
-     * @return float $deliveryVat
+     * {@inheritdoc}
      */
     public function getDeliveryVat()
     {

--- a/src/OrderBundle/Entity/BaseOrderElement.php
+++ b/src/OrderBundle/Entity/BaseOrderElement.php
@@ -21,7 +21,7 @@ use Sonata\ProductBundle\Entity\BaseDelivery;
 abstract class BaseOrderElement implements OrderElementInterface
 {
     /**
-     * @var int
+     * @var OrderInterface
      */
     protected $order;
 
@@ -100,8 +100,14 @@ abstract class BaseOrderElement implements OrderElementInterface
      */
     protected $productType;
 
+    /**
+     * @var \DateTime
+     */
     protected $createdAt;
 
+    /**
+     * @var \DateTime
+     */
     protected $updatedAt;
 
     public function __construct()
@@ -130,8 +136,6 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set order.
-     *
      * @param OrderInterface $order
      */
     public function setOrder(OrderInterface $order): void
@@ -140,9 +144,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get order.
-     *
-     * @return Order $order
+     * @return OrderInterface
      */
     public function getOrder()
     {
@@ -214,9 +216,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set designation.
-     *
-     * @param string $designation
+     * {@inheritdoc}
      */
     public function setDesignation($designation): void
     {
@@ -224,9 +224,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get designation.
-     *
-     * @return string $designation
+     * {@inheritdoc}
      */
     public function getDesignation()
     {
@@ -234,9 +232,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set description.
-     *
-     * @param string $description
+     * {@inheritdoc}
      */
     public function setDescription($description): void
     {
@@ -244,9 +240,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get description.
-     *
-     * @return string $description
+     * {@inheritdoc}
      */
     public function getDescription()
     {
@@ -254,8 +248,6 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set productId.
-     *
      * @param int $productId
      */
     public function setProductId($productId): void
@@ -264,9 +256,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get productId.
-     *
-     * @return int $productId
+     * {@inheritdoc}
      */
     public function getProductId()
     {
@@ -274,9 +264,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set status.
-     *
-     * @param int $status
+     * {@inheritdoc}
      */
     public function setStatus($status): void
     {
@@ -287,9 +275,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get status.
-     *
-     * @return int $status
+     * {@inheritdoc}
      */
     public function getStatus()
     {
@@ -351,9 +337,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set delivery_status.
-     *
-     * @param int $deliveryStatus
+     * {@inheritdoc}
      */
     public function setDeliveryStatus($deliveryStatus): void
     {
@@ -361,9 +345,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get delivery_status.
-     *
-     * @return int $deliveryStatus
+     * {@inheritdoc}
      */
     public function getDeliveryStatus()
     {
@@ -371,9 +353,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set validated_at.
-     *
-     * @param \DateTime $validatedAt
+     * {@inheritdoc}
      */
     public function setValidatedAt(\DateTime $validatedAt = null): void
     {
@@ -381,9 +361,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get validated_at.
-     *
-     * @return \DateTime $validatedAt
+     * {@inheritdoc}
      */
     public function getValidatedAt()
     {
@@ -391,9 +369,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Add product.
-     *
-     * @param ProductInterface $product
+     * {@inheritdoc}
      */
     public function setProduct(ProductInterface $product): void
     {
@@ -401,9 +377,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get product.
-     *
-     * @return ProductInterface $product
+     * {@inheritdoc}
      */
     public function getProduct()
     {
@@ -411,9 +385,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Set product_type.
-     *
-     * @param string $productType
+     * {@inheritdoc}
      */
     public function setProductType($productType): void
     {
@@ -421,9 +393,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Get product_type.
-     *
-     * @return string $productType
+     * {@inheritdoc}
      */
     public function getProductType()
     {
@@ -431,7 +401,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @param \DateTime|null $createdAt
+     * {@inheritdoc}
      */
     public function setCreatedAt(\DateTime $createdAt = null): void
     {
@@ -439,7 +409,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @return \DateTime
+     * {@inheritdoc}
      */
     public function getCreatedAt()
     {
@@ -447,7 +417,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @param \DateTime|null $updatedAt
+     * {@inheritdoc}
      */
     public function setUpdatedAt(\DateTime $updatedAt = null): void
     {
@@ -455,7 +425,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @return \DateTime
+     * {@inheritdoc}
      */
     public function getUpdatedAt()
     {
@@ -463,7 +433,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @param array $options
+     * {@inheritdoc}
      */
     public function setOptions($options): void
     {
@@ -471,7 +441,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getOptions()
     {
@@ -509,7 +479,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @param array $rawProduct
+     * {@inheritdoc}
      */
     public function setRawProduct($rawProduct): void
     {
@@ -534,7 +504,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getRawProduct()
     {
@@ -630,13 +600,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     }
 
     /**
-     * Return the total (price * quantity).
-     *
-     * if $vat = true, return the price with vat
-     *
-     * @param bool $vat
-     *
-     * @return float
+     * {@inheritdoc}
      */
     public function getTotal($vat = false)
     {

--- a/src/PaymentBundle/Consumer/PaymentProcessOrderElementConsumer.php
+++ b/src/PaymentBundle/Consumer/PaymentProcessOrderElementConsumer.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\PaymentBundle\Consumer;
 
+use Sonata\Component\Order\OrderElementManagerInterface;
 use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Payment\TransactionInterface;
 use Sonata\Component\Product\Pool as ProductPool;
+use Sonata\Component\Product\ProductManagerInterface;
 use Sonata\Component\Product\ProductProviderInterface;
-use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Consumer\ConsumerInterface;
 
@@ -29,7 +30,7 @@ use Sonata\NotificationBundle\Consumer\ConsumerInterface;
 class PaymentProcessOrderElementConsumer implements ConsumerInterface
 {
     /**
-     * @var ManagerInterface
+     * @var OrderElementManagerInterface
      */
     protected $orderElementManager;
 
@@ -39,10 +40,10 @@ class PaymentProcessOrderElementConsumer implements ConsumerInterface
     protected $productPool;
 
     /**
-     * @param ManagerInterface $orderElementManager
-     * @param ProductPool      $productPool
+     * @param OrderElementManagerInterface $orderElementManager
+     * @param ProductPool                  $productPool
      */
-    public function __construct(ManagerInterface $orderElementManager, ProductPool $productPool)
+    public function __construct(OrderElementManagerInterface $orderElementManager, ProductPool $productPool)
     {
         $this->orderElementManager = $orderElementManager;
         $this->productPool = $productPool;
@@ -102,7 +103,7 @@ class PaymentProcessOrderElementConsumer implements ConsumerInterface
      *
      * @param string $productType
      *
-     * @return ManagerInterface
+     * @return ProductManagerInterface
      */
     protected function getProductManager($productType)
     {

--- a/src/PaymentBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentBundle/DependencyInjection/Configuration.php
@@ -53,7 +53,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addPaymentSection(ArrayNodeDefinition $node): void
     {
@@ -279,7 +279,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addModelSection(ArrayNodeDefinition $node): void
     {

--- a/src/PaymentBundle/DependencyInjection/SonataPaymentExtension.php
+++ b/src/PaymentBundle/DependencyInjection/SonataPaymentExtension.php
@@ -58,8 +58,8 @@ class SonataPaymentExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param $config
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
     public function registerParameters(ContainerBuilder $container, array $config): void
     {
@@ -159,7 +159,7 @@ class SonataPaymentExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param ContainerBuilder $container
      * @param $selector
      */
     public function configureSelector(ContainerBuilder $container, $selector): void
@@ -168,8 +168,8 @@ class SonataPaymentExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param array                                                   $transformers
+     * @param ContainerBuilder $container
+     * @param array            $transformers
      */
     public function configureTransformer(ContainerBuilder $container, array $transformers): void
     {

--- a/src/PaymentBundle/Entity/BaseTransaction.php
+++ b/src/PaymentBundle/Entity/BaseTransaction.php
@@ -77,7 +77,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param \Sonata\Component\Order\OrderInterface $order
+     * {@inheritdoc}
      */
     public function setOrder(OrderInterface $order): void
     {
@@ -87,7 +87,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return \Sonata\Component\Order\OrderInterface
+     * {@inheritdoc}
      */
     public function getOrder()
     {
@@ -95,7 +95,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param int $state
+     * {@inheritdoc}
      */
     public function setState($state): void
     {
@@ -111,7 +111,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return int
+     * {@inheritdoc}
      */
     public function getState()
     {
@@ -119,7 +119,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param string $transactionId
+     * {@inheritdoc}
      */
     public function setTransactionId($transactionId): void
     {
@@ -128,7 +128,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getTransactionId()
     {
@@ -136,7 +136,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
      */
     public function isValid()
     {
@@ -144,7 +144,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param array $parameters
+     * {@inheritdoc}
      */
     public function setParameters(array $parameters): void
     {
@@ -152,7 +152,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getParameters()
     {
@@ -160,8 +160,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param $name
-     * @param null $default
+     * {@inheritdoc}
      */
     public function get($name, $default = null)
     {
@@ -169,7 +168,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param $statusCode
+     * {@inheritdoc}
      */
     public function setStatusCode($statusCode): void
     {
@@ -179,7 +178,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getStatusCode()
     {
@@ -187,7 +186,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getStatusName()
     {
@@ -201,9 +200,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * return status list.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public static function getStatusList()
     {
@@ -230,7 +227,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param \DateTime|null $createdAt
+     * {@inheritdoc}
      */
     public function setCreatedAt(\DateTime $createdAt = null): void
     {
@@ -238,7 +235,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return \DateTime
+     * {@inheritdoc}
      */
     public function getCreatedAt()
     {
@@ -246,7 +243,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param int $paymentCode
+     * {@inheritdoc}
      */
     public function setPaymentCode($paymentCode): void
     {
@@ -254,7 +251,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getPaymentCode()
     {
@@ -262,7 +259,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param $information
+     * {@inheritdoc}
      */
     public function addInformation($information): void
     {
@@ -270,7 +267,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @param $information
+     * {@inheritdoc}
      */
     public function setInformation($information): void
     {
@@ -278,7 +275,7 @@ class BaseTransaction implements TransactionInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getInformation()
     {

--- a/src/PriceBundle/DependencyInjection/Configuration.php
+++ b/src/PriceBundle/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addPriceSection(ArrayNodeDefinition $node): void
     {

--- a/src/PriceBundle/DependencyInjection/SonataPriceExtension.php
+++ b/src/PriceBundle/DependencyInjection/SonataPriceExtension.php
@@ -43,8 +43,8 @@ class SonataPriceExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param array                                                   $config
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
     public function registerParameters(ContainerBuilder $container, array $config): void
     {

--- a/src/ProductBundle/Admin/DeliveryAdmin.php
+++ b/src/ProductBundle/Admin/DeliveryAdmin.php
@@ -36,7 +36,7 @@ class DeliveryAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Form\FormMapper $formMapper
+     * {@inheritdoc}
      */
     public function configureFormFields(FormMapper $formMapper): void
     {
@@ -56,7 +56,7 @@ class DeliveryAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Datagrid\ListMapper $list
+     * {@inheritdoc}
      */
     public function configureListFields(ListMapper $list): void
     {

--- a/src/ProductBundle/Admin/ProductAdmin.php
+++ b/src/ProductBundle/Admin/ProductAdmin.php
@@ -22,20 +22,22 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Sonata\Component\Currency\CurrencyFormType;
-use Sonata\Component\Product\Pool;
+use Sonata\Component\Product\Pool as ProductPool;
 use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\FormatterBundle\Formatter\Pool as FormatterPool;
 
 class ProductAdmin extends AbstractAdmin
 {
     /**
-     * @var \Sonata\Component\Product\Pool
+     * @var ProductPool
      */
     protected $productPool;
 
     /**
-     * @var \Sonata\FormatterBundle\Formatter\Pool
+     * @var FormatterPool
      */
     protected $poolFormatter;
 
@@ -146,7 +148,7 @@ class ProductAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $filter
+     * {@inheritdoc}
      */
     public function configureDatagridFilters(DatagridMapper $filter): void
     {
@@ -160,15 +162,15 @@ class ProductAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\Component\Product\Pool $productPool
+     * @param ProductPool $productPool
      */
-    public function setProductPool(Pool $productPool): void
+    public function setProductPool(ProductPool $productPool): void
     {
         $this->productPool = $productPool;
     }
 
     /**
-     * @return \Sonata\Component\Product\Pool
+     * @return ProductPool
      */
     public function getProductPool()
     {
@@ -180,7 +182,7 @@ class ProductAdmin extends AbstractAdmin
      *
      * @param ProductInterface $product
      *
-     * @return \Sonata\Component\Product\ProductProviderInterface
+     * @return ProductProviderInterface
      */
     public function getProductProvider(ProductInterface $product)
     {

--- a/src/ProductBundle/Admin/ProductCategoryAdmin.php
+++ b/src/ProductBundle/Admin/ProductCategoryAdmin.php
@@ -70,7 +70,7 @@ class ProductCategoryAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $filter
+     * {@inheritdoc}
      */
     public function configureDatagridFilters(DatagridMapper $filter): void
     {

--- a/src/ProductBundle/Admin/ProductCollectionAdmin.php
+++ b/src/ProductBundle/Admin/ProductCollectionAdmin.php
@@ -69,7 +69,7 @@ class ProductCollectionAdmin extends AbstractAdmin
     }
 
     /**
-     * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $filter
+     * {@inheritdoc}
      */
     public function configureDatagridFilters(DatagridMapper $filter): void
     {

--- a/src/ProductBundle/Block/CategoriesMenuBlockService.php
+++ b/src/ProductBundle/Block/CategoriesMenuBlockService.php
@@ -17,8 +17,8 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Sonata\ProductBundle\Menu\ProductMenuBuilder;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Templating\EngineInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/src/ProductBundle/Block/FiltersMenuBlockService.php
+++ b/src/ProductBundle/Block/FiltersMenuBlockService.php
@@ -17,8 +17,8 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Sonata\ProductBundle\Menu\ProductMenuBuilder;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Templating\EngineInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/src/ProductBundle/Block/RecentProductsBlockService.php
+++ b/src/ProductBundle/Block/RecentProductsBlockService.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\ProductBundle\Block;
 
-use Doctrine\ORM\EntityRepository;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
@@ -32,7 +31,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RecentProductsBlockService extends BaseBlockService
 {
     /**
-     * @var EntityRepository
+     * @var BaseProductRepository
      */
     protected $productRepository;
 

--- a/src/ProductBundle/Block/SimilarProductsBlockService.php
+++ b/src/ProductBundle/Block/SimilarProductsBlockService.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\ProductBundle\Block;
 
-use Doctrine\ORM\EntityRepository;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
@@ -33,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class SimilarProductsBlockService extends BaseBlockService
 {
     /**
-     * @var EntityRepository
+     * @var BaseProductRepository
      */
     protected $productRepository;
 

--- a/src/ProductBundle/Block/VariationsFormBlockService.php
+++ b/src/ProductBundle/Block/VariationsFormBlockService.php
@@ -33,19 +33,20 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 class VariationsFormBlockService extends BaseBlockService
 {
     /**
-     * @var \Sonata\Component\Product\Pool
+     * @var Pool
      */
     protected $pool;
 
     /**
-     * @var \Symfony\Component\Form\FormFactoryInterface
+     * @var FormFactoryInterface
      */
     protected $formFactory;
 
     /**
-     * @param string          $name
-     * @param EngineInterface $templating
-     * @param Pool            $productPool
+     * @param string               $name
+     * @param EngineInterface      $templating
+     * @param Pool                 $productPool
+     * @param FormFactoryInterface $formFactory
      */
     public function __construct($name, EngineInterface $templating, Pool $productPool, FormFactoryInterface $formFactory)
     {

--- a/src/ProductBundle/DependencyInjection/Configuration.php
+++ b/src/ProductBundle/DependencyInjection/Configuration.php
@@ -35,7 +35,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addProductSection(ArrayNodeDefinition $node): void
     {
@@ -62,7 +62,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addModelSection(ArrayNodeDefinition $node): void
     {
@@ -87,7 +87,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $node
      */
     private function addSeoSection(ArrayNodeDefinition $node): void
     {

--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -66,8 +66,8 @@ class SonataProductExtension extends Extension
     }
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param array                                                   $config
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
     public function registerParameters(ContainerBuilder $container, array $config): void
     {

--- a/src/ProductBundle/Entity/BaseDelivery.php
+++ b/src/ProductBundle/Entity/BaseDelivery.php
@@ -72,9 +72,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set productId.
-     *
-     * @param ProductInterface $product
+     * {@inheritdoc}
      */
     public function setProduct(ProductInterface $product): void
     {
@@ -82,9 +80,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get productId.
-     *
-     * @return int $productId
+     * {@inheritdoc}
      */
     public function getProduct()
     {
@@ -92,9 +88,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set code.
-     *
-     * @param $code
+     * {@inheritdoc}
      */
     public function setCode($code): void
     {
@@ -102,9 +96,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get class_name.
-     *
-     * @return string $className
+     * {@inheritdoc}
      */
     public function getCode()
     {
@@ -112,9 +104,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set per_item.
-     *
-     * @param bool $perItem
+     * {@inheritdoc}
      */
     public function setPerItem($perItem): void
     {
@@ -122,9 +112,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get per_item.
-     *
-     * @return bool $perItem
+     * {@inheritdoc}
      */
     public function getPerItem()
     {
@@ -132,9 +120,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set country code.
-     *
-     * @param $countryCode
+     * {@inheritdoc}
      */
     public function setCountryCode($countryCode): void
     {
@@ -142,9 +128,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get country.
-     *
-     * @return string $country
+     * {@inheritdoc}
      */
     public function getCountryCode()
     {
@@ -152,9 +136,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set zone.
-     *
-     * @param string $zone
+     * {@inheritdoc}
      */
     public function setZone($zone): void
     {
@@ -162,9 +144,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get zone.
-     *
-     * @return string $zone
+     * {@inheritdoc}
      */
     public function getZone()
     {
@@ -172,9 +152,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set enabled.
-     *
-     * @param bool $enabled
+     * {@inheritdoc}
      */
     public function setEnabled($enabled): void
     {
@@ -182,9 +160,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get enabled.
-     *
-     * @return bool $enabled
+     * {@inheritdoc}
      */
     public function getEnabled()
     {
@@ -192,9 +168,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set updatedAt.
-     *
-     * @param \DateTime $updatedAt
+     * {@inheritdoc}
      */
     public function setUpdatedAt(\DateTime $updatedAt = null): void
     {
@@ -202,9 +176,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get updatedAt.
-     *
-     * @return \DateTime $updatedAt
+     * {@inheritdoc}
      */
     public function getUpdatedAt()
     {
@@ -212,9 +184,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Set createdAt.
-     *
-     * @param \DateTime $createdAt
+     * {@inheritdoc}
      */
     public function setCreatedAt(\DateTime $createdAt = null): void
     {
@@ -222,9 +192,7 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * Get createdAt.
-     *
-     * @return \DateTime $createdAt
+     * {@inheritdoc}
      */
     public function getCreatedAt()
     {
@@ -243,8 +211,6 @@ abstract class BaseDelivery implements DeliveryInterface
     }
 
     /**
-     * return delivery status list.
-     *
      * @return array
      */
     public static function getStatusList()

--- a/src/ProductBundle/Entity/BasePackage.php
+++ b/src/ProductBundle/Entity/BasePackage.php
@@ -75,9 +75,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Set width.
-     *
-     * @param float $width
+     * {@inheritdoc}
      */
     public function setWidth($width): void
     {
@@ -85,9 +83,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Get width.
-     *
-     * @return float $width
+     * {@inheritdoc}
      */
     public function getWidth()
     {
@@ -95,9 +91,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Set height.
-     *
-     * @param float $height
+     * {@inheritdoc}
      */
     public function setHeight($height): void
     {
@@ -105,9 +99,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Get height.
-     *
-     * @return float $height
+     * {@inheritdoc}
      */
     public function getHeight()
     {
@@ -115,9 +107,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Set length.
-     *
-     * @param float $length
+     * {@inheritdoc}
      */
     public function setLength($length): void
     {
@@ -125,9 +115,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Get length.
-     *
-     * @return float $length
+     * {@inheritdoc}
      */
     public function getLength()
     {
@@ -135,9 +123,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Set weight.
-     *
-     * @param float $weight
+     * {@inheritdoc}
      */
     public function setWeight($weight): void
     {
@@ -145,9 +131,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Get weight.
-     *
-     * @return float $weight
+     * {@inheritdoc}
      */
     public function getWeight()
     {
@@ -155,9 +139,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Set enabled.
-     *
-     * @param bool $enabled
+     * {@inheritdoc}
      */
     public function setEnabled($enabled): void
     {
@@ -165,9 +147,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Get enabled.
-     *
-     * @return bool $enabled
+     * {@inheritdoc}
      */
     public function getEnabled()
     {
@@ -175,9 +155,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Set updatedAt.
-     *
-     * @param \DateTime $updatedAt
+     * {@inheritdoc}
      */
     public function setUpdatedAt(\DateTime $updatedAt = null): void
     {
@@ -185,9 +163,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Get updatedAt.
-     *
-     * @return \DateTime $updatedAt
+     * {@inheritdoc}
      */
     public function getUpdatedAt()
     {
@@ -195,9 +171,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Set createdAt.
-     *
-     * @param \DateTime $createdAt
+     * {@inheritdoc}
      */
     public function setCreatedAt(\DateTime $createdAt = null): void
     {
@@ -205,9 +179,7 @@ abstract class BasePackage implements PackageInterface
     }
 
     /**
-     * Get createdAt.
-     *
-     * @return \DateTime $createdAt
+     * {@inheritdoc}
      */
     public function getCreatedAt()
     {

--- a/src/ProductBundle/Entity/BaseProduct.php
+++ b/src/ProductBundle/Entity/BaseProduct.php
@@ -15,11 +15,13 @@ namespace Sonata\ProductBundle\Entity;
 
 use Cocur\Slugify\Slugify;
 use Doctrine\Common\Collections\ArrayCollection;
+use Exporter\Exception\InvalidMethodCallException;
 use Sonata\Component\Product\DeliveryInterface;
 use Sonata\Component\Product\PackageInterface;
 use Sonata\Component\Product\ProductCategoryInterface;
 use Sonata\Component\Product\ProductCollectionInterface;
 use Sonata\Component\Product\ProductInterface;
+use Sonata\Component\Tests\Product\Collection;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -108,17 +110,17 @@ abstract class BaseProduct implements ProductInterface
     protected $createdAt;
 
     /**
-     * @var ArrayCollection
+     * @var ArrayCollection|PackageInterface[]
      */
     protected $packages;
 
     /**
-     * @var ArrayCollection
+     * @var ArrayCollection|DeliveryInterface[]
      */
     protected $deliveries;
 
     /**
-     * @var ArrayCollection
+     * @var ArrayCollection|ProductCollectionInterface[]
      */
     protected $productCategories;
 
@@ -148,7 +150,7 @@ abstract class BaseProduct implements ProductInterface
     protected $enabledVariations;
 
     /**
-     * @var ArrayCollection
+     * @var ArrayCollection|Collection[]
      */
     protected $productCollections;
 
@@ -414,7 +416,7 @@ abstract class BaseProduct implements ProductInterface
      */
     public function setQuantity($quantity): void
     {
-        throw new \InvalidMethodCallException('This method is not used');
+        throw new InvalidMethodCallException('This method is not used');
     }
 
     /**
@@ -422,7 +424,7 @@ abstract class BaseProduct implements ProductInterface
      */
     public function getQuantity(): void
     {
-        throw new \InvalidMethodCallException('This method is not used');
+        throw new InvalidMethodCallException('This method is not used');
     }
 
     /**
@@ -710,7 +712,7 @@ abstract class BaseProduct implements ProductInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function hasVariations()
     {

--- a/src/ProductBundle/Entity/BaseProductCategory.php
+++ b/src/ProductBundle/Entity/BaseProductCategory.php
@@ -49,6 +49,9 @@ abstract class BaseProductCategory implements ProductCategoryInterface
      */
     protected $category;
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return ($this->getProduct() ? $this->getProduct()->getName() : 'null').' - '.($this->getCategory() ? $this->getCategory()->getName() : 'null');

--- a/src/ProductBundle/Entity/BaseProductCollection.php
+++ b/src/ProductBundle/Entity/BaseProductCollection.php
@@ -44,6 +44,9 @@ abstract class BaseProductCollection implements ProductCollectionInterface
      */
     protected $collection;
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return ($this->getProduct() ? $this->getProduct()->getName() : 'null').' - '.($this->getCollection() ? $this->getCollection()->getName() : 'null');

--- a/src/ProductBundle/Entity/ProductCategoryManager.php
+++ b/src/ProductBundle/Entity/ProductCategoryManager.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\ProductBundle\Entity;
 
-use Doctrine\ORM\EntityManager;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\Component\Product\ProductCategoryManagerInterface;
@@ -22,18 +21,10 @@ use Sonata\CoreBundle\Model\BaseEntityManager;
 
 class ProductCategoryManager extends BaseEntityManager implements ProductCategoryManagerInterface
 {
-    //    const CATEGORY_PRODUCT_TYPE = 'product';
-
     /**
-     * @var \Sonata\ClassificationBundle\Model\CategoryManagerInterface
+     * @var CategoryManagerInterface
      */
     protected $categoryManager;
-
-    /**
-     * @param string                   $class
-     * @param EntityManager            $em
-     * @param CategoryManagerInterface $categoryManager
-     */
 
     /**
      * {@inheritdoc}
@@ -43,12 +34,6 @@ class ProductCategoryManager extends BaseEntityManager implements ProductCategor
         if ($this->findOneBy(['category' => $category, 'product' => $product])) {
             return;
         }
-        //
-        //        if (null !== $category->getType() && self::CATEGORY_PRODUCT_TYPE !== $category->getType()) {
-        //            // Should we throw an exception instead?
-        //            $category->setType(self::CATEGORY_PRODUCT_TYPE);
-        //            $this->categoryManager->save($category);
-        //        }
 
         $productCategory = $this->create();
 

--- a/src/ProductBundle/Entity/ProductManager.php
+++ b/src/ProductBundle/Entity/ProductManager.php
@@ -206,7 +206,7 @@ class ProductManager extends BaseEntityManager implements ProductManagerInterfac
      * @param array    $productCollections
      * @param null|int $limit
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     protected function queryInSameCollections($productCollections, $limit = null)
     {

--- a/src/ProductBundle/Menu/ProductMenuBuilder.php
+++ b/src/ProductBundle/Menu/ProductMenuBuilder.php
@@ -18,7 +18,6 @@ use Knp\Menu\ItemInterface;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\Component\Product\ProductCategoryManagerInterface;
 use Sonata\Component\Product\ProductProviderInterface;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -42,7 +41,7 @@ class ProductMenuBuilder
     protected $router;
 
     /**
-     * @param MenuFactory                     $factory
+     * @param FactoryInterface                $factory
      * @param ProductCategoryManagerInterface $categoryManager
      * @param RouterInterface                 $router
      */
@@ -88,7 +87,7 @@ class ProductMenuBuilder
      * @param array  $itemOptions The options given to the created menuItem
      * @param string $currentUri  The current URI
      *
-     * @return \Knp\Menu\ItemInterface
+     * @return ItemInterface
      */
     public function createCategoryMenu(array $itemOptions = [], $currentUri = null)
     {
@@ -100,9 +99,9 @@ class ProductMenuBuilder
     }
 
     /**
-     * @param \Knp\Menu\ItemInterface $menu       The item to fill with $routes
-     * @param array                   $options    The item options
-     * @param string                  $currentUri The current URI
+     * @param ItemInterface $menu       The item to fill with $routes
+     * @param array         $options    The item options
+     * @param string        $currentUri The current URI
      */
     public function buildCategoryMenu(ItemInterface $menu, array $options = [], $currentUri = null): void
     {

--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -39,6 +39,9 @@ use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\CoreBundle\Exception\InvalidParameterException;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -96,7 +99,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     protected $eventDispatcher;
 
     /**
-     * @param \JMS\Serializer\SerializerInterface $serializer
+     * @param SerializerInterface $serializer
      */
     public function __construct(SerializerInterface $serializer)
     {
@@ -104,7 +107,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     * @param EventDispatcherInterface $eventDispatcher
      */
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
     {
@@ -112,7 +115,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @return \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     * @return EventDispatcherInterface
      */
     public function getEventDispatcher()
     {
@@ -120,7 +123,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @param \Sonata\Component\Currency\CurrencyPriceCalculatorInterface $currencyPriceCalculator
+     * @param CurrencyPriceCalculatorInterface $currencyPriceCalculator
      */
     public function setCurrencyPriceCalculator(CurrencyPriceCalculatorInterface $currencyPriceCalculator): void
     {
@@ -128,7 +131,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @return \Sonata\Component\Currency\CurrencyPriceCalculatorInterface
+     * @return CurrencyPriceCalculatorInterface
      */
     public function getCurrencyPriceCalculator()
     {
@@ -136,7 +139,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @param \Sonata\Component\Basket\BasketElementManagerInterface $basketElementManager
+     * {@inheritdoc}
      */
     public function setBasketElementManager(BasketElementManagerInterface $basketElementManager): void
     {
@@ -152,7 +155,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @return \Sonata\Component\Basket\BasketElementManagerInterface
+     * {@inheritdoc}
      */
     public function getBasketElementManager()
     {
@@ -222,10 +225,10 @@ abstract class BaseProductProvider implements ProductProviderInterface
     //   ORDER RELATED FUNCTIONS
 
     /**
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement A basket element instance
-     * @param string                                          $format        A format to obtain raw product
+     * @param BasketElementInterface $basketElement A basket element instance
+     * @param string                 $format        A format to obtain raw product
      *
-     * @return \Sonata\Component\Order\OrderElementInterface
+     * @return OrderElementInterface
      */
     public function createOrderElement(BasketElementInterface $basketElement, $format = 'json')
     {
@@ -252,8 +255,8 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @param \Sonata\Component\Product\ProductInterface $product
-     * @param string                                     $format
+     * @param ProductInterface $product
+     * @param string           $format
      *
      * @return array
      */
@@ -267,7 +270,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
      * @param string                $type
      * @param string                $format
      *
-     * @return \Sonata\Component\Product\ProductInterface
+     * @return ProductInterface
      */
     public function getProductFromRaw(OrderElementInterface $orderElement, $type, $format = 'json')
     {
@@ -406,7 +409,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @param  $name
+     * @param $name
      *
      * @return bool return true if the field $name is a variation
      */
@@ -767,9 +770,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     // BASKET RELATED FUNCTIONS
 
     /**
-     * (non-PHPdoc).
-     *
-     * @see \Sonata\Component\Product\ProductProviderInterface::createBasketElement()
+     * {@inheritdoc}
      */
     public function createBasketElement(ProductInterface $product = null, array $options = [])
     {
@@ -796,12 +797,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * This function return the form used in the product view page.
-     *
-     * @param \Sonata\Component\Product\ProductInterface $product      A Sonata product instance
-     * @param \Symfony\Component\Form\FormBuilder        $formBuilder  Symfony form builder
-     * @param bool                                       $showQuantity Specifies if quantity field will be displayed (default true)
-     * @param array                                      $options      An options array
+     * {@inheritdoc}
      */
     public function defineAddBasketForm(ProductInterface $product, FormBuilder $formBuilder, $showQuantity = true, array $options = []): void
     {
@@ -810,30 +806,28 @@ abstract class BaseProductProvider implements ProductProviderInterface
         // create the product form
         $formBuilder
             ->setData($basketElement)
-            ->add('productId', 'hidden');
+            ->add('productId', HiddenType::class);
 
         if ($showQuantity) {
-            $formBuilder->add('quantity', 'integer');
+            $formBuilder->add('quantity', IntegerType::class);
         } else {
             $transformer = new QuantityTransformer();
             $formBuilder->add(
-                    $formBuilder->create('quantity', 'hidden', ['data' => 1])
+                    $formBuilder->create('quantity', HiddenType::class, ['data' => 1])
                                 ->addModelTransformer($transformer)
             );
         }
     }
 
     /**
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement
-     * @param \Symfony\Component\Form\FormBuilder             $formBuilder
-     * @param array                                           $options
+     * {@inheritdoc}
      */
     public function defineBasketElementForm(BasketElementInterface $basketElement, FormBuilder $formBuilder, array $options = []): void
     {
         $formBuilder
-            ->add('delete', 'checkbox')
-            ->add('quantity', 'integer')
-            ->add('productId', 'hidden');
+            ->add('delete', CheckboxType::class)
+            ->add('quantity', IntegerType::class)
+            ->add('productId', HiddenType::class);
     }
 
     /**
@@ -887,15 +881,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * Adds $basketElement related to $product to $basket.
-     *
-     * @param \Sonata\Component\Basket\BasketInterface        $basket
-     * @param \Sonata\Component\Product\ProductInterface      $product
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement
-     *
-     * @throws \Sonata\Component\Basket\InvalidProductException
-     *
-     * @return bool|\Sonata\Component\Basket\BasketElementInterface
+     * {@inheritdoc}
      */
     public function basketAddProduct(BasketInterface $basket, ProductInterface $product, BasketElementInterface $basketElement)
     {
@@ -929,16 +915,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * Merge a product with another when the product is already present into the basket.
-     *
-     *
-     * @param \Sonata\Component\Basket\BasketInterface        $basket
-     * @param \Sonata\Component\Product\ProductInterface      $product
-     * @param \Sonata\Component\Basket\BasketElementInterface $newBasketElement
-     *
-     * @throws \RuntimeException
-     *
-     * @return bool|\Sonata\Component\Basket\BasketElementInterface
+     * {@inheritdoc}
      */
     public function basketMergeProduct(BasketInterface $basket, ProductInterface $product, BasketElementInterface $newBasketElement)
     {
@@ -965,9 +942,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * @param \Sonata\Component\Basket\BasketElementInterface $basketElement
-     *
-     * @return bool true if the basket element is still valid
+     * {@inheritdoc}
      */
     public function isValidBasketElement(BasketElementInterface $basketElement)
     {
@@ -1018,13 +993,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
     }
 
     /**
-     * Return true if the product can be added to the provided basket.
-     *
-     * @param \Sonata\Component\Basket\BasketInterface   $basket
-     * @param \Sonata\Component\Product\ProductInterface $product
-     * @param array                                      $options
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isAddableToBasket(BasketInterface $basket, ProductInterface $product, array $options = [])
     {
@@ -1034,9 +1003,9 @@ abstract class BaseProductProvider implements ProductProviderInterface
     /**
      * return a fresh product instance (so information are reloaded: enabled and stock ...).
      *
-     * @param \Sonata\Component\Product\ProductInterface $product
+     * @param ProductInterface $product
      *
-     * @return \Sonata\Component\Product\ProductInterface
+     * @return ProductInterface
      */
     public function reloadProduct(ProductInterface $product)
     {

--- a/src/ProductBundle/Twig/Extension/ProductExtension.php
+++ b/src/ProductBundle/Twig/Extension/ProductExtension.php
@@ -126,7 +126,7 @@ class ProductExtension extends \Twig_Extension
      *
      * @param ProductInterface $product
      *
-     * @return ProductInterface
+     * @return float
      */
     public function getCheapestEnabledVariationPrice(ProductInterface $product)
     {


### PR DESCRIPTION
I am targeting this branch, because it's a BC break.

## Changelog

```markdown
### Fixed
- Fixed phpdoc
- Added missing params to `ProductManagerInterface` methods
- Added missing `parent::__construct` call in `BaseBasket`
- Replaced string types with FQCN in `BaseProductProvider`
- Fixed `Transformer/Pool` usage of indefined `methods` property
```

- Didn't touch Api controllers, they need a separate fix.
