### PR TITLE
Missing profile part

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,12 @@ UPGRADE 3.x
 UPGRADE FROM 3.0 to 3.1
 =======================
 
+## Added missing profile part to CustomerBundle
+
+Dashboard from SonataUserBundle was drop in 4.x. To keep functionality 
+profile was copy to CustomerBundle. Template and menu_builder was added 
+to configuration for easy extends/override this profile.
+
 ## Deprecated not passing dependencies to `Sonata\PaymentBundle\Controller\PaymentController`
 
 Dependencies are no longer fetched from the container, so if you manually

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,8 @@
             "Sonata\\OrderBundle\\": "src/OrderBundle",
             "Sonata\\PaymentBundle\\": "src/PaymentBundle",
             "Sonata\\PriceBundle\\": "src/PriceBundle",
-            "Sonata\\ProductBundle\\": "src/ProductBundle"
+            "Sonata\\ProductBundle\\": "src/ProductBundle",
+            "Sonata\\ProfileBundle\\": "src/ProfileBundle"
         }
     },
     "autoload-dev": {
@@ -103,7 +104,8 @@
             "Sonata\\OrderBundle\\Tests\\": "tests/OrderBundle",
             "Sonata\\PaymentBundle\\Tests\\": "tests/PaymentBundle",
             "Sonata\\PriceBundle\\Tests\\": "tests/PriceBundle",
-            "Sonata\\ProductBundle\\Tests\\": "tests/ProductBundle"
+            "Sonata\\ProductBundle\\Tests\\": "tests/ProductBundle",
+            "Sonata\\ProfileBundle\\Tests\\": "tests/ProfileBundle"
         }
     }
 }

--- a/docs/reference/bundles/customer.rst
+++ b/docs/reference/bundles/customer.rst
@@ -24,6 +24,15 @@ The bundle allows you to configure the entity classes; you'll also need to regis
 .. code-block:: yaml
 
     sonata_customer:
+        profile:
+            template:       'SonataCustomerBundle:Profile:action.html.twig'
+            menu_builder:   'sonata.customer.profile.menu_builder.default'
+            dashboard_blocks:
+                #- { position: left, type: sonata.block.service.text, settings: { content: "<h2>Welcome!</h2> <p>This is a sample user profile dashboard, feel free to override it in the configuration! Want to make this text dynamic? For instance display the user's name? Create a dedicated block and edit the configuration!</p>"} }
+                - { position: left, type: sonata.order.block.recent_orders, settings: { title: Recent Orders, number: 5, mode: public }}
+                #- { position: right, type: sonata.timeline.block.timeline, settings: { max_per_page: 15 }}
+                - { position: right, type: sonata.news.block.recent_posts, settings: { title: Recent Posts, number: 5, mode: public }}
+                - { position: right, type: sonata.news.block.recent_comments, settings: { title: Recent Comments, number: 5, mode: public }}
         class:
             customer:             App\Sonata\CustomerBundle\Entity\Customer
             address:              App\Sonata\CustomerBundle\Entity\Address

--- a/src/CustomerBundle/Resources/views/Addresses/list.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/list.html.twig
@@ -1,4 +1,4 @@
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_profile.template %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}address_list{% endtrans %}{% endblock %}

--- a/src/CustomerBundle/Resources/views/Addresses/new.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/new.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_profile.template %}
 
 {% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}address_new{% endtrans %}{% endblock %}
 

--- a/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_profile.template %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataInvoiceBundle' %}sonata.invoice.title_invoice{% endtrans %} - {{ invoice.reference }}{% endblock %}

--- a/src/OrderBundle/Resources/views/Order/index.html.twig
+++ b/src/OrderBundle/Resources/views/Order/index.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_profile.template %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataOrderBundle' %}order_list{% endtrans %}{% endblock %}

--- a/src/OrderBundle/Resources/views/Order/view.html.twig
+++ b/src/OrderBundle/Resources/views/Order/view.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_profile.template %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataOrderBundle' %}sonata.order.title_order{% endtrans %} - {{ order.reference }}{% endblock %}

--- a/src/ProfileBundle/Block/AccountBlockService.php
+++ b/src/ProfileBundle/Block/AccountBlockService.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Block;
+
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Render a block with the connection option or the login name.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class AccountBlockService extends AbstractAdminBlockService
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(string $name, EngineInterface $templating, TokenStorageInterface $tokenStorage)
+    {
+        parent::__construct($name, $templating);
+
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * @return Response
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $user = false;
+        if ($this->tokenStorage->getToken()) {
+            $user = $this->tokenStorage->getToken()->getUser();
+        }
+
+        if (!$user instanceof UserInterface) {
+            $user = false;
+        }
+
+        return $this->renderPrivateResponse($blockContext->getTemplate(), [
+            'user' => $user,
+            'block' => $blockContext->getBlock(),
+            'context' => $blockContext,
+        ]);
+    }
+
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'template' => 'SonataProfileBundle:Block:account.html.twig',
+            'ttl' => 0,
+        ]);
+    }
+
+    public function getName()
+    {
+        return 'Account Block';
+    }
+}

--- a/src/ProfileBundle/Block/ProfileMenuBlockService.php
+++ b/src/ProfileBundle/Block/ProfileMenuBlockService.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Block;
+
+use Knp\Menu\ItemInterface;
+use Knp\Menu\Provider\MenuProviderInterface;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\MenuBlockService;
+use Sonata\ProfileBundle\Menu\ProfileMenuBuilder;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+final class ProfileMenuBlockService extends MenuBlockService
+{
+    /**
+     * @var ProfileMenuBuilder
+     */
+    private $menuBuilder;
+
+    public function __construct(string $name, EngineInterface $templating, MenuProviderInterface $menuProvider, ProfileMenuBuilder $menuBuilder)
+    {
+        parent::__construct($name, $templating, $menuProvider, []);
+
+        $this->menuBuilder = $menuBuilder;
+    }
+
+    public function getName()
+    {
+        return 'Ecommerce Profile Menu';
+    }
+
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        parent::configureSettings($resolver);
+
+        $resolver->setDefaults([
+            'cache_policy' => 'private',
+            'menu_template' => 'SonataBlockBundle:Block:block_side_menu_template.html.twig',
+        ]);
+    }
+
+    /**
+     * @return ItemInterface
+     */
+    protected function getMenu(BlockContextInterface $blockContext)
+    {
+        $settings = $blockContext->getSettings();
+
+        $menu = parent::getMenu($blockContext);
+
+        if (null === $menu || '' === $menu) {
+            $menu = $this->menuBuilder->createProfileMenu(
+                [
+                    'childrenAttributes' => ['class' => $settings['menu_class']],
+                    'attributes' => ['class' => $settings['children_class']],
+                ]
+            );
+
+            if (method_exists($menu, 'setCurrentUri')) {
+                $menu->setCurrentUri($settings['current_uri']);
+            }
+        }
+
+        return $menu;
+    }
+}

--- a/src/ProfileBundle/Controller/ProfileController.php
+++ b/src/ProfileBundle/Controller/ProfileController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * This class is inspired from the FOS Profile Controller, except :
+ *   - only twig is supported
+ *   - separation of the user authentication form with the profile form.
+ */
+final class ProfileController extends Controller
+{
+    /**
+     * @throws AccessDeniedException
+     */
+    public function dashboardAction(): Response
+    {
+        $user = $this->getUser();
+        if (!\is_object($user) || !$user instanceof UserInterface) {
+            throw new AccessDeniedException('This user does not have access to this section.');
+        }
+
+        return $this->render('SonataProfileBundle::dashboard.html.twig', [
+            'user' => $user,
+            'blocks' => $this->container->getParameter('sonata.profile.configuration.profile_blocks'),
+        ]);
+    }
+}

--- a/src/ProfileBundle/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/ProfileBundle/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class GlobalVariablesCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container->getDefinition('twig')
+            ->addMethodCall('addGlobal', ['sonata_profile', new Reference('sonata.profile.twig.global')]);
+    }
+}

--- a/src/ProfileBundle/DependencyInjection/Configuration.php
+++ b/src/ProfileBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files.
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $node = $treeBuilder->root('sonata_profile');
+
+        $node
+            ->children()
+                ->scalarNode('template')->defaultValue('SonataProfileBundle::action.html.twig')->end()
+            ->end()
+        ;
+        $this->addDashboardSection($node);
+        $this->addMenuSection($node);
+
+        return $treeBuilder;
+    }
+
+    /**
+     * Returns default values for profile menu (to avoid BC Break).
+     */
+    protected function getProfileMenuDefaultValues(): array
+    {
+        return [
+            [
+                'route' => 'sonata_profile_dashboard',
+                'label' => 'link_list_dashboard',
+                'domain' => 'SonataProfileBundle',
+                'route_parameters' => [],
+            ],
+            [
+                'route' => 'sonata_customer_addresses',
+                'label' => 'link_list_addresses',
+                'domain' => 'SonataCustomerBundle',
+                'route_parameters' => [],
+            ],
+            [
+                'route' => 'sonata_order_index',
+                'label' => 'order_list',
+                'domain' => 'SonataOrderBundle',
+                'route_parameters' => [],
+            ],
+        ];
+    }
+
+    private function addDashboardSection(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->children()
+                ->arrayNode('dashboard')
+                    ->addDefaultsIfNotSet()
+                    ->fixXmlConfig('group')
+                    ->fixXmlConfig('block')
+                        ->children()
+                        ->arrayNode('groups')
+                            ->useAttributeAsKey('id')
+                            ->prototype('array')
+                            ->fixXmlConfig('item')
+                            ->fixXmlConfig('item_add')
+                            ->children()
+                                ->scalarNode('label')->end()
+                                ->scalarNode('label_catalogue')->end()
+                                ->arrayNode('items')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                                ->arrayNode('item_adds')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                                ->arrayNode('roles')
+                                    ->prototype('scalar')->defaultValue([])->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->arrayNode('blocks')
+                        ->defaultValue([['position' => 'left', 'settings' => ['content' => '<h2>Welcome!</h2> This is a sample shop profile dashboard, feel free to override it in the configuration!'], 'type' => 'sonata.block.service.text']])
+                        ->prototype('array')
+                            ->fixXmlConfig('setting')
+                                ->children()
+                                ->scalarNode('type')->cannotBeEmpty()->end()
+                                ->arrayNode('settings')
+                                    ->useAttributeAsKey('id')
+                                    ->prototype('variable')->defaultValue([])->end()
+                                ->end()
+                                ->scalarNode('position')->defaultValue('right')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addMenuSection(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->children()
+                ->arrayNode('menu')
+                    ->prototype('array')
+                        ->addDefaultsIfNotSet()
+                        ->cannotBeEmpty()
+                        ->children()
+                            ->scalarNode('route')->cannotBeEmpty()->end()
+                            ->arrayNode('route_parameters')
+                                ->defaultValue([])
+                                ->prototype('array')->end()
+                            ->end()
+                            ->scalarNode('label')->cannotBeEmpty()->end()
+                            ->scalarNode('domain')->defaultValue('messages')->end()
+                        ->end()
+                    ->end()
+                    ->defaultValue($this->getProfileMenuDefaultValues())
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/ProfileBundle/DependencyInjection/SonataProfileExtension.php
+++ b/src/ProfileBundle/DependencyInjection/SonataProfileExtension.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class SonataProfileExtension extends Extension
+{
+    /**
+     * @param array            $configs   An array of configuration settings
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     *
+     * @throws \Exception
+     */
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $config = $processor->processConfiguration($configuration, $configs);
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+
+        $loader->load('block.xml');
+        $loader->load('menu.xml');
+
+        $this->configureProfile($config, $container);
+        $this->configureMenu($config, $container);
+
+        $loader->load('twig.xml');
+        $this->configureTemplate($config, $container);
+    }
+
+    private function configureProfile(array $config, ContainerBuilder $container)
+    {
+        $container->setParameter('sonata.profile.configuration.profile_blocks', $config['dashboard']['blocks']);
+    }
+
+    private function configureTemplate(array $config, ContainerBuilder $container)
+    {
+        $container->setParameter('sonata.profile.template', $config['template']);
+    }
+
+    private function configureMenu(array $config, ContainerBuilder $container)
+    {
+        $container->getDefinition('sonata.profile.profile.menu_builder')->replaceArgument(2, $config['menu']);
+    }
+}

--- a/src/ProfileBundle/Menu/ProfileMenuBuilder.php
+++ b/src/ProfileBundle/Menu/ProfileMenuBuilder.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Menu;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+final class ProfileMenuBuilder
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var array
+     */
+    private $routes;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @param array $routes Routes to add to the menu (format: array(array('label' => ..., 'route' => ...)))
+     */
+    public function __construct(FactoryInterface $factory, TranslatorInterface $translator, array $routes, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->factory = $factory;
+        $this->translator = $translator;
+        $this->routes = $routes;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @param array $itemOptions The options given to the created menuItem
+     */
+    public function createProfileMenu(array $itemOptions = []): ItemInterface
+    {
+        $menu = $this->factory->createItem('profile', $itemOptions);
+
+        $this->buildProfileMenu($menu, $itemOptions);
+
+        return $menu;
+    }
+
+    /**
+     * @param ItemInterface $menu The item to fill with $routes
+     */
+    public function buildProfileMenu(ItemInterface $menu, array $itemOptions = [])
+    {
+        foreach ($this->routes as $route) {
+            $menu->addChild(
+                $this->translator->trans($route['label'], [], $route['domain']),
+                array_merge($itemOptions, ['route' => $route['route'], 'routeParameters' => $route['route_parameters']])
+            );
+        }
+
+        $event = new ProfileMenuEvent($menu);
+        $this->eventDispatcher->dispatch('sonata.profile.configure_menu', $event);
+    }
+}

--- a/src/ProfileBundle/Menu/ProfileMenuEvent.php
+++ b/src/ProfileBundle/Menu/ProfileMenuEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Menu;
+
+use Knp\Menu\ItemInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+final class ProfileMenuEvent extends Event
+{
+    /**
+     * @var ItemInterface
+     */
+    private $menu;
+
+    public function __construct(ItemInterface $menu)
+    {
+        $this->menu = $menu;
+    }
+
+    public function getMenu(): ItemInterface
+    {
+        return $this->menu;
+    }
+}

--- a/src/ProfileBundle/Resources/config/block.xml
+++ b/src/ProfileBundle/Resources/config/block.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.profile.block.menu" class="Sonata\ProfileBundle\Block\ProfileMenuBlockService">
+            <tag name="sonata.block"/>
+            <argument>sonata.profile.block.menu</argument>
+            <argument type="service" id="templating"/>
+            <argument type="service" id="knp_menu.menu_provider"/>
+            <argument type="service" id="sonata.profile.profile.menu_builder"/>
+        </service>
+        <service id="sonata.profile.block.account" class="Sonata\ProfileBundle\Block\AccountBlockService">
+            <tag name="sonata.block"/>
+            <argument>sonata.profile.block.account</argument>
+            <argument type="service" id="templating"/>
+            <argument type="service" id="security.token_storage"/>
+        </service>
+    </services>
+</container>

--- a/src/ProfileBundle/Resources/config/menu.xml
+++ b/src/ProfileBundle/Resources/config/menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.profile.profile.menu_builder" class="Sonata\ProfileBundle\Menu\ProfileMenuBuilder">
+            <argument type="service" id="knp_menu.factory"/>
+            <argument type="service" id="translator"/>
+            <argument type="collection"/>
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+    </services>
+</container>

--- a/src/ProfileBundle/Resources/config/routing/profile.xml
+++ b/src/ProfileBundle/Resources/config/routing/profile.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="sonata_profile_dashboard" path="/" methods="GET">
+        <default key="_controller">SonataProfileBundle:Profile:dashboard</default>
+    </route>
+</routes>

--- a/src/ProfileBundle/Resources/config/twig.xml
+++ b/src/ProfileBundle/Resources/config/twig.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.profile.twig.global" class="Sonata\ProfileBundle\Twig\GlobalVariables">
+            <argument type="service" id="service_container"/>
+        </service>
+    </services>
+</container>

--- a/src/ProfileBundle/Resources/translations/SonataProfileBundle.en.xliff
+++ b/src/ProfileBundle/Resources/translations/SonataProfileBundle.en.xliff
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- Begin - Titles -->
+            <trans-unit id="sonata_profile_dashboard">
+                <source>Dashboard</source>
+                <target>Dashboard</target>
+            </trans-unit>
+            <trans-unit id="sonata_profile_title">
+                <source>sonata_profile_title</source>
+                <target>Shop profile</target>
+            </trans-unit>
+            <trans-unit id="link_logout">
+                <source>link_logout</source>
+                <target>Log out</target>
+            </trans-unit>
+            <trans-unit id="link_login">
+                <source>link_login</source>
+                <target>Log in</target>
+            </trans-unit>
+            <trans-unit id="link_register">
+                <source>link_register</source>
+                <target>Register</target>
+            </trans-unit>
+            <!-- End - Titles -->
+        </body>
+    </file>
+</xliff>

--- a/src/ProfileBundle/Resources/views/Block/account.html.twig
+++ b/src/ProfileBundle/Resources/views/Block/account.html.twig
@@ -1,0 +1,19 @@
+{#
+This file is part of the Sonata package.
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div style="display:inline;">
+        {% if user %}
+            <a href="{{ path('sonata_profile_dashboard') }}">{{ user.username }}</a> |
+            <a href="{{ path('logout') }}">{{ 'link_logout' | trans({}, "SonataProfileBundle") }}</a>
+        {% else %}
+            <a href="{{ path('login') }}">{{ 'link_login'|trans({}, 'SonataProfileBundle') }} / {{ 'link_register'|trans({}, 'SonataProfileBundle') }}</a>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/src/ProfileBundle/Resources/views/action.html.twig
+++ b/src/ProfileBundle/Resources/views/action.html.twig
@@ -1,0 +1,33 @@
+{#
+This file is part of the Sonata package.
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+
+{% block sonata_page_breadcrumb %}
+    {% if breadcrumb_context is not defined %}
+        {% set breadcrumb_context = 'user_index' %}
+    {% endif %}
+    <div class="row-fluid clearfix">
+        {{ sonata_block_render_event('breadcrumb', { 'context': breadcrumb_context, 'current_uri': app.request.requestUri }) }}
+    </div>
+{% endblock %}
+
+<h2>{% block sonata_profile_title %}{% trans from 'SonataProfileBundle' %}sonata_profile_title{% endtrans %}{% endblock %}</h2>
+
+<div class="sonata-user-show row row-fluid">
+
+    <div class="span2 col-lg-2" style="padding: 8px 0;">
+        {% block sonata_profile_menu %}
+            {{ sonata_block_render({'type': 'sonata.profile.block.menu'}, {'current_uri': app.request.requestUri}) }}
+        {% endblock %}
+    </div>
+
+    <div class="span10 col-lg-10">
+        {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+
+        {% block sonata_profile_content '' %}
+    </div>
+
+</div>

--- a/src/ProfileBundle/Resources/views/dashboard.html.twig
+++ b/src/ProfileBundle/Resources/views/dashboard.html.twig
@@ -1,0 +1,47 @@
+{#
+This file is part of the Sonata package.
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+
+{% extends sonata_profile.template %}
+
+{% block sonata_profile_content %}
+    {% sonata_template_box 'This is the shop profile template. Feel free to override it.' %}
+
+    <div class="row row-fluid">
+        {% set has_center = false %}
+        {% for block in blocks %}
+            {% if block.position == 'center' %}
+                {% set has_center = true %}
+            {% endif %}
+        {% endfor %}
+
+        <div class="{% if has_center %}span4 col-lg-4{% else %}span6 col-lg-6{% endif %}">
+            {% for block in blocks %}
+                {% if block.position == 'left' %}
+                    {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
+                {% endif %}
+            {% endfor %}
+        </div>
+
+        {% if has_center %}
+            <div class="span4 col-lg-4">
+                {% for block in blocks %}
+                    {% if block.position == 'center' %}
+                        {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+
+        <div class="{% if has_center %}span4 col-lg-4{% else %}span6 col-lg-6{% endif %}">
+            {% for block in blocks %}
+                {% if block.position == 'right' %}
+                    {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/src/ProfileBundle/SonataProfileBundle.php
+++ b/src/ProfileBundle/SonataProfileBundle.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle;
+
+use Sonata\ProfileBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class SonataProfileBundle extends Bundle
+{
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new GlobalVariablesCompilerPass());
+    }
+}

--- a/src/ProfileBundle/Twig/GlobalVariables.php
+++ b/src/ProfileBundle/Twig/GlobalVariables.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Twig;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class GlobalVariables
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getTemplate(): string
+    {
+        return $this->container->getParameter('sonata.profile.template');
+    }
+}

--- a/tests/ProfileBundle/Controller/ProfileControllerTest.php
+++ b/tests/ProfileBundle/Controller/ProfileControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\ProfileBundle\Controller\ProfileController;
+
+class ProfileControllerTest extends TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new ProfileController();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/tests/ProfileBundle/Menu/ProfileMenuBuilderTest.php
+++ b/tests/ProfileBundle/Menu/ProfileMenuBuilderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProfileBundle\Tests\Menu;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\ProfileBundle\Menu\ProfileMenuBuilder;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+class ProfileMenuBuilderTest extends TestCase
+{
+    public function testCreateProfileMenu()
+    {
+        $menu = $this->createMock('Knp\Menu\ItemInterface');
+        $factory = $this->createMock('Knp\Menu\FactoryInterface');
+
+        $factory->expects($this->once())
+            ->method('createItem')
+            ->willReturn($menu);
+
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+
+        $builder = new ProfileMenuBuilder($factory, $translator, [], $eventDispatcher);
+
+        $genMenu = $builder->createProfileMenu();
+
+        $this->assertInstanceOf('Knp\Menu\ItemInterface', $genMenu);
+    }
+}


### PR DESCRIPTION
Reference to #614 #547 

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
I add SonataProfileBundle - copy of missing part when update SonataUserBundle 3.x to 4.x. 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because it is feature with BC. 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/ecommerce/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Added
- Added missing profile part when using SonataUserBundle > 3.x