### PR TITLE
Updated XML definition for sonata.basket service factory

### DIFF
--- a/src/BasketBundle/Resources/config/basket.xml
+++ b/src/BasketBundle/Resources/config/basket.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sonata.customer.selector.class">Sonata\Component\Customer\CustomerSelector</parameter>
     </parameters>
@@ -21,7 +22,9 @@
             <argument type="service" id="sonata.basket.factory"/>
             <argument type="service" id="sonata.customer.selector"/>
         </service>
-        <service id="sonata.basket" class="Sonata\Component\Basket\Basket" factory-service="sonata.basket.loader" factory-method="getBasket"/>
+        <service id="sonata.basket" class="Sonata\Component\Basket\Basket">
+            <factory service="sonata.basket.loader" method="getBasket"/>
+        </service>
         <service id="sonata.basket.block.nb_items" class="Sonata\BasketBundle\Block\BasketBlockService">
             <tag name="sonata.block"/>
             <argument>sonata.basket.block.nb_items</argument>

--- a/src/BasketBundle/Resources/config/basket.xml
+++ b/src/BasketBundle/Resources/config/basket.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sonata.customer.selector.class">Sonata\Component\Customer\CustomerSelector</parameter>
     </parameters>


### PR DESCRIPTION
I am targeting this branch, because this is for sf 3+.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Old XML service factory definition in `src/BasketBundle/Resources/config/basket.xml`
```



