### PR TITLE
Replace render tag with function in Twig templates

### DIFF
--- a/src/BasketBundle/Resources/views/Basket/final_review_step.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/final_review_step.html.twig
@@ -28,10 +28,10 @@ file that was distributed with this source code.
     <tbody>
         {# call each product controller to render its own view #}
         {% for basketElement in basket.BasketElements %}
-            {% render controller('SonataProductBundle:Product:renderFinalReviewBasketElement', {
+            {{ render(controller('SonataProductBundle:Product:renderFinalReviewBasketElement', {
                 'basketElement' : basketElement,
                 'basket':         basket
-            }) %}
+            })) }}
         {% endfor %}
 
         <tr>

--- a/src/BasketBundle/Resources/views/Basket/index.html.twig
+++ b/src/BasketBundle/Resources/views/Basket/index.html.twig
@@ -38,11 +38,11 @@ file that was distributed with this source code.
             <tbody>
                 {# call each product controller to render its own view #}
                 {% for basketElement in basket.getBasketElements %}
-                    {% render controller('SonataProductBundle:Product:renderFormBasketElement', {
+                    {{ render(controller('SonataProductBundle:Product:renderFormBasketElement', {
                         'formView':       form.basketElements.children[basketElement.position],
                         'basketElement':  basketElement,
                         'basket':         basket
-                    }) %}
+                    })) }}
                 {% endfor %}
 
                 {# mark the widget as rendered ... TODO: create a custom widget type ...#}

--- a/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
@@ -147,7 +147,7 @@ file that was distributed with this source code.
 
     {% block footer %}
 
-        {% render(controller('SonataPaymentBundle:Payment:terms')) %}
+        {{ render(controller('SonataPaymentBundle:Payment:terms')) }}
 
     {% endblock %}
 

--- a/src/ProductBundle/Resources/views/Category/side_menu_category.html.twig
+++ b/src/ProductBundle/Resources/views/Category/side_menu_category.html.twig
@@ -16,11 +16,11 @@ file that was distributed with this source code.
 
             {% if category.hasChildren and deep < depth%}
 
-                {% render controller('SonataProductBundle:Category:listSideMenuCategories', {
+                {{ render(controller('SonataProductBundle:Category:listSideMenuCategories', {
                     'category': category,
                     'deep' : deep,
                     'depth': depth
-                }) %}
+                })) }}
 
             {% endif %}
 


### PR DESCRIPTION
## Subject

The `{% render %}` tag has been removed in Symfony 3 and replaced with the `{{ render() }}` function

I am targeting this branch, because it's the only branch supporting Symfony 3.

## Changelog

```markdown
### fixed
- replaced the render tag in twig with the render function
```