### PR TITLE
Removed unnecessary conflict requirement on composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,7 @@
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<1.8 || >=3.0",
-        "jms/serializer": "<0.13",
-        "symfony/intl": "<2.8"
+        "jms/serializer": "<0.13"
     },
     "require-dev": {
         "friendsofsymfony/rest-bundle": "^1.8 || ^2.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
If we already have intl as a requirement with 2.8 version, we don't need a conflict with the same restriction.