### PR TITLE
 Get product class from provider

### DIFF
--- a/src/ProductBundle/Admin/ProductAdmin.php
+++ b/src/ProductBundle/Admin/ProductAdmin.php
@@ -166,6 +166,15 @@ class ProductAdmin extends AbstractAdmin
         return $product;
     }
 
+    public function getClass()
+    {
+        if ($this->hasRequest() && $code = $this->getProductType()) {
+            return $this->getProductPool()->getManager($code)->getClass();
+        }
+
+        return parent::getClass();
+    }
+
     public function validate(ErrorElement $errorElement, $object): void
     {
         $errorElement


### PR DESCRIPTION
## Subject

When creating a new product, the product class is not correctly retrieved since the `provider` query parameter is not taken into account.

I am targeting this branch, because the issue was first introduced in the master branch in #502 

Closes #511

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- get product class from provider parameter
```
