### PR TITLE
Make services public

### DIFF
--- a/src/BasketBundle/Resources/config/basket.xml
+++ b/src/BasketBundle/Resources/config/basket.xml
@@ -10,7 +10,7 @@
             <argument type="service" id="sonata.delivery.pool"/>
             <argument type="service" id="sonata.payment.pool"/>
         </service>
-        <service id="sonata.customer.selector" class="%sonata.customer.selector.class%">
+        <service id="sonata.customer.selector" class="%sonata.customer.selector.class%" public="true">
             <argument type="service" id="sonata.customer.manager"/>
             <argument type="service" id="session"/>
             <argument type="service" id="security.authorization_checker"/>
@@ -21,7 +21,7 @@
             <argument type="service" id="sonata.basket.factory"/>
             <argument type="service" id="sonata.customer.selector"/>
         </service>
-        <service id="sonata.basket" class="Sonata\Component\Basket\Basket">
+        <service id="sonata.basket" class="Sonata\Component\Basket\Basket" public="true">
             <factory service="sonata.basket.loader" method="getBasket"/>
         </service>
         <service id="sonata.basket.block.nb_items" class="Sonata\BasketBundle\Block\BasketBlockService">

--- a/src/CustomerBundle/Resources/config/orm.xml
+++ b/src/CustomerBundle/Resources/config/orm.xml
@@ -5,7 +5,7 @@
         <parameter key="sonata.customer.manager.class">Sonata\CustomerBundle\Entity\CustomerManager</parameter>
     </parameters>
     <services>
-        <service id="sonata.address.manager" class="%sonata.address.manager.class%">
+        <service id="sonata.address.manager" class="%sonata.address.manager.class%" public="true">
             <argument>%sonata.customer.address.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>

--- a/src/InvoiceBundle/Resources/config/orm.xml
+++ b/src/InvoiceBundle/Resources/config/orm.xml
@@ -5,7 +5,7 @@
         <parameter key="sonata.invoice_element.manager.class">Sonata\InvoiceBundle\Entity\InvoiceElementManager</parameter>
     </parameters>
     <services>
-        <service id="sonata.invoice.manager" class="%sonata.invoice.manager.class%">
+        <service id="sonata.invoice.manager" class="%sonata.invoice.manager.class%" public="true">
             <argument>%sonata.invoice.invoice.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>

--- a/src/OrderBundle/Resources/config/orm.xml
+++ b/src/OrderBundle/Resources/config/orm.xml
@@ -5,7 +5,7 @@
         <parameter key="sonata.order.order_element.manager.class">Sonata\OrderBundle\Entity\OrderElementManager</parameter>
     </parameters>
     <services>
-        <service id="sonata.order.manager" class="%sonata.order.order.manager.class%">
+        <service id="sonata.order.manager" class="%sonata.order.order.manager.class%" public="true">
             <argument>%sonata.order.order.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>

--- a/src/PaymentBundle/Resources/config/payment.xml
+++ b/src/PaymentBundle/Resources/config/payment.xml
@@ -40,7 +40,7 @@
         </service>
         <service id="sonata.payment.provider.scellius.none_generator" class="%sonata.payment.provider.scellius.none_generator.class%"/>
         <service id="sonata.payment.provider.scellius.order_generator" class="%sonata.payment.provider.scellius.order_generator.class%"/>
-        <service id="sonata.payment.method.debug" class="%sonata.payment.method.debug.class%">
+        <service id="sonata.payment.method.debug" class="%sonata.payment.method.debug.class%" public="true">
             <tag name="sonata.payment.method"/>
             <argument type="service" id="router"/>
             <argument/>
@@ -52,7 +52,7 @@
             <argument type="service" id="templating"/>
             <argument>%kernel.debug%</argument>
         </service>
-        <service id="sonata.payment.handler" class="%sonata.payment.handler.class%">
+        <service id="sonata.payment.handler" class="%sonata.payment.handler.class%" public="true">
             <argument type="service" id="sonata.order.manager"/>
             <argument type="service" id="sonata.payment.selector"/>
             <argument type="service" id="sonata.generator"/>

--- a/src/PaymentBundle/Resources/config/transformer.xml
+++ b/src/PaymentBundle/Resources/config/transformer.xml
@@ -11,13 +11,13 @@
             <argument type="service" id="sonata.product.pool"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
-        <service id="sonata.payment.transformer.invoice" class="%sonata.invoice_transformer.class%">
+        <service id="sonata.payment.transformer.invoice" class="%sonata.invoice_transformer.class%" public="true">
             <tag name="sonata.payment.transformer"/>
             <argument type="service" id="sonata.invoice_element.manager"/>
             <argument type="service" id="sonata.delivery.pool"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
-        <service id="sonata.payment.transformer.basket" class="%sonata.basket_transformer.class%">
+        <service id="sonata.payment.transformer.basket" class="%sonata.basket_transformer.class%" public="true">
             <tag name="sonata.payment.transformer"/>
             <argument type="service" id="sonata.order.manager"/>
             <argument type="service" id="sonata.product.pool"/>

--- a/src/PriceBundle/Resources/config/price.xml
+++ b/src/PriceBundle/Resources/config/price.xml
@@ -13,7 +13,7 @@
             <argument type="service" id="doctrine"/>
         </service>
         <service id="sonata.price.currency.calculator" class="%sonata.price.currency.calculator.class%"/>
-        <service id="sonata.price.currency.detector" class="%sonata.price.currency.detector.class%">
+        <service id="sonata.price.currency.detector" class="%sonata.price.currency.detector.class%" public="true">
             <argument>%sonata.price.currency%</argument>
             <argument type="service" id="sonata.price.currency.manager"/>
         </service>

--- a/src/ProductBundle/Resources/config/orm.xml
+++ b/src/ProductBundle/Resources/config/orm.xml
@@ -16,7 +16,7 @@
             <argument>%sonata.product.package.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>
-        <service id="sonata.product.set.manager" class="%sonata.product.set.manager.class%">
+        <service id="sonata.product.set.manager" class="%sonata.product.set.manager.class%" public="true">
             <argument>%sonata.product.product.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>

--- a/src/ProductBundle/Resources/config/product.xml
+++ b/src/ProductBundle/Resources/config/product.xml
@@ -14,7 +14,7 @@
         <parameter key="sonata.product.seo.facebook.class">Sonata\ProductBundle\Seo\Services\Facebook</parameter>
     </parameters>
     <services>
-        <service id="sonata.product.pool" class="%sonata.product.pool.class%">
+        <service id="sonata.product.pool" class="%sonata.product.pool.class%" public="true">
 
         </service>
         <service id="sonata.product.subscriber.orm" class="%sonata.product.subscriber.orm.class%">
@@ -32,7 +32,7 @@
             <argument type="service" id="sonata.product.set.manager"/>
         </service>
         <!-- SEO -->
-        <service id="sonata.product.seo.twitter" class="%sonata.product.seo.twitter.class%">
+        <service id="sonata.product.seo.twitter" class="%sonata.product.seo.twitter.class%" public="true">
             <argument type="service" id="sonata.media.pool"/>
             <argument type="service" id="sonata.intl.templating.helper.number"/>
             <argument type="service" id="sonata.price.currency.detector"/>
@@ -41,7 +41,7 @@
             <argument>%sonata.product.seo.product.domain%</argument>
             <argument>%sonata.product.seo.product.media_format%</argument>
         </service>
-        <service id="sonata.product.seo.facebook" class="%sonata.product.seo.facebook.class%">
+        <service id="sonata.product.seo.facebook" class="%sonata.product.seo.facebook.class%" public="true">
             <argument type="service" id="router"/>
             <argument type="service" id="sonata.media.pool"/>
             <argument type="service" id="sonata.intl.templating.helper.number"/>


### PR DESCRIPTION
## Subject

In Symfony 3.4, services are private by default, which means that it can't be retrieved from the dumped container using the `get` method unless they are explicitly set to public.
These are all the services that I could find that are pulled directly from the container, which breaks in Symfony 4 (in 3.4 it will still work due to the BC layer)

I am targeting this branch, because it adds support for Symfony 3 and 4.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- service definitions to be public
```
