### PR TITLE
Fixed GenerateProductCommand

### DIFF
--- a/src/ProductBundle/Command/GenerateProductCommand.php
+++ b/src/ProductBundle/Command/GenerateProductCommand.php
@@ -149,7 +149,7 @@ class GenerateProductCommand extends ContainerAwareCommand
     {{ service }}.type:
         class: Application\Sonata\ProductBundle\Provider\{{ product }}ProductProvider
         arguments:
-            - "@serializer"
+            - "@jms_serializer"
 
 <info>2. Add this service configuration</info>
 

--- a/src/ProductBundle/Command/GenerateProductCommand.php
+++ b/src/ProductBundle/Command/GenerateProductCommand.php
@@ -143,12 +143,12 @@ class GenerateProductCommand extends ContainerAwareCommand
         class: Sonata\ProductBundle\Entity\ProductManager
         arguments:
             - Application\Sonata\ProductBundle\Entity\{{ product }}
-            - @doctrine
+            - "@doctrine"
 
     {{ service }}.type:
         class: Application\Sonata\ProductBundle\Provider\{{ product }}ProductProvider
         arguments:
-            - @serializer
+            - "@serializer"
 
 <info>2. Add this service configuration</info>
 

--- a/src/ProductBundle/Command/GenerateProductCommand.php
+++ b/src/ProductBundle/Command/GenerateProductCommand.php
@@ -76,9 +76,11 @@ class GenerateProductCommand extends ContainerAwareCommand
 
         $output->writeln(' > mustaching skeleton files');
 
+        $product = ucfirst($input->getArgument('product'));
+
         Mustache::renderDir($bundle_dir, [
-            'product' => $input->getArgument('product'),
-            'root_name' => strtolower(preg_replace('/[A-Z]/', '_\\0', $input->getArgument('product'))),
+            'product' => $product,
+            'root_name' => strtolower(preg_replace('/[A-Z]/', '_\\0', $product)),
         ]);
 
         $renames = [
@@ -99,8 +101,8 @@ class GenerateProductCommand extends ContainerAwareCommand
         ];
 
         $dirs = [
-            sprintf('%s/Resources/views/%s', $bundle_dir, $input->getArgument('product')),
-            sprintf('%s/Product/%s', $bundle_dir, $input->getArgument('product')),
+            sprintf('%s/Resources/views/%s', $bundle_dir, $product),
+            sprintf('%s/Product/%s', $bundle_dir, $product),
             sprintf('%s/Provider', $bundle_dir),
         ];
 
@@ -112,7 +114,7 @@ class GenerateProductCommand extends ContainerAwareCommand
 
         foreach ($renames as $from => $to) {
             $from = sprintf($from, $bundle_dir);
-            $to = sprintf($to, $bundle_dir, $input->getArgument('product'));
+            $to = sprintf($to, $bundle_dir, $product);
 
             if (is_file($to) || is_dir($to)) {
                 $output->writeln(sprintf(' <info>-</info> deleting unused file : <comment>%s</comment>', basename($from)));
@@ -131,7 +133,6 @@ class GenerateProductCommand extends ContainerAwareCommand
             sprintf('%s/Resources/views/Entity', $bundle_dir),
         ]);
 
-        $product = $input->getArgument('product');
         $service = $input->getArgument('service_id');
 
         $output->write(Mustache::renderString(<<<CONFIG


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the 2.x branch looks dead.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Add quotes to yaml strings when generating it
- Generated product classes start with an uppercase char
- Fixed wrong argument for `*ProductProvider`
```


## Subject

This are some fixes for the product generator.
