### PR TITLE
Fix forms to be compatible with Symfony 3.0+

### DIFF
--- a/src/BasketBundle/Form/AddressType.php
+++ b/src/BasketBundle/Form/AddressType.php
@@ -21,7 +21,6 @@ use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -94,11 +93,6 @@ class AddressType extends AbstractType
                 'translation_domain' => 'SonataCustomerBundle',
             ];
 
-            // choice_as_value option is not needed in SF 3.0+
-            if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
-                $typeOptions['choices_as_values'] = true;
-            }
-
             $builder->add('type', ChoiceType::class, $typeOptions);
         }
 
@@ -118,11 +112,6 @@ class AddressType extends AbstractType
         $countryOptions = ['required' => !\count($addresses)];
 
         if (\count($countries) > 0) {
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
-                $countryOptions['choices_as_values'] = true;
-            }
-
             $countryOptions['choices'] = array_flip($countries);
         }
 

--- a/src/Component/Currency/CurrencyFormType.php
+++ b/src/Component/Currency/CurrencyFormType.php
@@ -50,9 +50,4 @@ class CurrencyFormType extends CurrencyType
     {
         return 'sonata_currency';
     }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
-    }
 }

--- a/src/Component/Form/Type/DeliveryChoiceType.php
+++ b/src/Component/Form/Type/DeliveryChoiceType.php
@@ -16,7 +16,7 @@ namespace Sonata\Component\Form\Type;
 use Sonata\Component\Delivery\Pool;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DeliveryChoiceType extends AbstractType
 {
@@ -40,12 +40,7 @@ class DeliveryChoiceType extends AbstractType
         return 'sonata_delivery_choice';
     }
 
-    public function getName()
-    {
-        return $this->getBlockPrefix();
-    }
-
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $choices = [];
 

--- a/src/Component/Form/Type/VariationChoiceType.php
+++ b/src/Component/Form/Type/VariationChoiceType.php
@@ -17,8 +17,7 @@ use Sonata\Component\Product\Pool;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormTypeInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -49,11 +48,6 @@ class VariationChoiceType extends AbstractType
                 'translation_domain' => 'SonataProductBundle',
             ];
 
-            // choice_as_value option is not needed in SF 3.0+
-            if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
-
             $builder->add($choiceTitle, ChoiceType::class, array_merge(
                 $choiceOptions,
                 $options['field_options']
@@ -61,7 +55,7 @@ class VariationChoiceType extends AbstractType
         }
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver): void
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'field_options' => [],
@@ -77,10 +71,5 @@ class VariationChoiceType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sonata_product_variation_choices';
-    }
-
-    public function getName()
-    {
-        return $this->getBlockPrefix();
     }
 }

--- a/src/OrderBundle/Admin/OrderElementAdmin.php
+++ b/src/OrderBundle/Admin/OrderElementAdmin.php
@@ -22,7 +22,6 @@ use Sonata\Component\Product\Pool;
 use Sonata\OrderBundle\Form\Type\OrderStatusType;
 use Sonata\ProductBundle\Form\Type\ProductDeliveryStatusType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\FormTypeInterface;
 
 class OrderElementAdmin extends AbstractAdmin
 {
@@ -63,11 +62,6 @@ class OrderElementAdmin extends AbstractAdmin
         $productTypeOptions = [
             'choices' => array_flip(array_keys($this->productPool->getProducts())),
         ];
-
-        // choice_as_value option is not needed in SF 3.0+
-        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
-            $productTypeOptions['choices_as_values'] = true;
-        }
 
         $formMapper
             ->with($this->trans('order_element.form.group_main_label', [], 'SonataOrderBundle'))

--- a/src/ProductBundle/Block/VariationsFormBlockService.php
+++ b/src/ProductBundle/Block/VariationsFormBlockService.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\Component\Form\Type\VariationChoiceType;
 use Sonata\Component\Product\Pool;
 use Sonata\Component\Product\ProductInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
@@ -82,7 +83,7 @@ class VariationsFormBlockService extends BaseBlockService
             $currentValues[$field] = array_search($accessor->getValue($product, $field), $values);
         }
 
-        $form = $this->formFactory->createBuilder('sonata_product_variation_choices', $currentValues, [
+        $form = $this->formFactory->createBuilder(VariationChoiceType::class, $currentValues, [
                 'field_options' => $blockContext->getSetting('form_field_options'),
                 'product' => $product,
                 'fields' => $fields,
@@ -121,7 +122,7 @@ class VariationsFormBlockService extends BaseBlockService
             'variations_properties' => [],
             'form_route' => 'sonata_product_variation_product',
             'form_route_parameters' => function (Options $options) {
-                $product = $options->get('product');
+                $product = $options['product'];
 
                 if (null !== $product && !$product instanceof ProductInterface) {
                     throw new \RuntimeException("Wrong 'product' parameter");

--- a/tests/Component/Currency/CurrencyFormTypeTest.php
+++ b/tests/Component/Currency/CurrencyFormTypeTest.php
@@ -49,8 +49,8 @@ class CurrencyFormTypeTest extends TestCase
         $this->assertEquals(CurrencyType::class, $this->currencyFormType->getParent());
     }
 
-    public function testGetName(): void
+    public function testGetBlockPrefix(): void
     {
-        $this->assertEquals('sonata_currency', $this->currencyFormType->getName());
+        $this->assertEquals('sonata_currency', $this->currencyFormType->getBlockPrefix());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix forms to be compatible with Symfony 3+. These are a few instances that I missed in #562

I am targeting this branch, because it is the only branch currently supporting Symfony 3.

## Changelog

I'm not sure if this requires a changelog entry, since it's just a follow-up of a previous PR with similar changes?
