### PR TITLE
Update forms compatibility with Symfony 3

### DIFF
--- a/src/BasketBundle/Controller/Api/BasketController.php
+++ b/src/BasketBundle/Controller/Api/BasketController.php
@@ -384,7 +384,7 @@ class BasketController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $basket = $form->getData();
             if ($basket->getCustomerId()) {
                 $this->checkExistingCustomerBasket($basket->getCustomerId());
@@ -441,7 +441,7 @@ class BasketController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $basketElement = $form->getData();
 
             if ($elementId) {

--- a/src/BasketBundle/Form/AddressType.php
+++ b/src/BasketBundle/Form/AddressType.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Intl\Intl;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -134,7 +134,7 @@ class AddressType extends AbstractType
         $view->vars['addresses'] = $options['addresses'];
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => $this->addressClass,
@@ -146,11 +146,6 @@ class AddressType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sonata_basket_address';
-    }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 
     /**

--- a/src/BasketBundle/Form/ApiBasketElementType.php
+++ b/src/BasketBundle/Form/ApiBasketElementType.php
@@ -16,7 +16,7 @@ namespace Sonata\BasketBundle\Form;
 use Sonata\Component\Form\Transformer\SerializeDataTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -43,7 +43,7 @@ class ApiBasketElementType extends AbstractType
         );
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => $this->class,
@@ -54,11 +54,6 @@ class ApiBasketElementType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sonata_basket_api_form_basket_element';
-    }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 
     public function getParent()

--- a/src/BasketBundle/Form/ApiBasketType.php
+++ b/src/BasketBundle/Form/ApiBasketType.php
@@ -16,7 +16,7 @@ namespace Sonata\BasketBundle\Form;
 use Sonata\Component\Currency\CurrencyFormType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -50,7 +50,7 @@ class ApiBasketType extends AbstractType
         );
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => $this->class,
@@ -62,11 +62,6 @@ class ApiBasketType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sonata_basket_api_form_basket';
-    }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 
     public function getParent()

--- a/src/BasketBundle/Form/BasketType.php
+++ b/src/BasketBundle/Form/BasketType.php
@@ -42,9 +42,4 @@ class BasketType extends AbstractType
     {
         return 'sonata_basket_basket';
     }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
-    }
 }

--- a/src/BasketBundle/Form/PaymentType.php
+++ b/src/BasketBundle/Form/PaymentType.php
@@ -20,7 +20,6 @@ use Sonata\Component\Form\Transformer\PaymentMethodTransformer;
 use Sonata\Component\Payment\PaymentSelectorInterface;
 use Sonata\Component\Payment\Pool as PaymentPool;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -82,7 +81,7 @@ class PaymentType extends AbstractType
 
         $choices = [];
         foreach ($methods as $method) {
-            $choices[$method->getCode()] = $method->getName();
+            $choices[$method->getName()] = $method->getCode();
         }
 
         reset($methods);
@@ -92,7 +91,7 @@ class PaymentType extends AbstractType
 
         $sub = $builder->create('paymentMethod', ChoiceType::class, [
             'expanded' => true,
-            'choice_list' => new SimpleChoiceList($choices),
+            'choices' => $choices,
         ]);
 
         $sub->addViewTransformer(new PaymentMethodTransformer($this->paymentPool), true);
@@ -103,10 +102,5 @@ class PaymentType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sonata_basket_payment';
-    }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 }

--- a/src/BasketBundle/Form/ShippingType.php
+++ b/src/BasketBundle/Form/ShippingType.php
@@ -19,7 +19,6 @@ use Sonata\Component\Delivery\ServiceDeliverySelectorInterface;
 use Sonata\Component\Delivery\UndeliverableCountryException;
 use Sonata\Component\Form\Transformer\DeliveryMethodTransformer;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -61,7 +60,7 @@ class ShippingType extends AbstractType
 
         $choices = [];
         foreach ($methods as $method) {
-            $choices[$method->getCode()] = $method->getName();
+            $choices[$method->getName()] = $method->getCode();
         }
 
         reset($methods);
@@ -71,7 +70,7 @@ class ShippingType extends AbstractType
 
         $sub = $builder->create('deliveryMethod', ChoiceType::class, [
             'expanded' => true,
-            'choice_list' => new SimpleChoiceList($choices),
+            'choices' => $choices,
         ]);
 
         $sub->addViewTransformer(new DeliveryMethodTransformer($this->deliveryPool), true);
@@ -82,10 +81,5 @@ class ShippingType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sonata_basket_shipping';
-    }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 }

--- a/src/Component/Form/EventListener/BasketResizeFormListener.php
+++ b/src/Component/Form/EventListener/BasketResizeFormListener.php
@@ -16,6 +16,7 @@ namespace Sonata\Component\Form\EventListener;
 use Sonata\Component\Basket\BasketInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -87,7 +88,7 @@ class BasketResizeFormListener implements EventSubscriberInterface
         }
 
         foreach ($basketElements as $basketElement) {
-            $basketElementBuilder = $this->factory->createNamedBuilder($basketElement->getPosition(), 'form', $basketElement, [
+            $basketElementBuilder = $this->factory->createNamedBuilder($basketElement->getPosition(), FormType::class, $basketElement, [
                 'property_path' => '['.$basketElement->getPosition().']',
                 'auto_initialize' => false,
             ]);

--- a/src/CustomerBundle/Controller/Api/AddressController.php
+++ b/src/CustomerBundle/Controller/Api/AddressController.php
@@ -238,7 +238,7 @@ class AddressController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $address = $form->getData();
             $this->addressManager->save($address);
 

--- a/src/CustomerBundle/Controller/Api/CustomerController.php
+++ b/src/CustomerBundle/Controller/Api/CustomerController.php
@@ -301,7 +301,7 @@ class CustomerController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $address = $form->getData();
             $address->setCustomer($customer);
 
@@ -331,7 +331,7 @@ class CustomerController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $customer = $form->getData();
             $this->customerManager->save($customer);
 

--- a/src/CustomerBundle/Controller/CustomerController.php
+++ b/src/CustomerBundle/Controller/CustomerController.php
@@ -161,22 +161,20 @@ class CustomerController extends Controller
 
         $template = 'SonataCustomerBundle:Addresses:new.html.twig';
 
-        if ('POST' == $request->getMethod()) {
-            $form->handleRequest($request);
+        $form->handleRequest($request);
 
-            if ($form->isValid()) {
-                $address = $form->getData();
+        if ($form->isSubmitted() && $form->isValid()) {
+            $address = $form->getData();
 
-                $customer->addAddress($address);
+            $customer->addAddress($address);
 
-                $this->getCustomerManager()->save($customer);
+            $this->getCustomerManager()->save($customer);
 
-                $this->get('session')->getFlashBag()->add('sonata_customer_success', $id ? 'address_edit_success' : 'address_add_success');
+            $this->get('session')->getFlashBag()->add('sonata_customer_success', $id ? 'address_edit_success' : 'address_add_success');
 
-                $url = $this->get('session')->get('sonata_address_redirect', $this->generateUrl('sonata_customer_addresses'));
+            $url = $this->get('session')->get('sonata_address_redirect', $this->generateUrl('sonata_customer_addresses'));
 
-                return new RedirectResponse($url);
-            }
+            return new RedirectResponse($url);
         }
 
         return $this->render($template, [

--- a/src/CustomerBundle/Form/Type/AddressType.php
+++ b/src/CustomerBundle/Form/Type/AddressType.php
@@ -18,9 +18,8 @@ use Sonata\Component\Basket\BasketInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Intl\Intl;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Vincent Composieux <composieux@ekino.com>
@@ -75,10 +74,6 @@ class AddressType extends AbstractType
         }
 
         if (\count($countries) > 0) {
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
-                $countryOptions['choices_as_values'] = true;
-            }
             $countryOptions['choices'] = array_flip($countries);
         }
 
@@ -95,12 +90,7 @@ class AddressType extends AbstractType
         return $this->name;
     }
 
-    public function getName()
-    {
-        return $this->getBlockPrefix();
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'context' => 'default',

--- a/src/ProductBundle/Controller/Api/ProductController.php
+++ b/src/ProductBundle/Controller/Api/ProductController.php
@@ -440,7 +440,7 @@ class ProductController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $product = $form->getData();
             $product->setDescription($this->formatterPool->transform($product->getDescriptionFormatter(), $product->getRawDescription()));
             $product->setShortDescription($this->formatterPool->transform($product->getShortDescriptionFormatter(), $product->getRawShortDescription()));

--- a/src/ProductBundle/Controller/BaseProductController.php
+++ b/src/ProductBundle/Controller/BaseProductController.php
@@ -17,6 +17,7 @@ use Sonata\Component\Basket\BasketElementInterface;
 use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Product\ProductInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -41,7 +42,7 @@ abstract class BaseProductController extends Controller
 
         $provider = $this->get('sonata.product.pool')->getProvider($product);
 
-        $formBuilder = $this->get('form.factory')->createNamedBuilder('add_basket', 'form', null, ['data_class' => $this->container->getParameter('sonata.basket.basket_element.class'), 'csrf_protection' => false]);
+        $formBuilder = $this->get('form.factory')->createNamedBuilder('add_basket', FormType::class, null, ['data_class' => $this->container->getParameter('sonata.basket.basket_element.class'), 'csrf_protection' => false]);
         $provider->defineAddBasketForm($product, $formBuilder);
 
         $form = $formBuilder->getForm()->createView();

--- a/src/ProductBundle/Controller/ProductVariationAdminController.php
+++ b/src/ProductBundle/Controller/ProductVariationAdminController.php
@@ -60,33 +60,31 @@ class ProductVariationAdminController extends Controller
         // product is the main product object, used to create a set of variation
         $product = $this->admin->getParent()->getSubject();
 
-        if ($request->isMethod('POST')) {
-            $form->submit($request);
+        $form->handleRequest($request);
 
-            if ($form->isValid()) {
-                $number = $form->get('number')->getData();
+        if ($form->isSubmitted() && $form->isValid()) {
+            $number = $form->get('number')->getData();
 
-                $manager = $this->getProductManager();
-                $productProvider = $this->getProductPool()->getProvider($product);
+            $manager = $this->getProductManager();
+            $productProvider = $this->getProductPool()->getProvider($product);
 
-                for ($i = 1; $i <= $number; ++$i) {
-                    try {
-                        $variation = $productProvider->createVariation($product);
+            for ($i = 1; $i <= $number; ++$i) {
+                try {
+                    $variation = $productProvider->createVariation($product);
 
-                        $manager->persist($variation);
-                    } catch (\Exception $e) {
-                        $this->addFlash('sonata_flash_error', 'flash_create_variation_error');
+                    $manager->persist($variation);
+                } catch (\Exception $e) {
+                    $this->addFlash('sonata_flash_error', 'flash_create_variation_error');
 
-                        return new RedirectResponse($this->admin->generateUrl('create'));
-                    }
+                    return new RedirectResponse($this->admin->generateUrl('create'));
                 }
-
-                $manager->flush();
-
-                $this->addFlash('sonata_flash_success', $this->getTranslator()->trans('flash_create_variation_success', [], 'SonataProductBundle'));
-
-                return new RedirectResponse($this->admin->generateUrl('list'));
             }
+
+            $manager->flush();
+
+            $this->addFlash('sonata_flash_success', $this->getTranslator()->trans('flash_create_variation_success', [], 'SonataProductBundle'));
+
+            return new RedirectResponse($this->admin->generateUrl('list'));
         }
 
         return $this->render('SonataProductBundle:ProductAdmin:create_variation.html.twig', [

--- a/src/ProductBundle/Form/Type/ApiProductType.php
+++ b/src/ProductBundle/Form/Type/ApiProductType.php
@@ -16,7 +16,7 @@ namespace Sonata\ProductBundle\Form\Type;
 use Sonata\Component\Product\Pool;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Vincent Composieux <vincent.composieux@gmail.com>
@@ -44,7 +44,7 @@ class ApiProductType extends AbstractType
         }
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => null,
@@ -56,11 +56,6 @@ class ApiProductType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sonata_product_api_form_product';
-    }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 
     public function getParent()

--- a/src/ProductBundle/Resources/views/ProductAdmin/create_variation.html.twig
+++ b/src/ProductBundle/Resources/views/ProductAdmin/create_variation.html.twig
@@ -15,8 +15,7 @@ file that was distributed with this source code.
 
     <h5>{{ 'product.title.create_variations'|trans([], 'SonataProductBundle') }}</h5>
 
-    <form class="form-horizontal" action="{{ admin.generateUrl('create') }}" method="post" {{ form_enctype(form) }}>
-
+    {{ form_start(form, {'attr' : {'role': 'form', 'class': 'form-horizontal'}, 'action': admin.generateUrl('create'), 'method': 'post'}) }}
         {% if form.vars.errors|length > 0 %}
             <div class="sonata-ba-form-error">
                 {{ form_errors(form) }}
@@ -31,6 +30,6 @@ file that was distributed with this source code.
             <input type="submit" class="btn btn-primary" value="{{ 'product.submit.create_variations'|trans({}, 'SonataProductBundle') }}"/>
         </div>
 
-    </form>
+    {{ form_end(form) }}
 
 {% endblock %}

--- a/src/ProductBundle/Twig/Extension/ProductExtension.php
+++ b/src/ProductBundle/Twig/Extension/ProductExtension.php
@@ -17,6 +17,7 @@ use Sonata\Component\Currency\CurrencyInterface;
 use Sonata\Component\Product\Pool as ProductPool;
 use Sonata\Component\Product\ProductInterface;
 use Sonata\Component\Product\ProductProviderInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormView;
 
@@ -168,7 +169,7 @@ class ProductExtension extends \Twig_Extension
      */
     public function getFormAddBasket(ProductInterface $product)
     {
-        $formBuilder = $this->formFactory->createNamedBuilder('add_basket', 'form', null, [
+        $formBuilder = $this->formFactory->createNamedBuilder('add_basket', FormType::class, null, [
             'data_class' => $this->basketElementClass,
             'csrf_protection' => false,
         ]);

--- a/tests/BasketBundle/Controller/Api/BasketControllerTest.php
+++ b/tests/BasketBundle/Controller/Api/BasketControllerTest.php
@@ -97,6 +97,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basket));
 
@@ -117,6 +118,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData')->will($this->returnValue($basket));
 
@@ -138,6 +140,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basket));
 
@@ -159,6 +162,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData')->will($this->returnValue($basket));
 
@@ -225,6 +229,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basketElement));
 
@@ -267,6 +272,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData');
 
@@ -311,6 +317,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($basketElement));
 
@@ -354,6 +361,7 @@ class BasketControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
         $form->expects($this->never())->method('getData');
 

--- a/tests/CustomerBundle/Controller/Api/AddressControllerTest.php
+++ b/tests/CustomerBundle/Controller/Api/AddressControllerTest.php
@@ -66,6 +66,7 @@ class AddressControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($address));
 
@@ -86,6 +87,7 @@ class AddressControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
@@ -106,6 +108,7 @@ class AddressControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($address));
 
@@ -127,6 +130,7 @@ class AddressControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->createMock(FormFactoryInterface::class);

--- a/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
+++ b/tests/CustomerBundle/Controller/Api/CustomerControllerTest.php
@@ -91,6 +91,7 @@ class CustomerControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($customer));
 
@@ -112,6 +113,7 @@ class CustomerControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
@@ -136,6 +138,7 @@ class CustomerControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($address));
 
@@ -163,6 +166,7 @@ class CustomerControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
@@ -184,6 +188,7 @@ class CustomerControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($customer));
 
@@ -206,6 +211,7 @@ class CustomerControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->createMock(FormFactoryInterface::class);

--- a/tests/ProductBundle/Controller/Api/ProductControllerTest.php
+++ b/tests/ProductBundle/Controller/Api/ProductControllerTest.php
@@ -148,6 +148,7 @@ class ProductControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($product));
 
@@ -175,6 +176,7 @@ class ProductControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
@@ -202,6 +204,7 @@ class ProductControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($product));
 
@@ -230,6 +233,7 @@ class ProductControllerTest extends TestCase
 
         $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
+        $form->expects($this->once())->method('isSubmitted')->will($this->returnValue(true));
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
         $formFactory = $this->createMock(FormFactoryInterface::class);


### PR DESCRIPTION
## Subject

Update all forms to be compatible with Symfony 3.4 

I am targeting this branch, because it is the only branch currently supporting Symfony 3.

One step closer to Close #531

## Changelog

```markdown
### Changed
- form submissions to check `isSubmitted` before `isValid`
- form factory to use FQCN form FormType instead of `form` alias

### Removed
- `getName` method on all form types
```

