### PR TITLE
Require DoctrineBundle 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^7.1",
         "cocur/slugify": "^2.5 || ^3.0",
+        "doctrine/doctrine-bundle": "^1.0",
         "knplabs/knp-menu-bundle": "^2.1",
         "knplabs/knp-paginator-bundle": "^2.6",
         "kriswallsmith/buzz": "^0.15 || 0.16.0",

--- a/tests/Component/Form/BasketValidatorTest.php
+++ b/tests/Component/Form/BasketValidatorTest.php
@@ -20,6 +20,8 @@ use Sonata\Component\Form\BasketValidator;
 use Sonata\Component\Product\Pool;
 use Sonata\Component\Product\ProductProviderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -47,7 +49,11 @@ class BasketValidatorTest extends TestCase
         $violationBuilder->expects($this->once())->method('addViolation');
 
         $context = $this->createMock(ExecutionContext::class);
-        $context->expects($this->once())->method('getViolations')->willReturn(['violation1']);
+        $context->expects($this->once())
+                ->method('getViolations')
+                ->willReturn(new ConstraintViolationList([
+                    $this->createMock(ConstraintViolationInterface::class),
+                ]));
         $context->expects($this->once())->method('buildViolation')->willReturn($violationBuilder);
 
         $validator = new BasketValidator($pool, $consValFact);


### PR DESCRIPTION
## Subject

We use the "doctrine" service, which is defined by this bundle. We are
not compatible with the version 2 of the bundle yet, and should thus
restrict ourselves to version 1.


I am targeting this branch, because this is BC.

Closes #620

## Changelog


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash when using doctrine bundle 2
```