### PR TITLE
Fix deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "sonata-project/block-bundle": "^3.8",
         "sonata-project/classification-bundle": "^3.3",
         "sonata-project/comment-bundle": "^3.1",
-        "sonata-project/core-bundle": "^3.12.0",
+        "sonata-project/core-bundle": "^3.13.0",
         "sonata-project/datagrid-bundle": "^2.3",
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
         "sonata-project/formatter-bundle": "^3.4",

--- a/src/BasketBundle/Controller/Api/BasketController.php
+++ b/src/BasketBundle/Controller/Api/BasketController.php
@@ -563,7 +563,7 @@ class BasketController
     {
         $basket = $this->basketManager->findOneBy(['customer' => $customerId]);
         if ($basket instanceof BasketInterface) {
-            throw new HttpException('400', sprintf('Customer (%d) already has a basket', $customerId));
+            throw new HttpException(400, sprintf('Customer (%d) already has a basket', $customerId));
         }
     }
 }

--- a/src/Component/Basket/Basket.php
+++ b/src/Component/Basket/Basket.php
@@ -529,7 +529,7 @@ class Basket implements \Serializable, BasketInterface
      */
     public function hasProduct(ProductInterface $product)
     {
-        if (!array_key_exists($product->getId(), $this->positions)) {
+        if (!\array_key_exists($product->getId(), $this->positions)) {
             return false;
         }
 
@@ -787,7 +787,7 @@ class Basket implements \Serializable, BasketInterface
      */
     public function getOption($name, $default = null)
     {
-        if (!array_key_exists($name, $this->options)) {
+        if (!\array_key_exists($name, $this->options)) {
             return $default;
         }
 

--- a/src/Component/Basket/BasketElement.php
+++ b/src/Component/Basket/BasketElement.php
@@ -241,7 +241,7 @@ class BasketElement implements \Serializable, BasketElementInterface
      */
     public function getOption($name, $default = null)
     {
-        if (!array_key_exists($name, $this->options)) {
+        if (!\array_key_exists($name, $this->options)) {
             return $default;
         }
 
@@ -253,7 +253,7 @@ class BasketElement implements \Serializable, BasketElementInterface
      */
     public function hasOption($name)
     {
-        return array_key_exists($name, $this->options);
+        return \array_key_exists($name, $this->options);
     }
 
     /**

--- a/src/Component/Basket/BasketElementManager.php
+++ b/src/Component/Basket/BasketElementManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Basket;
 
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class BasketElementManager extends BaseEntityManager implements BasketElementManagerInterface
 {

--- a/src/Component/Basket/BasketElementManagerInterface.php
+++ b/src/Component/Basket/BasketElementManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Basket;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface BasketElementManagerInterface extends ManagerInterface
 {

--- a/src/Component/Basket/BasketManager.php
+++ b/src/Component/Basket/BasketManager.php
@@ -15,9 +15,9 @@ namespace Sonata\Component\Basket;
 
 use Doctrine\ORM\NoResultException;
 use Sonata\Component\Customer\CustomerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class BasketManager extends BaseEntityManager implements BasketManagerInterface
 {

--- a/src/Component/Basket/BasketManagerInterface.php
+++ b/src/Component/Basket/BasketManagerInterface.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Sonata\Component\Basket;
 
 use Sonata\Component\Customer\CustomerInterface;
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface BasketManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Component/Currency/CurrencyDoctrineType.php
+++ b/src/Component/Currency/CurrencyDoctrineType.php
@@ -31,7 +31,7 @@ class CurrencyDoctrineType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if (!array_key_exists($value, Intl::getCurrencyBundle()->getCurrencyNames())) {
+        if (!\array_key_exists($value, Intl::getCurrencyBundle()->getCurrencyNames())) {
             throw new \RuntimeException(sprintf("'%d' is not a supported currency.", $value));
         }
 

--- a/src/Component/Currency/CurrencyManager.php
+++ b/src/Component/Currency/CurrencyManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Currency;
 
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/src/Component/Currency/CurrencyManagerInterface.php
+++ b/src/Component/Currency/CurrencyManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Currency;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/src/Component/Customer/AddressManagerInterface.php
+++ b/src/Component/Customer/AddressManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Customer;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface AddressManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Component/Customer/CustomerManagerInterface.php
+++ b/src/Component/Customer/CustomerManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Customer;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface CustomerManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Component/Invoice/InvoiceElementManagerInterface.php
+++ b/src/Component/Invoice/InvoiceElementManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Invoice;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface InvoiceElementManagerInterface extends ManagerInterface
 {

--- a/src/Component/Invoice/InvoiceManagerInterface.php
+++ b/src/Component/Invoice/InvoiceManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Invoice;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface InvoiceManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Component/Invoice/InvoiceStatusRenderer.php
+++ b/src/Component/Invoice/InvoiceStatusRenderer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Invoice;
 
-use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
+use Sonata\Twig\Status\StatusClassRendererInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/src/Component/Order/OrderElementManagerInterface.php
+++ b/src/Component/Order/OrderElementManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Order;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface OrderElementManagerInterface extends ManagerInterface
 {

--- a/src/Component/Order/OrderManagerInterface.php
+++ b/src/Component/Order/OrderManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Order;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 use Sonata\UserBundle\Model\UserInterface;
 
 interface OrderManagerInterface extends ManagerInterface, PageableManagerInterface

--- a/src/Component/Order/OrderStatusRenderer.php
+++ b/src/Component/Order/OrderStatusRenderer.php
@@ -15,7 +15,7 @@ namespace Sonata\Component\Order;
 
 use Sonata\Component\Delivery\BaseServiceDelivery;
 use Sonata\Component\Payment\TransactionInterface;
-use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
+use Sonata\Twig\Status\StatusClassRendererInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/src/Component/Payment/BasePayment.php
+++ b/src/Component/Payment/BasePayment.php
@@ -131,7 +131,7 @@ abstract class BasePayment implements PaymentInterface
      */
     public function hasOption($name)
     {
-        return array_key_exists($name, $this->options);
+        return \array_key_exists($name, $this->options);
     }
 
     /**

--- a/src/Component/Payment/Debug/DebugPayment.php
+++ b/src/Component/Payment/Debug/DebugPayment.php
@@ -76,7 +76,7 @@ class DebugPayment extends PassPayment
     {
         $parameters = $transaction->getParameters();
 
-        if (!array_key_exists('action', $parameters)) {
+        if (!\array_key_exists('action', $parameters)) {
             throw new \RuntimeException('"action" parameter is missing from Transaction.');
         }
 

--- a/src/Component/Payment/Selector.php
+++ b/src/Component/Payment/Selector.php
@@ -92,7 +92,7 @@ class Selector implements PaymentSelectorInterface
      */
     public function getPayment($bank)
     {
-        if (!array_key_exists($bank, $this->getPaymentPool()->getMethods())) {
+        if (!\array_key_exists($bank, $this->getPaymentPool()->getMethods())) {
             throw new PaymentNotFoundException($bank);
         }
 

--- a/src/Component/Payment/TransactionManagerInterface.php
+++ b/src/Component/Payment/TransactionManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Payment;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface TransactionManagerInterface extends ManagerInterface
 {

--- a/src/Component/Product/DeliveryManagerInterface.php
+++ b/src/Component/Product/DeliveryManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Product;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface DeliveryManagerInterface extends ManagerInterface
 {

--- a/src/Component/Product/PackageManagerInterface.php
+++ b/src/Component/Product/PackageManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Product;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface PackageManagerInterface extends ManagerInterface
 {

--- a/src/Component/Product/ProductCategoryManagerInterface.php
+++ b/src/Component/Product/ProductCategoryManagerInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Component\Product;
 
 use Sonata\ClassificationBundle\Model\CategoryInterface;
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface ProductCategoryManagerInterface extends ManagerInterface
 {

--- a/src/Component/Product/ProductCollectionManagerInterface.php
+++ b/src/Component/Product/ProductCollectionManagerInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Component\Product;
 
 use Sonata\ClassificationBundle\Model\CollectionInterface;
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface ProductCollectionManagerInterface extends ManagerInterface
 {

--- a/src/Component/Product/ProductManagerInterface.php
+++ b/src/Component/Product/ProductManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Product;
 
-use Sonata\CoreBundle\Model\ManagerInterface;
-use Sonata\CoreBundle\Model\PageableManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
+use Sonata\Doctrine\Model\PageableManagerInterface;
 
 interface ProductManagerInterface extends ManagerInterface, PageableManagerInterface
 {

--- a/src/Component/Product/ProductProviderInterface.php
+++ b/src/Component/Product/ProductProviderInterface.php
@@ -20,7 +20,7 @@ use Sonata\Component\Basket\BasketElementInterface;
 use Sonata\Component\Basket\BasketElementManagerInterface;
 use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Currency\CurrencyInterface;
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 

--- a/src/Component/Status/StatusClassRendererInterface.php
+++ b/src/Component/Status/StatusClassRendererInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\Component\Status;
 
-use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface as BaseStatusClassRendererInterface;
+use Sonata\Twig\Status\StatusClassRendererInterface as BaseStatusClassRendererInterface;
 
 /**
  * @deprecated

--- a/src/CustomerBundle/Entity/AddressManager.php
+++ b/src/CustomerBundle/Entity/AddressManager.php
@@ -15,9 +15,9 @@ namespace Sonata\CustomerBundle\Entity;
 
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Customer\AddressManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class AddressManager extends BaseEntityManager implements AddressManagerInterface
 {

--- a/src/CustomerBundle/Entity/CustomerManager.php
+++ b/src/CustomerBundle/Entity/CustomerManager.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sonata\CustomerBundle\Entity;
 
 use Sonata\Component\Customer\CustomerManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class CustomerManager extends BaseEntityManager implements CustomerManagerInterface
 {

--- a/src/CustomerBundle/Twig/Extension/AddressExtension.php
+++ b/src/CustomerBundle/Twig/Extension/AddressExtension.php
@@ -16,7 +16,6 @@ namespace Sonata\CustomerBundle\Twig\Extension;
 use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Delivery\ServiceDeliverySelectorInterface;
-use Sonata\CoreBundle\Exception\InvalidParameterException;
 use Sonata\CustomerBundle\Entity\BaseAddress;
 
 /**
@@ -81,7 +80,7 @@ class AddressExtension extends \Twig_Extension
         $requiredAddressKeys = ['firstname', 'lastname', 'address1', 'postcode', 'city', 'country_code'];
 
         if (!($address instanceof AddressInterface) && (!\is_array($address) || 0 !== \count(array_diff($requiredAddressKeys, array_keys($address))))) {
-            throw new InvalidParameterException(sprintf(
+            throw new \RuntimeException(sprintf(
                 'sonata_address_render needs an AddressInterface instance or an array with keys (%s)',
                 implode(', ', $requiredAddressKeys)
             ));
@@ -95,7 +94,7 @@ class AddressExtension extends \Twig_Extension
             ];
         } else {
             if ($showEdit && !array_key_exists('id', $address)) {
-                throw new InvalidParameterException(
+                throw new \RuntimeException(
                     "sonata_address_render needs 'id' key to be set to render the edit button"
                 );
             }

--- a/src/CustomerBundle/Twig/Extension/AddressExtension.php
+++ b/src/CustomerBundle/Twig/Extension/AddressExtension.php
@@ -93,13 +93,13 @@ class AddressExtension extends \Twig_Extension
                 'address' => $address->getFullAddressHtml(),
             ];
         } else {
-            if ($showEdit && !array_key_exists('id', $address)) {
+            if ($showEdit && !\array_key_exists('id', $address)) {
                 throw new \RuntimeException(
                     "sonata_address_render needs 'id' key to be set to render the edit button"
                 );
             }
 
-            if ($showName && !array_key_exists('name', $address)) {
+            if ($showName && !\array_key_exists('name', $address)) {
                 $address['name'] = '';
                 $showName = false;
             }

--- a/src/DeliveryBundle/DependencyInjection/SonataDeliveryExtension.php
+++ b/src/DeliveryBundle/DependencyInjection/SonataDeliveryExtension.php
@@ -74,7 +74,7 @@ class SonataDeliveryExtension extends Extension
         $configured = [];
 
         foreach ($config['services'] as $id => $settings) {
-            if (array_key_exists($id, $internal)) {
+            if (\array_key_exists($id, $internal)) {
                 $id = $internal[$id];
 
                 $definition = $container->getDefinition($id);
@@ -88,7 +88,7 @@ class SonataDeliveryExtension extends Extension
         }
 
         foreach ($config['methods'] as $code => $id) {
-            if (array_key_exists($code, $configured)) {
+            if (\array_key_exists($code, $configured)) {
                 // Internal service
                 $id = $configured[$code];
             }

--- a/src/InvoiceBundle/Entity/InvoiceElementManager.php
+++ b/src/InvoiceBundle/Entity/InvoiceElementManager.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\InvoiceBundle\Entity;
 
 use Sonata\Component\Invoice\InvoiceElementManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class InvoiceElementManager extends BaseEntityManager implements InvoiceElementManagerInterface
 {

--- a/src/InvoiceBundle/Entity/InvoiceManager.php
+++ b/src/InvoiceBundle/Entity/InvoiceManager.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sonata\InvoiceBundle\Entity;
 
 use Sonata\Component\Invoice\InvoiceManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class InvoiceManager extends BaseEntityManager implements InvoiceManagerInterface
 {

--- a/src/OrderBundle/Entity/BaseOrderElement.php
+++ b/src/OrderBundle/Entity/BaseOrderElement.php
@@ -526,7 +526,7 @@ abstract class BaseOrderElement implements OrderElementInterface
     {
         $values = $this->getRawProduct();
 
-        if (array_key_exists($name, $values)) {
+        if (\array_key_exists($name, $values)) {
             return $values[$name];
         }
 

--- a/src/OrderBundle/Entity/OrderElementManager.php
+++ b/src/OrderBundle/Entity/OrderElementManager.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\OrderBundle\Entity;
 
 use Sonata\Component\Order\OrderElementManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class OrderElementManager extends BaseEntityManager implements OrderElementManagerInterface
 {

--- a/src/OrderBundle/Entity/OrderManager.php
+++ b/src/OrderBundle/Entity/OrderManager.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sonata\OrderBundle\Entity;
 
 use Sonata\Component\Order\OrderManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\UserBundle\Model\UserInterface;
 
 class OrderManager extends BaseEntityManager implements OrderManagerInterface

--- a/src/PaymentBundle/Consumer/PaymentProcessOrderConsumer.php
+++ b/src/PaymentBundle/Consumer/PaymentProcessOrderConsumer.php
@@ -16,7 +16,7 @@ namespace Sonata\PaymentBundle\Consumer;
 use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Order\OrderManagerInterface;
 use Sonata\Component\Payment\TransactionInterface;
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Consumer\ConsumerInterface;

--- a/src/PaymentBundle/Consumer/PaymentProcessOrderElementConsumer.php
+++ b/src/PaymentBundle/Consumer/PaymentProcessOrderElementConsumer.php
@@ -17,7 +17,7 @@ use Sonata\Component\Order\OrderInterface;
 use Sonata\Component\Payment\TransactionInterface;
 use Sonata\Component\Product\Pool as ProductPool;
 use Sonata\Component\Product\ProductProviderInterface;
-use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
 use Sonata\NotificationBundle\Consumer\ConsumerInterface;
 

--- a/src/PaymentBundle/DependencyInjection/SonataPaymentExtension.php
+++ b/src/PaymentBundle/DependencyInjection/SonataPaymentExtension.php
@@ -90,7 +90,7 @@ class SonataPaymentExtension extends Extension
 
         // define the payment method
         foreach ($config['services'] as $id => $settings) {
-            if (array_key_exists($id, $internal)) {
+            if (\array_key_exists($id, $internal)) {
                 $id = $internal[$id];
 
                 $name = $settings['name'] ?? 'n/a';
@@ -117,7 +117,7 @@ class SonataPaymentExtension extends Extension
         }
 
         foreach ($config['methods'] as $code => $id) {
-            if (array_key_exists($code, $configured)) {
+            if (\array_key_exists($code, $configured)) {
                 // Internal service
                 $id = $configured[$code];
             }

--- a/src/PaymentBundle/Entity/TransactionManager.php
+++ b/src/PaymentBundle/Entity/TransactionManager.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\PaymentBundle\Entity;
 
 use Sonata\Component\Payment\TransactionManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class TransactionManager extends BaseEntityManager implements TransactionManagerInterface
 {

--- a/src/ProductBundle/DependencyInjection/Compiler/AddProductProviderCompilerPass.php
+++ b/src/ProductBundle/DependencyInjection/Compiler/AddProductProviderCompilerPass.php
@@ -61,7 +61,7 @@ class AddProductProviderCompilerPass implements CompilerPassInterface
                 $container->getDefinition($options['provider'])->addMethodCall('setOrderElementClassName', [$container->getParameter('sonata.order.order_element.class')]);
                 $container->getDefinition($options['provider'])->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')]);
 
-                if (array_key_exists('variations', $options)) {
+                if (\array_key_exists('variations', $options)) {
                     $container->getDefinition($options['provider'])->addMethodCall('setVariationFields', [$options['variations']['fields']]);
                 }
             }

--- a/src/ProductBundle/Entity/BaseDelivery.php
+++ b/src/ProductBundle/Entity/BaseDelivery.php
@@ -279,23 +279,23 @@ abstract class BaseDelivery implements DeliveryInterface
      */
     public function fromArray($array)
     {
-        if (array_key_exists('code', $array)) {
+        if (\array_key_exists('code', $array)) {
             $this->code = $array['code'];
         }
 
-        if (array_key_exists('perItem', $array)) {
+        if (\array_key_exists('perItem', $array)) {
             $this->perItem = $array['perItem'];
         }
 
-        if (array_key_exists('countryCode', $array)) {
+        if (\array_key_exists('countryCode', $array)) {
             $this->countryCode = $array['countryCode'];
         }
 
-        if (array_key_exists('zone', $array)) {
+        if (\array_key_exists('zone', $array)) {
             $this->zone = $array['zone'];
         }
 
-        if (array_key_exists('enabled', $array)) {
+        if (\array_key_exists('enabled', $array)) {
             $this->enabled = $array['enabled'];
         }
     }

--- a/src/ProductBundle/Entity/DeliveryManager.php
+++ b/src/ProductBundle/Entity/DeliveryManager.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\ProductBundle\Entity;
 
 use Sonata\Component\Product\DeliveryManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class DeliveryManager extends BaseEntityManager implements DeliveryManagerInterface
 {

--- a/src/ProductBundle/Entity/PackageManager.php
+++ b/src/ProductBundle/Entity/PackageManager.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\ProductBundle\Entity;
 
 use Sonata\Component\Product\PackageManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class PackageManager extends BaseEntityManager implements PackageManagerInterface
 {

--- a/src/ProductBundle/Entity/ProductCategoryManager.php
+++ b/src/ProductBundle/Entity/ProductCategoryManager.php
@@ -18,7 +18,7 @@ use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\Component\Product\ProductCategoryManagerInterface;
 use Sonata\Component\Product\ProductInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class ProductCategoryManager extends BaseEntityManager implements ProductCategoryManagerInterface
 {

--- a/src/ProductBundle/Entity/ProductCollectionManager.php
+++ b/src/ProductBundle/Entity/ProductCollectionManager.php
@@ -16,7 +16,7 @@ namespace Sonata\ProductBundle\Entity;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\Component\Product\ProductCollectionManagerInterface;
 use Sonata\Component\Product\ProductInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class ProductCollectionManager extends BaseEntityManager implements ProductCollectionManagerInterface
 {

--- a/src/ProductBundle/Entity/ProductManager.php
+++ b/src/ProductBundle/Entity/ProductManager.php
@@ -17,9 +17,9 @@ use Doctrine\ORM\QueryBuilder;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\Component\Product\ProductInterface;
 use Sonata\Component\Product\ProductManagerInterface;
-use Sonata\CoreBundle\Model\BaseEntityManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\Doctrine\Entity\BaseEntityManager;
 
 class ProductManager extends BaseEntityManager implements ProductManagerInterface
 {

--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -368,7 +368,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
         foreach ($variations as $mVariation) {
             foreach ($fields as $field) {
                 $variationValue = $accessor->getValue($mVariation, $field);
-                if (!array_key_exists($field, $choices) || !\in_array($variationValue, $choices[$field])) {
+                if (!\array_key_exists($field, $choices) || !\in_array($variationValue, $choices[$field])) {
                     $choices = array_merge_recursive($choices, [$field => [$variationValue]]);
                 }
             }
@@ -602,7 +602,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
         $values = $product->toArray();
 
         foreach ($variationFields as $field) {
-            if (array_key_exists($field, $values)) {
+            if (\array_key_exists($field, $values)) {
                 unset($values[$field]);
             }
         }

--- a/src/ProductBundle/Model/BaseProductProvider.php
+++ b/src/ProductBundle/Model/BaseProductProvider.php
@@ -36,8 +36,7 @@ use Sonata\Component\Product\ProductCollectionManagerInterface;
 use Sonata\Component\Product\ProductInterface;
 use Sonata\Component\Product\ProductManagerInterface;
 use Sonata\Component\Product\ProductProviderInterface;
-use Sonata\CoreBundle\Exception\InvalidParameterException;
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -1006,7 +1005,7 @@ abstract class BaseProductProvider implements ProductProviderInterface
         $quantity = $event->getQuantity();
 
         if (!\is_int($quantity) || $quantity < 1) {
-            throw new InvalidParameterException('Expected integer >= 1 for quantity, '.$quantity.' given.');
+            throw new \RuntimeException('Expected integer >= 1 for quantity, '.$quantity.' given.');
         }
 
         $price = (float) (bcmul((string) $this->currencyPriceCalculator->getPrice($product, $currency, $vat), (string) $quantity));

--- a/tests/Component/Basket/BasketManagerTest.php
+++ b/tests/Component/Basket/BasketManagerTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\BasketBundle\Entity\BaseBasket;
 use Sonata\Component\Basket\Basket;
 use Sonata\Component\Basket\BasketManager;
-use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\Doctrine\Test\EntityManagerMockFactory;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/tests/CustomerBundle/Entity/AddressManagerTest.php
+++ b/tests/CustomerBundle/Entity/AddressManagerTest.php
@@ -18,9 +18,9 @@ use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Customer\CustomerInterface;
-use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\CustomerBundle\Entity\AddressManager;
 use Sonata\CustomerBundle\Entity\BaseAddress;
+use Sonata\Doctrine\Test\EntityManagerMockFactory;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/tests/CustomerBundle/Entity/CustomerManagerTest.php
+++ b/tests/CustomerBundle/Entity/CustomerManagerTest.php
@@ -15,9 +15,9 @@ namespace Sonata\CustomerBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\CustomerBundle\Entity\BaseCustomer;
 use Sonata\CustomerBundle\Entity\CustomerManager;
+use Sonata\Doctrine\Test\EntityManagerMockFactory;
 
 class CustomerManagerTest extends TestCase
 {

--- a/tests/CustomerBundle/Twig/Extension/AddressExtensionTest.php
+++ b/tests/CustomerBundle/Twig/Extension/AddressExtensionTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Sonata\Component\Basket\BasketInterface;
 use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Delivery\ServiceDeliverySelectorInterface;
-use Sonata\CoreBundle\Exception\InvalidParameterException;
 use Sonata\CustomerBundle\Twig\Extension\AddressExtension;
 
 /**
@@ -57,7 +56,7 @@ class AddressExtensionTest extends TestCase
 
     public function testRenderAddressInvalidParameter()
     {
-        $this->expectException(InvalidParameterException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('sonata_address_render needs an AddressInterface instance or an array with keys (firstname, lastname, address1, postcode, city, country_code)');
 
         $environment = $this->createMock('Twig_Environment');
@@ -71,7 +70,7 @@ class AddressExtensionTest extends TestCase
 
     public function testRenderAddressMissingId()
     {
-        $this->expectException(InvalidParameterException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('sonata_address_render needs \'id\' key to be set to render the edit button');
 
         $environment = $this->createMock('Twig_Environment');

--- a/tests/InvoiceBundle/Entity/InvoiceManagerTest.php
+++ b/tests/InvoiceBundle/Entity/InvoiceManagerTest.php
@@ -15,7 +15,7 @@ namespace Sonata\InvoiceBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\Doctrine\Test\EntityManagerMockFactory;
 use Sonata\InvoiceBundle\Entity\BaseInvoice;
 use Sonata\InvoiceBundle\Entity\InvoiceManager;
 

--- a/tests/OrderBundle/Entity/OrderManagerTest.php
+++ b/tests/OrderBundle/Entity/OrderManagerTest.php
@@ -16,7 +16,7 @@ namespace Sonata\OrderBundle\Tests\Entity;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\Doctrine\Test\EntityManagerMockFactory;
 use Sonata\OrderBundle\Entity\BaseOrder;
 use Sonata\OrderBundle\Entity\OrderManager;
 

--- a/tests/ProductBundle/Entity/ProductManagerTest.php
+++ b/tests/ProductBundle/Entity/ProductManagerTest.php
@@ -15,7 +15,7 @@ namespace Sonata\ProductBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\Doctrine\Test\EntityManagerMockFactory;
 use Sonata\ProductBundle\Entity\BaseProduct;
 use Sonata\ProductBundle\Entity\ProductManager;
 

--- a/tests/ProductBundle/Model/BaseProductProviderTest.php
+++ b/tests/ProductBundle/Model/BaseProductProviderTest.php
@@ -23,8 +23,7 @@ use Sonata\Component\Basket\InvalidProductException;
 use Sonata\Component\Currency\Currency;
 use Sonata\Component\Currency\CurrencyPriceCalculator;
 use Sonata\Component\Product\ProductInterface;
-use Sonata\CoreBundle\Exception\InvalidParameterException;
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\Form\Validator\ErrorElement;
 use Sonata\ProductBundle\Entity\BaseProduct;
 use Sonata\ProductBundle\Model\BaseProductProvider;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -455,7 +454,7 @@ class BaseProductProviderTest extends TestCase
 
     public function testCalculatePriceException()
     {
-        $this->expectException(InvalidParameterException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Expected integer >= 1 for quantity, 4.32 given.');
 
         $product = new ProductTest();
@@ -469,7 +468,7 @@ class BaseProductProviderTest extends TestCase
 
     public function testCalculatePriceExceptionLessThanOne()
     {
-        $this->expectException(InvalidParameterException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Expected integer >= 1 for quantity, 0.32 given.');
 
         $product = new ProductTest();

--- a/tests/ProductBundle/Model/BaseProductProviderTest.php
+++ b/tests/ProductBundle/Model/BaseProductProviderTest.php
@@ -67,10 +67,6 @@ class ProductTest extends BaseProduct implements ProductInterface
  */
 class BaseProductProviderTest extends TestCase
 {
-    public function testGetProductFromRaw()
-    {
-    }
-
     public function testCreateVariation()
     {
         $productProvider = $this->createNewProductProvider();


### PR DESCRIPTION
## Subject

Sonata CoreBundle includes various deprecations in version 3 which will be removed in version 4.
This removes the usage of all the deprecated classes and interfaces for forward-compatibility.

I am targeting this branch, because it's bugfix against the current stable version.

## Changelog

```markdown
### Fixed
- removed usage of deprecated classes and interfaces
```

