### PR TITLE
Inject basketfactory for payment controller

### DIFF
--- a/src/PaymentBundle/Controller/PaymentController.php
+++ b/src/PaymentBundle/Controller/PaymentController.php
@@ -27,6 +27,52 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 class PaymentController extends Controller
 {
     /**
+     * @var BasketFactoryInterface
+     */
+    private $basketFactory;
+
+    /**
+     * @var PaymentHandlerInterface
+     */
+    private $paymentHandler;
+
+    /**
+     * @var Basket
+     */
+    private $basket;
+
+    public function __construct(BasketFactoryInterface $basketFactory = null, PaymentHandlerInterface $paymentHandler = null, Basket $basket = null)
+    {
+        if (!$basketFactory) {
+            @trigger_error(sprintf(
+                'Not providing a %s instance to %s is deprecated since sonata-project/ecommerce 3.x. Providing it will be mandatory in 4.0',
+                BasketFactoryInterface::class,
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        if (!$paymentHandler) {
+            @trigger_error(sprintf(
+                'Not providing a %s instance to %s is deprecated since sonata-project/ecommerce 3.x. Providing it will be mandatory in 4.0',
+                PaymentHandlerInterface::class,
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        if (!$basket) {
+            @trigger_error(sprintf(
+                'Not providing a %s instance to %s is deprecated since sonata-project/ecommerce 3.x. Providing it will be mandatory in 4.0',
+                Basket::class,
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->basketFactory = $basketFactory;
+        $this->paymentHandler = $paymentHandler;
+        $this->basket = $basket;
+    }
+
+    /**
      * This action is called by the user after the sendbank
      * In most case the order is already cancelled by a previous callback.
      *
@@ -153,6 +199,10 @@ class PaymentController extends Controller
      */
     protected function getBasketFactory()
     {
+        if ($this->basketFactory instanceof BasketFactoryInterface) {
+            return $this->basketFactory;
+        }
+
         return $this->get('sonata.basket.factory');
     }
 
@@ -161,6 +211,10 @@ class PaymentController extends Controller
      */
     protected function getBasket()
     {
+        if ($this->basket instanceof Basket) {
+            return $this->basket;
+        }
+
         return $this->get('sonata.basket');
     }
 
@@ -169,6 +223,10 @@ class PaymentController extends Controller
      */
     protected function getPaymentHandler()
     {
+        if ($this->paymentHandler instanceof PaymentHandlerInterface) {
+            return $this->paymentHandler;
+        }
+
         return $this->get('sonata.payment.handler');
     }
 }

--- a/src/PaymentBundle/Resources/config/payment.xml
+++ b/src/PaymentBundle/Resources/config/payment.xml
@@ -63,6 +63,8 @@
         <service id="Sonata\PaymentBundle\Controller\PaymentController">
             <tag name="controller.service_arguments"/>
             <argument type="service" id="sonata.basket.factory"/>
+            <argument type="service" id="sonata.payment.handler"/>
+            <argument type="service" id="sonata.basket"/>
         </service>
     </services>
 </container>

--- a/tests/PaymentBundle/Controller/PaymentControllerTest.php
+++ b/tests/PaymentBundle/Controller/PaymentControllerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\PaymentBundle\Tests\Controller;
+
+use Buzz\Browser;
+use Buzz\Client\ClientInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\Component\Basket\Basket;
+use Sonata\Component\Basket\BasketFactoryInterface;
+use Sonata\Component\Payment\Debug\DebugPayment;
+use Sonata\Component\Payment\PaymentHandlerInterface;
+use Sonata\Component\Tests\Payment\DebugPaymentTest_Order;
+use Sonata\OrderBundle\Entity\BaseOrderElement;
+use Sonata\PaymentBundle\Controller\PaymentController;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+final class PaymentControllerTest extends TestCase
+{
+    public function testInstanceBasketInterfacePaymentAction(): void
+    {
+        $classPaymentController = new \ReflectionClass(PaymentController::class);
+        $methodGetBasketFactory = $classPaymentController->getMethod('getBasketFactory');
+        $methodGetBasketFactory->setAccessible(true);
+
+        $methodGetBasket = $classPaymentController->getMethod('getBasket');
+        $methodGetBasket->setAccessible(true);
+
+        $methodGetPaymentHandler = $classPaymentController->getMethod('getPaymentHandler');
+        $methodGetPaymentHandler->setAccessible(true);
+
+        $basketFactoryInterface = $this->createMock(BasketFactoryInterface::class);
+        $paymentHandlerInterface = $this->createMock(PaymentHandlerInterface::class);
+        $basket = $this->createMock(Basket::class);
+
+        $paymentController = $this->createPaymentController($basketFactoryInterface, $paymentHandlerInterface, $basket);
+
+        $this->assertSame($basketFactoryInterface, $methodGetBasketFactory->invoke($paymentController));
+        $this->assertSame($paymentHandlerInterface, $methodGetPaymentHandler->invoke($paymentController));
+        $this->assertSame($basket, $methodGetBasket->invoke($paymentController));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testInstanceNullBasketInterfacePaymentAction(): void
+    {
+        $classPaymentController = new \ReflectionClass(PaymentController::class);
+        $methodGetBasketFactory = $classPaymentController->getMethod('getBasketFactory');
+        $methodGetBasketFactory->setAccessible(true);
+
+        $methodGetBasket = $classPaymentController->getMethod('getBasket');
+        $methodGetBasket->setAccessible(true);
+
+        $methodGetPaymentHandler = $classPaymentController->getMethod('getPaymentHandler');
+        $methodGetPaymentHandler->setAccessible(true);
+
+        $basketFactoryInterface = $this->createMock(BasketFactoryInterface::class);
+        $basket = $this->createMock(Basket::class);
+        $paymentHandlerInterface = $this->createMock(PaymentHandlerInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->at(0))
+            ->method('get')
+            ->with('sonata.basket.factory')
+            ->willReturn($basketFactoryInterface);
+
+        $container->expects($this->at(1))
+            ->method('get')
+            ->with('sonata.basket')
+            ->willReturn($basket);
+
+        $container->expects($this->at(2))
+            ->method('get')
+            ->with('sonata.payment.handler')
+            ->willReturn($paymentHandlerInterface);
+
+        $paymentController = new PaymentController();
+
+        $paymentController->setContainer($container);
+
+        $this->assertSame($basketFactoryInterface, $methodGetBasketFactory->invoke($paymentController));
+        $this->assertSame($basket, $methodGetBasket->invoke($paymentController));
+        $this->assertSame($paymentHandlerInterface, $methodGetPaymentHandler->invoke($paymentController));
+    }
+
+    public function testSendBankAction(): void
+    {
+        $request = new Request();
+        $request->setMethod('POST');
+
+        $payment = $this->getDebugPayment();
+
+        $order = $this->getOrder();
+
+        $paymentHandlerInterface = $this->createMock(PaymentHandlerInterface::class);
+        $paymentHandlerInterface->expects($this->once())
+            ->method('getSendbankOrder')
+            ->willReturn($order);
+
+        $basket = $this->createMock(Basket::class);
+        $basket->expects($this->once())
+            ->method('isValid')
+            ->willReturn(true);
+
+        $basket->expects($this->once())
+            ->method('getPaymentMethod')
+            ->willReturn($payment);
+
+        $paymentController = $this->createPaymentController(null, $paymentHandlerInterface, $basket);
+
+        $this->assertInstanceOf(Response::class, $paymentController->sendbankAction($request));
+    }
+
+    private function getOrder(): DebugPaymentTest_Order
+    {
+        $date = new \DateTime('1981-11-30', new \DateTimeZone('Europe/Paris'));
+
+        $order = new DebugPaymentTest_Order();
+        $order->setCreatedAt($date);
+
+        $element1 = $this->getMockBuilder(BaseOrderElement::class)->getMock();
+        $element1->expects($this->any())->method('getVatRate')->willReturn(20);
+        $element1->expects($this->any())->method('getVatAmount')->willReturn(3);
+
+        $element2 = $this->getMockBuilder(BaseOrderElement::class)->getMock();
+        $element2->expects($this->any())->method('getVatRate')->willReturn(10);
+        $element2->expects($this->any())->method('getVatAmount')->willReturn(2);
+
+        $order->setOrderElements([$element1, $element2]);
+
+        $order->setReference('my-reference');
+
+        return $order;
+    }
+
+    private function getDebugPayment(): DebugPayment
+    {
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects($this->exactly(1))->method('generate')->willReturn('http://foo.bar/ok-url');
+
+        $client = $this->createMock(ClientInterface::class);
+
+        $browser = new Browser($client);
+
+        $payment = new DebugPayment($router, $browser);
+
+        return $payment;
+    }
+
+    private function createPaymentController(
+        ?BasketFactoryInterface $basketFactory = null,
+        ?PaymentHandlerInterface $paymentHandler = null,
+        ?Basket $basket = null
+    ): PaymentController {
+        if (null === $basketFactory) {
+            $basketFactory = $this->createMock(BasketFactoryInterface::class);
+        }
+
+        if (null === $paymentHandler) {
+            $paymentHandler = $this->createMock(PaymentHandlerInterface::class);
+        }
+
+        if (null === $basket) {
+            $basket = $this->createMock(Basket::class);
+        }
+
+        return new PaymentController($basketFactory, $paymentHandler, $basket);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
The "sonata.basket.factory" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Fixes #624 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/ecommerce/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash on payment validation
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
