### PR TITLE
Fix validator compatibility with Symfony 3

### DIFF
--- a/src/BasketBundle/Controller/BasketController.php
+++ b/src/BasketBundle/Controller/BasketController.php
@@ -468,7 +468,7 @@ class BasketController extends Controller
 
         $violations = $this
             ->get('validator')
-            ->validate($basket, ['elements', 'delivery', 'payment']);
+            ->validate($basket, null, ['elements', 'delivery', 'payment']);
 
         if ($violations->count() > 0) {
             // basket not valid

--- a/src/ProductBundle/Admin/ProductAdmin.php
+++ b/src/ProductBundle/Admin/ProductAdmin.php
@@ -169,7 +169,7 @@ class ProductAdmin extends AbstractAdmin
     public function validate(ErrorElement $errorElement, $object): void
     {
         $errorElement
-            ->assertCallback(['validateOneMainCategory'])
+            ->assertCallback(['callback' => 'validateOneMainCategory'])
         ;
     }
 


### PR DESCRIPTION
## Subject

Fix the validator compatibility with Symfony 3

I am targeting this branch, because it is the only branch with support for Symfony 3.

Closes #470 

## Changelog

```markdown
### Fixed
- validator parameters to be compatible with Symfony 3
```
