### PR TITLE
Remove form aliases

### DIFF
--- a/src/Component/Currency/CurrencyFormType.php
+++ b/src/Component/Currency/CurrencyFormType.php
@@ -43,7 +43,7 @@ class CurrencyFormType extends CurrencyType
 
     public function getParent()
     {
-        return 'currency';
+        return CurrencyType::class;
     }
 
     public function getBlockPrefix()

--- a/src/CustomerBundle/Block/RecentCustomersBlockService.php
+++ b/src/CustomerBundle/Block/RecentCustomersBlockService.php
@@ -19,8 +19,12 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Component\Customer\CustomerManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -67,11 +71,11 @@ class RecentCustomersBlockService extends AbstractAdminBlockService
 
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['number', 'integer', ['required' => true]],
-                ['title', 'text', ['required' => false]],
-                ['mode', 'choice', [
+                ['number', IntegerType::class, ['required' => true]],
+                ['title', TextType::class, ['required' => false]],
+                ['mode', ChoiceType::class, [
                     'choices' => [
                         'public' => 'public',
                         'admin' => 'admin',

--- a/src/CustomerBundle/Form/Type/AddressType.php
+++ b/src/CustomerBundle/Form/Type/AddressType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\CustomerBundle\Form\Type;
 
+use Sonata\BasketBundle\Form\AddressType as BasketAddressType;
 use Sonata\Component\Basket\BasketInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
@@ -86,7 +87,7 @@ class AddressType extends AbstractType
 
     public function getParent()
     {
-        return 'sonata_basket_address';
+        return BasketAddressType::class;
     }
 
     public function getBlockPrefix()

--- a/src/OrderBundle/Block/RecentOrdersBlockService.php
+++ b/src/OrderBundle/Block/RecentOrdersBlockService.php
@@ -20,8 +20,12 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Component\Customer\CustomerManagerInterface;
 use Sonata\Component\Order\OrderManagerInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -99,11 +103,11 @@ class RecentOrdersBlockService extends BaseBlockService
 
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['number', 'integer', ['required' => true]],
-                ['title', 'text', ['required' => false]],
-                ['mode', 'choice', [
+                ['number', IntegerType::class, ['required' => true]],
+                ['title', TextType::class, ['required' => false]],
+                ['mode', ChoiceType::class, [
                     'choices' => [
                         'public' => 'public',
                         'admin' => 'admin',

--- a/src/ProductBundle/Block/RecentProductsBlockService.php
+++ b/src/ProductBundle/Block/RecentProductsBlockService.php
@@ -19,10 +19,13 @@ use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Component\Currency\CurrencyDetectorInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\ProductBundle\Repository\BaseProductRepository;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -79,10 +82,14 @@ class RecentProductsBlockService extends BaseBlockService
 
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['number', 'integer', ['required' => true]],
-                ['title',  'text',    ['required' => false]],
+                ['number', IntegerType::class, [
+                    'required' => true,
+                ]],
+                ['title',  TextType::class, [
+                    'required' => false,
+                ]],
             ],
         ]);
     }

--- a/src/ProductBundle/Block/SimilarProductsBlockService.php
+++ b/src/ProductBundle/Block/SimilarProductsBlockService.php
@@ -20,10 +20,13 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Component\Currency\CurrencyDetectorInterface;
 use Sonata\Component\Product\ProductFinderInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\ProductBundle\Repository\BaseProductRepository;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -90,11 +93,17 @@ class SimilarProductsBlockService extends BaseBlockService
 
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block): void
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['number',          'integer', ['required' => true]],
-                ['title',           'text',    ['required' => false]],
-                ['base_product_id', 'integer', ['required' => false]],
+                ['number',  IntegerType::class, [
+                    'required' => true,
+                ]],
+                ['title', TextType::class, [
+                    'required' => false,
+                ]],
+                ['base_product_id', IntegerType::class, [
+                    'required' => false,
+                ]],
             ],
         ]);
     }

--- a/src/ProductBundle/Controller/ProductVariationAdminController.php
+++ b/src/ProductBundle/Controller/ProductVariationAdminController.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\ORMException;
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
 use Sonata\Component\Product\Pool;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -45,7 +46,7 @@ class ProductVariationAdminController extends Controller
         }
 
         $form = $this->createFormBuilder(null, [])
-            ->add('number', 'integer', [
+            ->add('number', IntegerType::class, [
                 'required' => true,
                 'label' => $this->getTranslator()->trans('variations_number', [], 'SonataProductBundle'),
                 'attr' => ['min' => 1, 'max' => 10],

--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -16,6 +16,7 @@ namespace Sonata\ProductBundle\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use JMS\Serializer\SerializerInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\Component\Basket\BasketElementInterface;
 use Sonata\Component\Basket\BasketElementManagerInterface;
@@ -38,7 +39,12 @@ use Sonata\Component\Product\ProductManagerInterface;
 use Sonata\Component\Product\ProductProviderInterface;
 use Sonata\CoreBundle\Exception\InvalidParameterException;
 use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\FormatterBundle\Form\Type\FormatterType;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -423,14 +429,14 @@ abstract class BaseProductProvider implements ProductProviderInterface
         $formMapper->add('sku');
 
         $formMapper
-            ->add('price', 'number')
+            ->add('price', NumberType::class)
             ->add('priceIncludingVat')
-            ->add('vatRate', 'number')
-            ->add('stock', 'integer')
+            ->add('vatRate', NumberType::class)
+            ->add('stock', IntegerType::class)
         ;
 
         if (!$isVariation || in_array('description', $this->variationFields)) {
-            $formMapper->add('description', 'sonata_formatter_type', [
+            $formMapper->add('description', FormatterType::class, [
                 'source_field' => 'rawDescription',
                 'source_field_options' => ['attr' => ['class' => 'span10', 'rows' => 20]],
                 'format_field' => 'descriptionFormatter',
@@ -440,7 +446,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
         }
 
         if (!$isVariation || in_array('short_description', $this->variationFields)) {
-            $formMapper->add('shortDescription', 'sonata_formatter_type', [
+            $formMapper->add('shortDescription', FormatterType::class, [
                 'source_field' => 'rawShortDescription',
                 'source_field_options' => ['attr' => ['class' => 'span10', 'rows' => 20]],
                 'format_field' => 'shortDescriptionFormatter',
@@ -455,7 +461,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
             $formMapper->with('Media');
 
             if (!$isVariation || in_array('image', $this->variationFields)) {
-                $formMapper->add('image', 'sonata_type_model_list', [
+                $formMapper->add('image', ModelListType::class, [
                     'required' => false,
                 ], [
                     'link_parameters' => [
@@ -467,7 +473,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
             }
 
             if (!$isVariation || in_array('gallery', $this->variationFields)) {
-                $formMapper->add('gallery', 'sonata_type_model_list', [
+                $formMapper->add('gallery', ModelListType::class, [
                     'required' => false,
                 ], [
                     'link_parameters' => [
@@ -744,14 +750,14 @@ abstract class BaseProductProvider implements ProductProviderInterface
         // create the product form
         $formBuilder
             ->setData($basketElement)
-            ->add('productId', 'hidden');
+            ->add('productId', HiddenType::class);
 
         if ($showQuantity) {
-            $formBuilder->add('quantity', 'integer');
+            $formBuilder->add('quantity', IntegerType::class);
         } else {
             $transformer = new QuantityTransformer();
             $formBuilder->add(
-                    $formBuilder->create('quantity', 'hidden', ['data' => 1])
+                    $formBuilder->create('quantity', HiddenType::class, ['data' => 1])
                                 ->addModelTransformer($transformer)
             );
         }
@@ -765,9 +771,9 @@ abstract class BaseProductProvider implements ProductProviderInterface
     public function defineBasketElementForm(BasketElementInterface $basketElement, FormBuilder $formBuilder, array $options = []): void
     {
         $formBuilder
-            ->add('delete', 'checkbox')
-            ->add('quantity', 'integer')
-            ->add('productId', 'hidden');
+            ->add('delete', CheckboxType::class)
+            ->add('quantity', IntegerType::class)
+            ->add('productId', HiddenType::class);
     }
 
     public function validateFormBasketElement(ErrorElement $errorElement, BasketElementInterface $basketElement, BasketInterface $basket): void

--- a/tests/Component/Currency/CurrencyFormTypeTest.php
+++ b/tests/Component/Currency/CurrencyFormTypeTest.php
@@ -16,6 +16,7 @@ namespace Sonata\Component\Tests\Currency;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Currency\CurrencyDataTransformer;
 use Sonata\Component\Currency\CurrencyFormType;
+use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Form\FormBuilder;
 
 /**
@@ -45,7 +46,7 @@ class CurrencyFormTypeTest extends TestCase
 
     public function testGetParent(): void
     {
-        $this->assertEquals('currency', $this->currencyFormType->getParent());
+        $this->assertEquals(CurrencyType::class, $this->currencyFormType->getParent());
     }
 
     public function testGetName(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the 2.x branch looks dead.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Remove form aliases
```


## Subject

This will now work with symfony 3.
