### PR TITLE
Change template reference to use recommended native Twig reference

### DIFF
--- a/src/BasketBundle/Block/BasketBlockService.php
+++ b/src/BasketBundle/Block/BasketBlockService.php
@@ -49,7 +49,7 @@ class BasketBlockService extends AbstractAdminBlockService
     public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'template' => 'SonataBasketBundle:Block:block_basket_items.html.twig',
+            'template' => '@SonataBasket/Block/block_basket_items.html.twig',
         ]);
     }
 }

--- a/src/BasketBundle/Controller/BasketController.php
+++ b/src/BasketBundle/Controller/BasketController.php
@@ -62,7 +62,7 @@ class BasketController extends Controller
 
         $this->get('sonata.seo.page')->setTitle($this->get('translator')->trans('basket_index_title', [], 'SonataBasketBundle'));
 
-        return $this->render('SonataBasketBundle:Basket:index.html.twig', [
+        return $this->render('@SonataBasket/Basket/index.html.twig', [
             'basket' => $this->get('sonata.basket'),
             'form' => $form->createView(),
         ]);
@@ -149,7 +149,7 @@ class BasketController extends Controller
             $this->get('sonata.basket.factory')->save($basket);
 
             if ($request->isXmlHttpRequest() && $provider->getOption('product_add_modal')) {
-                return $this->render('SonataBasketBundle:Basket:add_product_popin.html.twig', [
+                return $this->render('@SonataBasket/Basket/add_product_popin.html.twig', [
                     'basketElement' => $basketElement,
                     'locale' => $basket->getLocale(),
                     'product' => $product,
@@ -189,7 +189,7 @@ class BasketController extends Controller
      */
     public function headerPreviewAction()
     {
-        return $this->render('SonataBasketBundle:Basket:header_preview.html.twig', [
+        return $this->render('@SonataBasket/Basket/header_preview.html.twig', [
             'basket' => $this->get('sonata.basket'),
         ]);
     }
@@ -255,7 +255,7 @@ class BasketController extends Controller
 
         $this->get('sonata.seo.page')->setTitle($this->get('translator')->trans('basket_payment_title', [], 'SonataBasketBundle'));
 
-        return $this->render('SonataBasketBundle:Basket:payment_step.html.twig', [
+        return $this->render('@SonataBasket/Basket/payment_step.html.twig', [
             'basket' => $basket,
             'form' => $form->createView(),
             'customer' => $customer,
@@ -295,7 +295,7 @@ class BasketController extends Controller
             return new RedirectResponse($this->generateUrl('sonata_basket_index'));
         }
 
-        $template = 'SonataBasketBundle:Basket:delivery_step.html.twig';
+        $template = '@SonataBasket/Basket/delivery_step.html.twig';
 
         $form->handleRequest($request);
 
@@ -350,7 +350,7 @@ class BasketController extends Controller
 
         // Show address creation / selection form
         $form = $this->createForm(AddressType::class, null, ['addresses' => $addresses]);
-        $template = 'SonataBasketBundle:Basket:delivery_address_step.html.twig';
+        $template = '@SonataBasket/Basket/delivery_address_step.html.twig';
 
         $form->handleRequest($request);
 
@@ -413,7 +413,7 @@ class BasketController extends Controller
 
         // Show address creation / selection form
         $form = $this->createForm(AddressType::class, null, ['addresses' => $addresses->toArray()]);
-        $template = 'SonataBasketBundle:Basket:payment_address_step.html.twig';
+        $template = '@SonataBasket/Basket/payment_address_step.html.twig';
 
         $form->handleRequest($request);
 
@@ -483,7 +483,7 @@ class BasketController extends Controller
 
         $this->get('sonata.seo.page')->setTitle($this->get('translator')->trans('basket_review_title', [], 'SonataBasketBundle'));
 
-        return $this->render('SonataBasketBundle:Basket:final_review_step.html.twig', [
+        return $this->render('@SonataBasket/Basket/final_review_step.html.twig', [
             'basket' => $basket,
             'tac_error' => 'POST' == $request->getMethod(),
         ]);

--- a/src/BasketBundle/Resources/views/Basket/add_product_form_button.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/add_product_form_button.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% set provider = sonata_product_provider(product) %}
 
-{% extends 'SonataBasketBundle:Basket:add_product_form.html.twig' %}
+{% extends '@SonataBasket/Basket/add_product_form.html.twig' %}
 
 {% block add_product_form_content %}
     {% if sonata_product_has_variations(product) %}

--- a/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/delivery_address_step.html.twig
@@ -12,10 +12,10 @@ file that was distributed with this source code.
 {% sonata_template_box 'This is the basket delivery address step template. Feel free to override it.' %}
 
 {% block sonata_flash_messages %}
-    {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+    {% include '@SonataCore/FlashMessage/render.html.twig' %}
 {% endblock %}
 
-{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'delivery'} %}
+{% include '@SonataBasket/Basket/stepper.html.twig' with {step: 'delivery'} %}
 
 {{ form_start(form, {'attr': {'role': 'form', 'class': 'form-horizontal'}}) }}
     {{ form_errors(form) }}

--- a/src/BasketBundle/Resources/views/Basket/delivery_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/delivery_step.html.twig
@@ -12,10 +12,10 @@ file that was distributed with this source code.
 {% sonata_template_box 'This is the basket delivery address template. Feel free to override it.' %}
 
 {% block sonata_flash_messages %}
-    {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+    {% include '@SonataCore/FlashMessage/render.html.twig' %}
 {% endblock %}
 
-{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'delivery'} %}
+{% include '@SonataBasket/Basket/stepper.html.twig' with {step: 'delivery'} %}
 
 {% block delivery_step %}
     <form action="{{ url('sonata_basket_delivery') }}" method="POST" >

--- a/src/BasketBundle/Resources/views/Basket/final_review_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/final_review_step.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% sonata_template_box 'This is the basket final review template. Feel free to override it.' %}
 
-{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'checkout'} %}
+{% include '@SonataBasket/Basket/stepper.html.twig' with {step: 'checkout'} %}
 
 <table class="table basket">
 

--- a/src/BasketBundle/Resources/views/Basket/index.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/index.html.twig
@@ -10,12 +10,12 @@ file that was distributed with this source code.
 #}
 
 {% block sonata_flash_messages %}
-    {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+    {% include '@SonataCore/FlashMessage/render.html.twig' %}
 {% endblock %}
 
 {% sonata_template_box 'This is the basket page template. Feel free to override it.' %}
 
-{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'basket'} %}
+{% include '@SonataBasket/Basket/stepper.html.twig' with {step: 'basket'} %}
 
 {% if basket.hasBasketElements %}
 

--- a/src/BasketBundle/Resources/views/Basket/payment_address_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/payment_address_step.html.twig
@@ -12,10 +12,10 @@ file that was distributed with this source code.
 {% sonata_template_box 'This is the basket billing address step template. Feel free to override it.' %}
 
 {% block sonata_flash_messages %}
-    {% include 'SonataCoreBundle:FlashMessage:render.html.twig' with {domain: 'SonataCustomerBundle'} %}
+    {% include '@SonataCore/FlashMessage/render.html.twig' with {domain: 'SonataCustomerBundle'} %}
 {% endblock %}
 
-{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'billing'} %}
+{% include '@SonataBasket/Basket/stepper.html.twig' with {step: 'billing'} %}
 
 {{ form_start(form, {'attr': {'class': 'form-horizontal'}}) }}
 {{ form_errors(form) }}

--- a/src/BasketBundle/Resources/views/Basket/payment_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/payment_step.html.twig
@@ -12,10 +12,10 @@ file that was distributed with this source code.
 {% sonata_template_box 'This is the basket billing step template. Feel free to override it.' %}
 
 {% block sonata_flash_messages %}
-    {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+    {% include '@SonataCore/FlashMessage/render.html.twig' %}
 {% endblock %}
 
-{% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'billing'} %}
+{% include '@SonataBasket/Basket/stepper.html.twig' with {step: 'billing'} %}
 
 <form action="{{ url('sonata_basket_payment') }}" method="POST" >
     <div class="row">

--- a/src/BasketBundle/Resources/views/Basket/render_delivery_address.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/render_delivery_address.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%extends 'TwigBundle::form.html.twig' %}
+{% extends '@TwigBundle/form.html.twig' %}
 
 {% block choice_field %}
     {% for choice, child in field %}

--- a/src/BasketBundle/Resources/views/Basket/render_payment_address.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/render_payment_address.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%extends 'TwigBundle::form.html.twig' %}
+{% extends '@TwigBundle/form.html.twig' %}
 
 {% block choice_field %}
     {% for choice, child in field %}

--- a/src/CustomerBundle/Admin/AddressAdmin.php
+++ b/src/CustomerBundle/Admin/AddressAdmin.php
@@ -86,7 +86,7 @@ class AddressAdmin extends AbstractAdmin
             ->addIdentifier('name')
             ->add('fulladdress', TextType::class, [
                 'code' => 'getFullAddressHtml',
-                'template' => 'SonataCustomerBundle:Admin:list_address.html.twig',
+                'template' => '@SonataCustomer/Admin/list_address.html.twig',
             ])
             ->add('current')
             ->add('typeCode', 'trans', ['catalogue' => $this->translationDomain])

--- a/src/CustomerBundle/Block/RecentCustomersBlockService.php
+++ b/src/CustomerBundle/Block/RecentCustomersBlockService.php
@@ -97,7 +97,7 @@ class RecentCustomersBlockService extends AbstractAdminBlockService
             'mode' => 'public',
             'title' => 'Recent Customers',
 //            'tags'      => 'Recent Customers',
-            'template' => 'SonataCustomerBundle:Block:recent_customers.html.twig',
+            'template' => '@SonataCustomer/Block/recent_customers.html.twig',
         ]);
     }
 }

--- a/src/CustomerBundle/Controller/CustomerController.php
+++ b/src/CustomerBundle/Controller/CustomerController.php
@@ -65,7 +65,7 @@ class CustomerController extends Controller
         // Set redirection URL to be to the list of addresses
         $this->get('session')->set('sonata_address_redirect', $this->generateUrl('sonata_customer_addresses'));
 
-        return $this->render('SonataCustomerBundle:Addresses:list.html.twig', [
+        return $this->render('@SonataCustomer/Addresses/list.html.twig', [
                 'addresses' => $addresses,
                 'customer' => $customer,
                 'breadcrumb_context' => 'customer_address',
@@ -159,7 +159,7 @@ class CustomerController extends Controller
             ]);
         }
 
-        $template = 'SonataCustomerBundle:Addresses:new.html.twig';
+        $template = '@SonataCustomer/Addresses/new.html.twig';
 
         $form->handleRequest($request);
 

--- a/src/CustomerBundle/Resources/views/Addresses/list.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/list.html.twig
@@ -1,4 +1,4 @@
-{% extends "SonataUserBundle:Profile:action.html.twig" %}
+{% extends "@SonataUser/Profile/action.html.twig" %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}address_list{% endtrans %}{% endblock %}
@@ -8,7 +8,7 @@
     {% sonata_template_box 'This is the customer addresses list template. Feel free to override it.' %}
 
     {% block sonata_flash_messages %}
-        {% include 'SonataCoreBundle:FlashMessage:render.html.twig' with {domain: 'SonataCustomerBundle'} %}
+        {% include '@SonataCore/FlashMessage/render.html.twig' with {domain: 'SonataCustomerBundle'} %}
     {% endblock %}
 
     {% block sonata_profile_address_actions %}

--- a/src/CustomerBundle/Resources/views/Addresses/new.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/new.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends "SonataUserBundle:Profile:action.html.twig" %}
+{% extends "@SonataUser/Profile/action.html.twig" %}
 
 {% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}address_new{% endtrans %}{% endblock %}
 

--- a/src/CustomerBundle/Resources/views/Admin/list_address.html.twig
+++ b/src/CustomerBundle/Resources/views/Admin/list_address.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "SonataAdminBundle:CRUD:list_string.html.twig" %}
+{% extends "@SonataAdmin/CRUD/list_string.html.twig" %}
 
 {% block field %}
     {{ value|raw }}

--- a/src/CustomerBundle/Twig/Extension/AddressExtension.php
+++ b/src/CustomerBundle/Twig/Extension/AddressExtension.php
@@ -108,7 +108,7 @@ class AddressExtension extends \Twig_Extension
             ];
         }
 
-        return $environment->render('SonataCustomerBundle:Addresses:_address.html.twig', [
+        return $environment->render('@SonataCustomer/Addresses/_address.html.twig', [
                 'address' => $addressArray,
                 'showName' => $showName,
                 'showEdit' => $showEdit,

--- a/src/InvoiceBundle/Admin/InvoiceAdmin.php
+++ b/src/InvoiceBundle/Admin/InvoiceAdmin.php
@@ -84,7 +84,7 @@ class InvoiceAdmin extends AbstractAdmin
             ->addIdentifier('reference')
             ->add('customer')
             ->add('status', TextType::class, [
-                'template' => 'SonataInvoiceBundle:InvoiceAdmin:list_status.html.twig',
+                'template' => '@SonataInvoice/InvoiceAdmin/list_status.html.twig',
             ])
             ->add('totalExcl', CurrencyFormType::class, [
                 'currency' => $this->currencyDetector->getCurrency()->getLabel(),

--- a/src/InvoiceBundle/Controller/InvoiceController.php
+++ b/src/InvoiceBundle/Controller/InvoiceController.php
@@ -59,7 +59,7 @@ class InvoiceController extends Controller
 
         $this->get('sonata.seo.page')->setTitle($this->get('translator')->trans('invoice_view_title', [], 'SonataInvoiceBundle'));
 
-        return $this->render('SonataInvoiceBundle:Invoice:view.html.twig', [
+        return $this->render('@SonataInvoice/Invoice/view.html.twig', [
             'invoice' => $invoice,
             'order' => $order,
         ]);

--- a/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "SonataUserBundle:Profile:action.html.twig" %}
+{% extends "@SonataUser/Profile/action.html.twig" %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataInvoiceBundle' %}sonata.invoice.title_invoice{% endtrans %} - {{ invoice.reference }}{% endblock %}

--- a/src/InvoiceBundle/Resources/views/InvoiceAdmin/list_status.html.twig
+++ b/src/InvoiceBundle/Resources/views/InvoiceAdmin/list_status.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
     <span class="label{{ object|sonata_status_class(null, 'danger') ? ' label-'~object|sonata_status_class(null, 'danger') : '' }}">{{ object.statusName|trans([], 'SonataInvoiceBundle') }}</span>

--- a/src/OrderBundle/Admin/OrderAdmin.php
+++ b/src/OrderBundle/Admin/OrderAdmin.php
@@ -146,13 +146,13 @@ class OrderAdmin extends AbstractAdmin
 
         $list
             ->add('status', TextType::class, [
-                'template' => 'SonataOrderBundle:OrderAdmin:list_status.html.twig',
+                'template' => '@SonataOrder/OrderAdmin/list_status.html.twig',
             ])
             ->add('deliveryStatus', TextType::class, [
-                'template' => 'SonataOrderBundle:OrderAdmin:list_delivery_status.html.twig',
+                'template' => '@SonataOrder/OrderAdmin/list_delivery_status.html.twig',
             ])
             ->add('paymentStatus', TextType::class, [
-                'template' => 'SonataOrderBundle:OrderAdmin:list_payment_status.html.twig',
+                'template' => '@SonataOrder/OrderAdmin/list_payment_status.html.twig',
             ])
             ->add('validatedAt')
             ->add('totalInc', CurrencyFormType::class, ['currency' => $currency])

--- a/src/OrderBundle/Block/RecentOrdersBlockService.php
+++ b/src/OrderBundle/Block/RecentOrdersBlockService.php
@@ -128,7 +128,7 @@ class RecentOrdersBlockService extends BaseBlockService
             'number' => 5,
             'mode' => 'public',
             'title' => 'Recent Orders',
-            'template' => 'SonataOrderBundle:Block:recent_orders.html.twig',
+            'template' => '@SonataOrder/Block/recent_orders.html.twig',
         ]);
     }
 }

--- a/src/OrderBundle/Controller/OrderCRUDController.php
+++ b/src/OrderBundle/Controller/OrderCRUDController.php
@@ -30,7 +30,7 @@ class OrderCRUDController extends CRUDController
         }
 
         if (null === $this->getRequest()->get('confirm')) {
-            return $this->render('SonataOrderBundle:OrderAdmin:invoice_generate_confirm.html.twig', ['id' => $id]);
+            return $this->render('@SonataOrder/OrderAdmin/invoice_generate_confirm.html.twig', ['id' => $id]);
         }
 
         $order = $this->admin->getObject($id);

--- a/src/OrderBundle/Controller/OrderController.php
+++ b/src/OrderBundle/Controller/OrderController.php
@@ -40,7 +40,7 @@ class OrderController extends Controller
 
         $this->get('sonata.seo.page')->setTitle($this->get('translator')->trans('order_index_title', [], 'SonataOrderBundle'));
 
-        return $this->render('SonataOrderBundle:Order:index.html.twig', [
+        return $this->render('@SonataOrder/Order/index.html.twig', [
             'orders' => $orders,
             'breadcrumb_context' => 'user_order',
         ]);
@@ -72,7 +72,7 @@ class OrderController extends Controller
             $element->setProduct($provider->getProductFromRaw($element, $this->get('sonata.product.pool')->getManager($element->getProductType())->getClass()));
         }
 
-        return $this->render('SonataOrderBundle:Order:view.html.twig', [
+        return $this->render('@SonataOrder/Order/view.html.twig', [
             'order' => $order,
             'breadcrumb_context' => 'user_order',
         ]);

--- a/src/OrderBundle/Resources/views/Order/index.html.twig
+++ b/src/OrderBundle/Resources/views/Order/index.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "SonataUserBundle:Profile:action.html.twig" %}
+{% extends "@SonataUser/Profile/action.html.twig" %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataOrderBundle' %}order_list{% endtrans %}{% endblock %}

--- a/src/OrderBundle/Resources/views/Order/view.html.twig
+++ b/src/OrderBundle/Resources/views/Order/view.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "SonataUserBundle:Profile:action.html.twig" %}
+{% extends "@SonataUser/Profile/action.html.twig" %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataOrderBundle' %}sonata.order.title_order{% endtrans %} - {{ order.reference }}{% endblock %}

--- a/src/OrderBundle/Resources/views/OrderAdmin/invoice_generate_confirm.html.twig
+++ b/src/OrderBundle/Resources/views/OrderAdmin/invoice_generate_confirm.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle::standard_layout.html.twig' %}
+{% extends '@SonataAdmin/standard_layout.html.twig' %}
 
 {% block sonata_admin_content %}
     <div class="alert alert-info col-sm-6">

--- a/src/OrderBundle/Resources/views/OrderAdmin/list_delivery_status.html.twig
+++ b/src/OrderBundle/Resources/views/OrderAdmin/list_delivery_status.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
     <span class="label{{ object|sonata_status_class('delivery', 'danger') ? ' label-'~object|sonata_status_class('delivery', 'danger') : '' }}">{{ object.deliveryStatusName|trans([], 'SonataDeliveryBundle') }}</span>

--- a/src/OrderBundle/Resources/views/OrderAdmin/list_payment_status.html.twig
+++ b/src/OrderBundle/Resources/views/OrderAdmin/list_payment_status.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
     <span class="label{{ object|sonata_status_class('payment', 'danger') ? ' label-'~object|sonata_status_class('payment', 'danger') : '' }}">{{ object.paymentStatusName|trans([], 'SonataPaymentBundle') }}</span>

--- a/src/OrderBundle/Resources/views/OrderAdmin/list_status.html.twig
+++ b/src/OrderBundle/Resources/views/OrderAdmin/list_status.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
     <span class="label{{ object|sonata_status_class(null, 'danger') ? ' label-'~object|sonata_status_class(null, 'danger') : '' }}">{{ object.statusName|trans([], 'SonataOrderBundle') }}</span>

--- a/src/PaymentBundle/Controller/DebugPaymentController.php
+++ b/src/PaymentBundle/Controller/DebugPaymentController.php
@@ -38,7 +38,7 @@ class DebugPaymentController extends Controller
     {
         $order = $this->checkRequest();
 
-        return $this->render('SonataPaymentBundle:Payment:debug.html.twig', [
+        return $this->render('@SonataPayment/Payment/debug.html.twig', [
             'order' => $order,
             'check' => $request->get('check'),
         ]);

--- a/src/PaymentBundle/Controller/PaymentController.php
+++ b/src/PaymentBundle/Controller/PaymentController.php
@@ -45,7 +45,7 @@ class PaymentController extends Controller
             throw new UnauthorizedHttpException($ex->getMessage());
         }
 
-        return $this->render('SonataPaymentBundle:Payment:error.html.twig', [
+        return $this->render('@SonataPayment/Payment/error.html.twig', [
             'order' => $order,
         ]);
     }
@@ -67,12 +67,12 @@ class PaymentController extends Controller
         }
 
         if (!($order->isValidated() || $order->isPending())) {
-            return $this->render('SonataPaymentBundle:Payment:error.html.twig', [
+            return $this->render('@SonataPayment/Payment/error.html.twig', [
                 'order' => $order,
             ]);
         }
 
-        return $this->render('SonataPaymentBundle:Payment:confirmation.html.twig', [
+        return $this->render('@SonataPayment/Payment/confirmation.html.twig', [
             'order' => $order,
         ]);
     }
@@ -145,7 +145,7 @@ class PaymentController extends Controller
      */
     public function termsAction()
     {
-        return $this->render('SonataPaymentBundle:Payment:terms.html.twig');
+        return $this->render('@SonataPayment/Payment/terms.html.twig');
     }
 
     /**

--- a/src/PaymentBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentBundle/DependencyInjection/Configuration.php
@@ -197,7 +197,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('url_return_ko')->defaultValue('sonata_payment_error')->cannotBeEmpty()->end()
                                         ->scalarNode('url_return_ok')->defaultValue('sonata_payment_confirmation')->cannotBeEmpty()->end()
 
-                                        ->scalarNode('template')->defaultValue('SonataPaymentBundle:Payment:scellius.html.twig')->cannotBeEmpty()->end()
+                                        ->scalarNode('template')->defaultValue('@SonataPayment/Payment/scellius.html.twig')->cannotBeEmpty()->end()
                                         ->scalarNode('shop_secret_key')->cannotBeEmpty()->end()
                                         ->scalarNode('request_command')->cannotBeEmpty()->end()
                                         ->scalarNode('response_command')->cannotBeEmpty()->end()
@@ -259,7 +259,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('sha_key')->isRequired()->cannotBeEmpty()->end()
                                         ->scalarNode('sha-out_key')->isRequired()->cannotBeEmpty()->end()
 
-                                        ->scalarNode('template')->defaultValue('SonataPaymentBundle:Payment:ogone.html.twig')->cannotBeEmpty()->end()
+                                        ->scalarNode('template')->defaultValue('@SonataPayment/Payment/ogone.html.twig')->cannotBeEmpty()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/PaymentBundle/Resources/views/Payment/terms.html.twig
+++ b/src/PaymentBundle/Resources/views/Payment/terms.html.twig
@@ -1,7 +1,7 @@
 <h1>Terms and Conditions</h1>
 
 <div class='alert alert-default alert-info'>
-    <p>This page should contain your “Terms and Conditions” policy. Feel free to override it. This file can be found in <code>SonataPaymentBundle:Payment:terms.html.twig</code>.</p>
+    <p>This page should contain your “Terms and Conditions” policy. Feel free to override it. This file can be found in <code>@SonataPayment/Payment/terms.html.twig</code>.</p>
 </div>
 
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quae cum essent dicta, finem fecimus et ambulandi et disputandi. Duo Reges: constructio interrete. Itaque eos id agere, ut a se dolores, morbos, debilitates repellant. Quae cum dixisset paulumque institisset, Quid est? At iam decimum annum in spelunca iacet. Tibi hoc incredibile, quod beatissimum. Conferam avum tuum Drusum cum C. </p>

--- a/src/ProductBundle/Block/CategoriesMenuBlockService.php
+++ b/src/ProductBundle/Block/CategoriesMenuBlockService.php
@@ -53,7 +53,7 @@ class CategoriesMenuBlockService extends MenuBlockService
         parent::configureSettings($resolver);
 
         $resolver->setDefaults([
-                'menu_template' => 'SonataBlockBundle:Block:block_side_menu_template.html.twig',
+                'menu_template' => '@SonataBlock/Block/block_side_menu_template.html.twig',
                 'safe_labels' => true,
             ]);
     }

--- a/src/ProductBundle/Block/RecentProductsBlockService.php
+++ b/src/ProductBundle/Block/RecentProductsBlockService.php
@@ -104,7 +104,7 @@ class RecentProductsBlockService extends BaseBlockService
         $resolver->setDefaults([
             'number' => 5,
             'title' => 'Recent products',
-            'template' => 'SonataProductBundle:Block:recent_products.html.twig',
+            'template' => '@SonataProduct/Block/recent_products.html.twig',
         ]);
     }
 

--- a/src/ProductBundle/Block/SimilarProductsBlockService.php
+++ b/src/ProductBundle/Block/SimilarProductsBlockService.php
@@ -119,7 +119,7 @@ class SimilarProductsBlockService extends BaseBlockService
             'number' => 5,
             'title' => 'Similar products',
             'base_product_id' => null,
-            'template' => 'SonataProductBundle:Block:similar_products.html.twig',
+            'template' => '@SonataProduct/Block/similar_products.html.twig',
         ]);
     }
 

--- a/src/ProductBundle/Block/VariationsFormBlockService.php
+++ b/src/ProductBundle/Block/VariationsFormBlockService.php
@@ -134,7 +134,7 @@ class VariationsFormBlockService extends BaseBlockService
             },
             'form_field_options' => [],
             'title' => 'Product variations',
-            'template' => 'SonataProductBundle:Block:variations_choice.html.twig',
+            'template' => '@SonataProduct/Block/variations_choice.html.twig',
         ]);
     }
 }

--- a/src/ProductBundle/Controller/CatalogController.php
+++ b/src/ProductBundle/Controller/CatalogController.php
@@ -52,7 +52,7 @@ class CatalogController extends Controller
         $pager = $this->get('knp_paginator');
         $pagination = $pager->paginate($this->getProductSetManager()->getCategoryActiveProductsQueryBuilder($category, $filter, $option), $page, $displayMax);
 
-        return $this->render('SonataProductBundle:Catalog:index.html.twig', [
+        return $this->render('@SonataProduct/Catalog/index.html.twig', [
             'display_mode' => $displayMode,
             'pager' => $pagination,
             'currency' => $this->getCurrencyDetector()->getCurrency(),

--- a/src/ProductBundle/Controller/CategoryController.php
+++ b/src/ProductBundle/Controller/CategoryController.php
@@ -29,7 +29,7 @@ class CategoryController extends Controller
     {
         $category = $category ?: $this->get('sonata.classification.manager.category')->getRootCategory();
 
-        return $this->render('SonataProductBundle:Category:side_menu_category.html.twig', [
+        return $this->render('@SonataProduct/Category/side_menu_category.html.twig', [
           'root_category' => $category,
           'depth' => $depth,
           'deep' => $deep + 1,

--- a/src/ProductBundle/Controller/CollectionController.php
+++ b/src/ProductBundle/Controller/CollectionController.php
@@ -30,7 +30,7 @@ class CollectionController extends Controller
         $pager = $this->get('sonata.classification.manager.collection')
             ->getRootCollectionsPager($request->get('page'));
 
-        return $this->render('SonataProductBundle:Collection:index.html.twig', [
+        return $this->render('@SonataProduct/Collection/index.html.twig', [
             'pager' => $pager,
         ]);
     }
@@ -54,7 +54,7 @@ class CollectionController extends Controller
             throw new NotFoundHttpException(sprintf('Unable to find the collection with id=%d', $collectionId));
         }
 
-        return $this->render('SonataProductBundle:Collection:view.html.twig', [
+        return $this->render('@SonataProduct/Collection/view.html.twig', [
            'collection' => $collection,
         ]);
     }
@@ -71,7 +71,7 @@ class CollectionController extends Controller
         $pager = $this->get('sonata.classification.manager.collection')
             ->getSubCollectionsPager($collectionId, $request->get('page'));
 
-        return $this->render('SonataProductBundle:Collection:list_sub_collections.html.twig', [
+        return $this->render('@SonataProduct/Collection/list_sub_collections.html.twig', [
             'pager' => $pager,
         ]);
     }
@@ -88,7 +88,7 @@ class CollectionController extends Controller
         $pager = $this->get('sonata.product.set.manager')
             ->getProductsByCollectionIdPager($collectionId, $request->get('page'));
 
-        return $this->render('SonataProductBundle:Collection:list_products.html.twig', [
+        return $this->render('@SonataProduct/Collection/list_products.html.twig', [
             'pager' => $pager,
         ]);
     }
@@ -104,7 +104,7 @@ class CollectionController extends Controller
     {
         $collection = $collection ?: $this->get('sonata.classification.manager.collection')->getRootCollection();
 
-        return $this->render('SonataProductBundle:Collection:side_menu_collection.html.twig', [
+        return $this->render('@SonataProduct/Collection/side_menu_collection.html.twig', [
           'root_collection' => $collection,
           'depth' => $depth,
           'deep' => $deep + 1,

--- a/src/ProductBundle/Controller/ProductAdminController.php
+++ b/src/ProductBundle/Controller/ProductAdminController.php
@@ -36,7 +36,7 @@ class ProductAdminController extends Controller
         $parameters = $this->admin->getPersistentParameters();
 
         if (!$parameters['provider']) {
-            return $this->render('SonataProductBundle:ProductAdmin:select_provider.html.twig', [
+            return $this->render('@SonataProduct/ProductAdmin/select_provider.html.twig', [
                 'providers' => $this->get('sonata.product.pool')->getProducts(),
                 'base_template' => $this->getBaseTemplate(),
                 'admin' => $this->admin,
@@ -62,7 +62,7 @@ class ProductAdminController extends Controller
             throw new NotFoundHttpException('Product not found.');
         }
 
-        return $this->render('SonataProductBundle:ProductAdmin:variations.html.twig', [
+        return $this->render('@SonataProduct/ProductAdmin/variations.html.twig', [
             'product' => $product,
         ]);
     }

--- a/src/ProductBundle/Controller/ProductVariationAdminController.php
+++ b/src/ProductBundle/Controller/ProductVariationAdminController.php
@@ -87,7 +87,7 @@ class ProductVariationAdminController extends Controller
             return new RedirectResponse($this->admin->generateUrl('list'));
         }
 
-        return $this->render('SonataProductBundle:ProductAdmin:create_variation.html.twig', [
+        return $this->render('@SonataProduct/ProductAdmin/create_variation.html.twig', [
             'object' => $product,
             'form' => $form->createView(),
             'action' => 'edit',

--- a/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/final_review_basket_element.html.twig
+++ b/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/final_review_basket_element.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
       => rewrite your own template
 #}
 
-{% extends 'SonataProductBundle:Product:final_review_basket_element.html.twig' %}
+{% extends '@SonataProduct/Product/final_review_basket_element.html.twig' %}
 
 {% block product_description %}
     <b>{{ basketElement.name }}</b> <br />

--- a/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/form_basket_element.html.twig
+++ b/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/form_basket_element.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
       => rewrite your own template
 #}
 
-{% extends 'SonataProductBundle:Product:form_basket_element.html.twig' %}
+{% extends '@SonataProduct/Product/form_basket_element.html.twig' %}
 
 {% block product_description %}
     <b><a href="{{ url('sonata_product_view', {'productId': basketElement.product.id, 'slug': basketElement.product.slug}) }}">{{ basketElement.name }}</a></b> <br />

--- a/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/view.html.twig
+++ b/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/view.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
       => rewrite your own template
 #}
 
-{% extends 'SonataProductBundle:Product:view.html.twig' %}
+{% extends '@SonataProduct/Product/view.html.twig' %}
 
 {% block product_title %}{{ product.name }}{% endblock %}
 

--- a/src/ProductBundle/Resources/views/Block/_base_products_block.html.twig
+++ b/src/ProductBundle/Resources/views/Block/_base_products_block.html.twig
@@ -31,7 +31,7 @@ file that was distributed with this source code.
 
                         {% if sonata_product_has_enabled_variations(product) or not sonata_product_has_variations(product) %}
                             <li class="col-sm-3" itemscope itemtype="http://schema.org/Product">
-                                {% include 'SonataProductBundle:Catalog:_product_grid.html.twig' %}
+                                {% include '@SonataProduct/Catalog/_product_grid.html.twig' %}
                             </li>
                         {% endif %}
 

--- a/src/ProductBundle/Resources/views/Block/recent_products.html.twig
+++ b/src/ProductBundle/Resources/views/Block/recent_products.html.twig
@@ -8,4 +8,4 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends 'SonataProductBundle:Block:_base_products_block.html.twig' %}
+{% extends '@SonataProduct/Block/_base_products_block.html.twig' %}

--- a/src/ProductBundle/Resources/views/Block/similar_products.html.twig
+++ b/src/ProductBundle/Resources/views/Block/similar_products.html.twig
@@ -8,4 +8,4 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends 'SonataProductBundle:Block:_base_products_block.html.twig' %}
+{% extends '@SonataProduct/Block/_base_products_block.html.twig' %}

--- a/src/ProductBundle/Resources/views/Catalog/_product_grid.html.twig
+++ b/src/ProductBundle/Resources/views/Catalog/_product_grid.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "SonataProductBundle:Product:view_thumbnail.html.twig" %}
+{% extends "@SonataProduct/Product/view_thumbnail.html.twig" %}

--- a/src/ProductBundle/Resources/views/Catalog/grid.html.twig
+++ b/src/ProductBundle/Resources/views/Catalog/grid.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
         {% if not sonata_product_has_variations(product) or (sonata_product_has_variations(product) and sonata_product_has_enabled_variations(product)) %}
 
             <div class="col-sm-4" itemscope itemtype="http://schema.org/Product">
-                {% include 'SonataProductBundle:Catalog:_product_grid.html.twig' %}
+                {% include '@SonataProduct/Catalog/_product_grid.html.twig' %}
             </div>
 
         {% endif %}

--- a/src/ProductBundle/Resources/views/Catalog/index.html.twig
+++ b/src/ProductBundle/Resources/views/Catalog/index.html.twig
@@ -9,11 +9,11 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataProductBundle:Catalog:layout.html.twig' %}
+{% extends '@SonataProduct/Catalog/layout.html.twig' %}
 
 
 {% block products %}
 
-    {% include 'SonataProductBundle:Catalog:' ~ display_mode ~ '.html.twig' %}
+    {% include '@SonataProduct/Catalog/' ~ display_mode ~ '.html.twig' %}
 
 {% endblock %}

--- a/src/ProductBundle/Resources/views/Catalog/layout.html.twig
+++ b/src/ProductBundle/Resources/views/Catalog/layout.html.twig
@@ -67,7 +67,7 @@ file that was distributed with this source code.
                             </h4>
                         </div>
                         <div class="col-sm-9">
-                            {% include 'SonataProductBundle:Catalog:_pager.html.twig' %}
+                            {% include '@SonataProduct/Catalog/_pager.html.twig' %}
                         </div>
                     </div>
                 </div>
@@ -78,7 +78,7 @@ file that was distributed with this source code.
                     <div class="panel-footer">
                         <div class="row">
                             <div class="col-sm-12">
-                                {% include 'SonataProductBundle:Catalog:_pager.html.twig' %}
+                                {% include '@SonataProduct/Catalog/_pager.html.twig' %}
                             </div>
                         </div>
                     </div>

--- a/src/ProductBundle/Resources/views/Product/view.html.twig
+++ b/src/ProductBundle/Resources/views/Product/view.html.twig
@@ -36,7 +36,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block product %}
-    {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+    {% include '@SonataCore/FlashMessage/render.html.twig' %}
     <!-- Begin product display -->
     <div class="row">
         <div class="col-lg-12">
@@ -49,7 +49,7 @@ file that was distributed with this source code.
                 {% block product_carousel %}
                     <div>
                         {% if product.gallery and product.gallery.galleryHasMedias|length > 0 %}
-                            {% include "SonataProductBundle:Product:carousel.html.twig" %}
+                            {% include "@SonataProduct/Product/carousel.html.twig" %}
                         {% else %}
                             {% thumbnail product.image, 'large' with {'itemprop':'image', 'class': 'img-rounded img-responsive', 'style': 'margin: 0 10px 10px 0;'} %}
                         {% endif %}
@@ -122,7 +122,7 @@ file that was distributed with this source code.
                             <div itemprop="offers" class="row" itemscope itemtype="http://schema.org/Offer">
                                 <div class="col-lg-12">
                                     {% block product_basket %}
-                                        {% include "SonataBasketBundle:Basket:add_product_form.html.twig" %}
+                                        {% include "@SonataBasket/Basket/add_product_form.html.twig" %}
                                     {% endblock %}
                                 </div>
                             </div>
@@ -138,7 +138,7 @@ file that was distributed with this source code.
     <!-- Cross selling -->
     <div>
         {% block product_cross_selling %}
-            {% include "SonataProductBundle:Product:view_similar.html.twig" %}
+            {% include "@SonataProduct/Product/view_similar.html.twig" %}
         {% endblock %}
     </div>
     <!-- End Cross selling -->

--- a/src/ProductBundle/Resources/views/Product/view_thumbnail.html.twig
+++ b/src/ProductBundle/Resources/views/Product/view_thumbnail.html.twig
@@ -26,7 +26,7 @@ file that was distributed with this source code.
         </div>
         <div class="panel-footer">
             <span class="text-left">
-                {% include "SonataBasketBundle:Basket:add_product_form_button.html.twig" %}
+                {% include "@SonataBasket/Basket/add_product_form_button.html.twig" %}
             </span>
             <span itemprop="price" class="text-right">
                 {% if not sonata_product_has_variations(product) %}

--- a/src/ProductBundle/Resources/views/ProductAdmin/create_variation.html.twig
+++ b/src/ProductBundle/Resources/views/ProductAdmin/create_variation.html.twig
@@ -1,4 +1,4 @@
-{#
+o{#
 
 This file is part of the Sonata package.
 
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_edit.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_edit.html.twig' %}
 
 {% block form %}
 

--- a/src/ProductBundle/Resources/views/ProductAdmin/edit.html.twig
+++ b/src/ProductBundle/Resources/views/ProductAdmin/edit.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_edit.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_edit.html.twig' %}
 
 {% block preview %}
     {% if product is defined and product.id %}

--- a/src/ProductBundle/Resources/views/ProductAdmin/list.html.twig
+++ b/src/ProductBundle/Resources/views/ProductAdmin/list.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}
 
 {% block preview %}
     {% if product is defined and product.id %}

--- a/src/ProductBundle/Resources/views/ProductAdmin/select_provider.html.twig
+++ b/src/ProductBundle/Resources/views/ProductAdmin/select_provider.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:action.html.twig' %}
+{% extends '@SonataAdmin/CRUD/action.html.twig' %}
 
 {% block title %}{% trans from 'SonataPageBundle' %}title_select_provider{% endtrans %}{% endblock %}
 


### PR DESCRIPTION
## Subject

Change all templates reference to use the recommended native Twig reference

`@SonataProductBundle/Path/template.html.twig` instead of `SonataProductBundle:Path:template.html.twig`
<!-- Describe your Pull Request content here -->

I am targeting this branch, because it is the recommended way to reference and override template since Symfony 3.
