### PR TITLE
Simplify FOSRest configuration

### DIFF
--- a/src/BasketBundle/Controller/Api/BasketController.php
+++ b/src/BasketBundle/Controller/Api/BasketController.php
@@ -15,7 +15,7 @@ use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
-use JMS\Serializer\SerializationContext;
+use FOS\RestBundle\View\View as FOSRestView;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\Component\Basket\BasketBuilderInterface;
 use Sonata\Component\Basket\BasketElementInterface;
@@ -263,7 +263,7 @@ class BasketController
         try {
             $this->basketManager->delete($basket);
         } catch (\Exception $e) {
-            return \FOS\RestBundle\View\View::create(['error' => $e->getMessage()], 400);
+            return FOSRestView::create(['error' => $e->getMessage()], 400);
         }
 
         return ['deleted' => true];
@@ -367,23 +367,21 @@ class BasketController
             $basket->setBasketElements($elements);
             $this->basketManager->save($basket);
         } catch (\Exception $e) {
-            return \FOS\RestBundle\View\View::create(['error' => $e->getMessage()], 400);
+            return FOSRestView::create(['error' => $e->getMessage()], 400);
         }
 
-        $view = \FOS\RestBundle\View\View::create($basket);
+        $context = new Context();
+        $context->setGroups(['sonata_api_read']);
 
-        // BC for FOSRestBundle < 2.0
-        if (method_exists($view, 'setSerializationContext')) {
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(['sonata_api_read']);
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
+        // simplify when dropping FOSRest < 2.1
+        if (method_exists($context, 'enableMaxDepth')) {
+            $context->enableMaxDepth();
         } else {
-            $context = new Context();
-            $context->setGroups(['sonata_api_read']);
-            $context->setMaxDepth(0);
-            $view->setContext($context);
+            $context->setMaxDepth(10);
         }
+
+        $view = FOSRestView::create($basket);
+        $view->setContext($context);
 
         return $view;
     }
@@ -413,20 +411,18 @@ class BasketController
             }
             $this->basketManager->save($basket);
 
-            $view = \FOS\RestBundle\View\View::create($basket);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
 
-            // BC for FOSRestBundle < 2.0
-            if (method_exists($view, 'setSerializationContext')) {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
+            // simplify when dropping FOSRest < 2.1
+            if (method_exists($context, 'enableMaxDepth')) {
+                $context->enableMaxDepth();
             } else {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $context->setMaxDepth(0);
-                $view->setContext($context);
+                $context->setMaxDepth(10);
             }
+
+            $view = FOSRestView::create($basket);
+            $view->setContext($context);
 
             return $view;
         }
@@ -475,20 +471,18 @@ class BasketController
                 $this->basketManager->save($basket);
             }
 
-            $view = \FOS\RestBundle\View\View::create($basket);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
 
-            // BC for FOSRestBundle < 2.0
-            if (method_exists($view, 'setSerializationContext')) {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
+            // simplify when dropping FOSRest < 2.1
+            if (method_exists($context, 'enableMaxDepth')) {
+                $context->enableMaxDepth();
             } else {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $context->setMaxDepth(0);
-                $view->setContext($context);
+                $context->setMaxDepth(10);
             }
+
+            $view = FOSRestView::create($basket);
+            $view->setContext($context);
 
             return $view;
         }

--- a/src/ProductBundle/Controller/Api/ProductController.php
+++ b/src/ProductBundle/Controller/Api/ProductController.php
@@ -18,7 +18,7 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\Route;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
-use JMS\Serializer\SerializationContext;
+use FOS\RestBundle\View\View as FOSRestView;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
@@ -249,7 +249,7 @@ class ProductController
         try {
             $manager->delete($product);
         } catch (\Exception $e) {
-            return \FOS\RestBundle\View\View::create(['error' => $e->getMessage()], 400);
+            return FOSRestView::create(['error' => $e->getMessage()], 400);
         }
 
         return ['deleted' => true];
@@ -463,20 +463,18 @@ class ProductController
             $product->setShortDescription($this->formatterPool->transform($product->getShortDescriptionFormatter(), $product->getRawShortDescription()));
             $manager->save($product);
 
-            $view = \FOS\RestBundle\View\View::create($product);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
 
-            // BC for FOSRestBundle < 2.0
-            if (method_exists($view, 'setSerializationContext')) {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
+            // simplify when dropping FOSRest < 2.1
+            if (method_exists($context, 'enableMaxDepth')) {
+                $context->enableMaxDepth();
             } else {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $context->setMaxDepth(0);
-                $view->setContext($context);
+                $context->setMaxDepth(10);
             }
+
+            $view = FOSRestView::create($product);
+            $view->setContext($context);
 
             return $view;
         }

--- a/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
+++ b/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
@@ -144,10 +144,16 @@ class CustomerControllerTest extends TestCase
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $view = $this->createCustomerController($customer, $customerManager, $addressManager, $formFactory)
-            ->postCustomerAddressAction(1, new Request());
+        $customerController = $this->createCustomerController(
+            $customer,
+            $customerManager,
+            $addressManager,
+            $formFactory
+        );
 
-        $this->assertInstanceOf(View::class, $view);
+        $customer = $customerController->postCustomerAddressAction(1, new Request());
+
+        $this->assertInstanceOf(AddressInterface::class, $customer);
     }
 
     public function testPostCustomerAddressInvalidAction()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Avoid deprecations for usage of FOSRest Context `setMaxDepth `method. Replaced by `enableMaxDepth`
```

## Subject

<!-- Describe your Pull Request content here -->
We can simplify some code needed to create Views. Based on https://github.com/sonata-project/SonataNewsBundle/pull/443

Fixed a deprecation with `setMaxDepth` method, deprecated on FOSRest 2.1