### PR TITLE
Removed FOS\RestBundle\Controller\Annotations\QueryParam#array parameter

### DIFF
--- a/src/BasketBundle/Controller/Api/BasketController.php
+++ b/src/BasketBundle/Controller/Api/BasketController.php
@@ -88,7 +88,7 @@ class BasketController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for baskets list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of baskets by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query baskets basket by clause (key is field, value is direction")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Query baskets basket by clause (key is field, value is direction")
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *

--- a/src/CustomerBundle/Controller/Api/AddressController.php
+++ b/src/CustomerBundle/Controller/Api/AddressController.php
@@ -60,7 +60,7 @@ class AddressController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for addresses list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of addresses by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query orders addresses by clause (key is field, value is direction")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Query orders addresses by clause (key is field, value is direction")
      * @QueryParam(name="customer", requirements="\d+", nullable=true, strict=true, description="Filter on customer id")
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)

--- a/src/CustomerBundle/Controller/Api/CustomerController.php
+++ b/src/CustomerBundle/Controller/Api/CustomerController.php
@@ -78,7 +78,7 @@ class CustomerController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for customers list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of customers by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query customers order by clause (key is field, value is direction")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Query customers order by clause (key is field, value is direction")
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *

--- a/src/InvoiceBundle/Controller/Api/InvoiceController.php
+++ b/src/InvoiceBundle/Controller/Api/InvoiceController.php
@@ -50,7 +50,7 @@ class InvoiceController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for invoices list pagination")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of invoices by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query invoices invoice by clause (key is field, value is direction")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Query invoices invoice by clause (key is field, value is direction")
      * @QueryParam(name="status", requirements="\d+", nullable=true, strict=true, description="Filter on invoice statuses")
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)

--- a/src/OrderBundle/Controller/Api/OrderController.php
+++ b/src/OrderBundle/Controller/Api/OrderController.php
@@ -50,7 +50,7 @@ class OrderController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for orders list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of orders by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query orders order by clause (key is field, value is direction")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Query orders order by clause (key is field, value is direction")
      * @QueryParam(name="status", requirements="\d+", nullable=true, strict=true, description="Filter on order statuses")
      * @QueryParam(name="customer", requirements="\d+", nullable=true, strict=true, description="Filter on customer id")
      *

--- a/src/ProductBundle/Controller/Api/ProductController.php
+++ b/src/ProductBundle/Controller/Api/ProductController.php
@@ -85,7 +85,7 @@ class ProductController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for products list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of products by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query products order by clause (key is field, value is direction")
+     * @QueryParam(name="orderBy", requirements="ASC|DESC", nullable=true, strict=true, description="Query products order by clause (key is field, value is direction")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/disabled products only?")
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)


### PR DESCRIPTION
I am targeting this branch, because this is aimed at sf 3+.

Closes #454

## Changelog

```markdown
### Fixed
- Annotation errors in `Sonata\BasketBundle\Controller\Api\BasketController::getBasketsAction()` and other places
```

As per @kunicmarko20 instructions I just removed the `array` parameter everywhere I could find it