### PR TITLE
Change authentication check to REMEMBERED instead of FULLY in customerSelector

### DIFF
--- a/src/Component/Customer/CustomerSelector.php
+++ b/src/Component/Customer/CustomerSelector.php
@@ -66,7 +66,7 @@ class CustomerSelector implements CustomerSelectorInterface
         $customer = null;
         $user = null;
 
-        if (true === $this->securityContext->isGranted('IS_AUTHENTICATED_FULLY')) {
+        if (true === $this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
             // user is authenticated
             $user = $this->securityContext->getToken()->getUser();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

I am targeting this branch, because this is a bugfix that is backwards compatible.

Closes #549

## Changelog
- Fix CustomerSelector, users authenticated by the "remember me" cookie will now be linked to the created customer. 

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
Changed the authentication check in the CustomerSelector, check for IS_AUTHENTICATED_REMEMBERED.
```
