### PR TITLE
Add profile to CustomerBundle

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,12 @@ UPGRADE 3.x
 UPGRADE FROM 3.0 to 3.1
 =======================
 
+## Added missing profile part to CustomerBundle
+
+Profile dependencies are no longer fetched from SonataUserBundle, but you can
+use this profile by changing the configuration (`template` and `menu_builder`). 
+ 
+
 ## Deprecated not passing dependencies to `Sonata\PaymentBundle\Controller\PaymentController`
 
 Dependencies are no longer fetched from the container, so if you manually

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "knplabs/knp-paginator-bundle": "^2.6",
         "kriswallsmith/buzz": "^0.15 || 0.16.0",
         "sonata-project/admin-bundle": "^3.29",
-        "sonata-project/block-bundle": "^3.8",
+        "sonata-project/block-bundle": "^3.18.3",
         "sonata-project/classification-bundle": "^3.3",
         "sonata-project/comment-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.15.1",

--- a/docs/reference/bundles/customer.rst
+++ b/docs/reference/bundles/customer.rst
@@ -24,6 +24,41 @@ The bundle allows you to configure the entity classes; you'll also need to regis
 .. code-block:: yaml
 
     sonata_customer:
+        profile:
+            template:       'SonataCustomerBundle:Profile:action.html.twig' # or 'SonataCustomerBundle:Profile:action_with_user_menu.html.twig'
+            menu_builder:   'sonata.customer.profile.menu_builder.default'
+
+            menu:
+                -
+                    route: 'sonata_customer_dashboard'
+                    label: 'link_list_dashboard'
+                    domain: 'SonataCustomerBundle'
+                    route_parameters: {}
+                -
+                    route: 'sonata_customer_addresses'
+                    label: 'link_list_addresses'
+                    domain: 'SonataCustomerBundle'
+                    route_parameters: {}
+                -
+                    route: 'sonata_order_index'
+                    label: 'order_list'
+                    domain: 'SonataOrderBundle'
+                    route_parameters: {}
+
+            blocks:
+                -
+                    position: left
+                    type: sonata.order.block.recent_orders
+                    settings: { title: Recent Orders, number: 5, mode: public }
+                -
+                    position: right
+                    type: sonata.news.block.recent_posts
+                    settings: { title: Recent Posts, number: 5, mode: public }
+                -
+                    position: right
+                    type: sonata.news.block.recent_comments
+                    settings: { title: Recent Comments, number: 5, mode: public }
+
         class:
             customer:             App\Sonata\CustomerBundle\Entity\Customer
             address:              App\Sonata\CustomerBundle\Entity\Address

--- a/src/CustomerBundle/Block/ProfileMenuBlockService.php
+++ b/src/CustomerBundle/Block/ProfileMenuBlockService.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Block;
+
+use Knp\Menu\ItemInterface;
+use Knp\Menu\Provider\MenuProviderInterface;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\MenuBlockService;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+final class ProfileMenuBlockService extends MenuBlockService
+{
+    private $menuBuilder;
+
+    /**
+     * @param object $menuBuilder
+     */
+    public function __construct(string $name, EngineInterface $templating, MenuProviderInterface $menuProvider, $menuBuilder)
+    {
+        parent::__construct($name, $templating, $menuProvider, []);
+
+        if (!\is_object($menuBuilder) || !method_exists($menuBuilder, 'createProfileMenu')) {
+            throw new \InvalidArgumentException(
+                'Argument 4 should be object with public function "createProfileMenu(array $itemOptions = [])"'
+            );
+        }
+
+        $this->menuBuilder = $menuBuilder;
+    }
+
+    public function getName(): string
+    {
+        return 'Ecommerce Profile Menu';
+    }
+
+    public function configureSettings(OptionsResolver $resolver): void
+    {
+        parent::configureSettings($resolver);
+
+        $resolver->setDefaults([
+            'cache_policy' => 'private',
+            'menu_template' => 'SonataBlockBundle:Block:block_side_menu_template.html.twig',
+        ]);
+    }
+
+    private function getMenu(BlockContextInterface $blockContext): ItemInterface
+    {
+        $settings = $blockContext->getSettings();
+
+        $menu = parent::getMenu($blockContext);
+
+        if (null === $menu || '' === $menu) {
+            $menu = $this->menuBuilder->createProfileMenu(
+                [
+                    'childrenAttributes' => ['class' => $settings['menu_class']],
+                    'attributes' => ['class' => $settings['children_class']],
+                ]
+            );
+
+            if (method_exists($menu, 'setCurrentUri')) {
+                $menu->setCurrentUri($settings['current_uri']);
+            }
+        }
+
+        return $menu;
+    }
+}

--- a/src/CustomerBundle/Controller/DashboardController.php
+++ b/src/CustomerBundle/Controller/DashboardController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DashboardController extends Controller
+{
+    public function dashboardAction(): Response
+    {
+        return $this->render('SonataCustomerBundle:Profile:dashboard.html.twig', [
+            'blocks' => $this->container->getParameter('sonata.customer.profile.blocks'),
+        ]);
+    }
+}

--- a/src/CustomerBundle/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/CustomerBundle/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class GlobalVariablesCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container->getDefinition('twig')
+            ->addMethodCall('addGlobal', ['sonata_customer', new Reference('sonata.customer.twig.global')]);
+    }
+}

--- a/src/CustomerBundle/DependencyInjection/Configuration.php
+++ b/src/CustomerBundle/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
         $node = $treeBuilder->root('sonata_customer');
 
         $this->addModelSection($node);
+        $this->addProfileSection($node);
 
         return $treeBuilder;
     }
@@ -62,5 +63,109 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    private function addProfileSection(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->children()
+                ->arrayNode('profile')
+                    ->addDefaultsIfNotSet()
+                    ->fixXmlConfig('block')
+                    ->children()
+                        ->scalarNode('template')
+                            ->info('This is the profile template. You should extend your profile actions template by using {% extends sonata_customer.profileTemplate %}.')
+                            ->cannotBeEmpty()
+                            ->defaultValue('SonataCustomerBundle:Profile:action.html.twig')
+                        ->end()
+                        ->scalarNode('menu_builder')
+                            ->info('MenuBuilder::createProfileMenu(array $itemOptions = []):ItemInterface is used to build profile menu.')
+                            ->defaultValue('sonata.customer.profile.menu_builder.default')
+                            ->cannotBeEmpty()
+                        ->end()
+                        ->arrayNode('blocks')
+                            ->info('Define your customer profile block here.')
+                            ->defaultValue($this->getProfileBlocksDefaultValues())
+                            ->prototype('array')
+                                ->fixXmlConfig('setting')
+                                ->children()
+                                    ->scalarNode('type')->cannotBeEmpty()->end()
+                                    ->arrayNode('settings')
+                                        ->useAttributeAsKey('id')
+                                        ->prototype('variable')->defaultValue([])->end()
+                                    ->end()
+                                    ->scalarNode('position')->defaultValue('right')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('menu')
+                            ->info('Define your customer profile menu records here.')
+                            ->prototype('array')
+                                ->addDefaultsIfNotSet()
+                                ->cannotBeEmpty()
+                                ->children()
+                                    ->scalarNode('route')->cannotBeEmpty()->end()
+                                    ->arrayNode('route_parameters')
+                                    ->defaultValue([])
+                                    ->prototype('array')->end()
+                                    ->end()
+                                    ->scalarNode('label')->cannotBeEmpty()->end()
+                                    ->scalarNode('domain')->defaultValue('messages')->end()
+                                ->end()
+                            ->end()
+                            ->defaultValue($this->getProfileMenuDefaultValues())
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Returns default values for profile menu (to avoid BC Break).
+     */
+    private function getProfileMenuDefaultValues(): array
+    {
+        return [
+            [
+                'route' => 'sonata_customer_dashboard',
+                'label' => 'link_list_dashboard',
+                'domain' => 'SonataCustomerBundle',
+                'route_parameters' => [],
+            ],
+            [
+                'route' => 'sonata_customer_addresses',
+                'label' => 'link_list_addresses',
+                'domain' => 'SonataCustomerBundle',
+                'route_parameters' => [],
+            ],
+            [
+                'route' => 'sonata_order_index',
+                'label' => 'order_list',
+                'domain' => 'SonataOrderBundle',
+                'route_parameters' => [],
+            ],
+        ];
+    }
+
+    private function getProfileBlocksDefaultValues(): array
+    {
+        return [
+            [
+                'position' => 'left',
+                'type' => 'sonata.order.block.recent_orders',
+                'settings' => ['title' => 'Recent Orders', 'number' => 5, 'mode' => 'public'],
+            ],
+            [
+                'position' => 'right',
+                'type' => 'sonata.news.block.recent_posts',
+                'settings' => ['title' => 'Recent Posts', 'number' => 5, 'mode' => 'public'],
+            ],
+            [
+                'position' => 'right',
+                'type' => 'sonata.news.block.recent_comments',
+                'settings' => ['title' => 'Recent Comments', 'number' => 5, 'mode' => 'public'],
+            ],
+        ];
     }
 }

--- a/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
+++ b/src/CustomerBundle/DependencyInjection/SonataCustomerExtension.php
@@ -55,8 +55,9 @@ class SonataCustomerExtension extends Extension implements PrependExtensionInter
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('block.xml');
-        $loader->load('orm.xml');
         $loader->load('form.xml');
+        $loader->load('menu.xml');
+        $loader->load('orm.xml');
         $loader->load('twig.xml');
 
         if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'])) {
@@ -69,6 +70,7 @@ class SonataCustomerExtension extends Extension implements PrependExtensionInter
             $loader->load('admin.xml');
         }
 
+        $this->configureCustomerProfile($container, $config);
         $this->registerDoctrineMapping($config);
         $this->registerParameters($container, $config);
     }
@@ -156,5 +158,14 @@ class SonataCustomerExtension extends Extension implements PrependExtensionInter
             ],
             'orphanRemoval' => false,
         ]);
+    }
+
+    private function configureCustomerProfile(ContainerBuilder $container, array $config)
+    {
+        $container->setParameter('sonata.customer.profile.blocks', $config['profile']['blocks']);
+        $container->setParameter('sonata.customer.profile.template', $config['profile']['template']);
+
+        $container->setAlias('sonata.customer.profile.menu_builder', $config['profile']['menu_builder']);
+        $container->getDefinition('sonata.customer.profile.menu_builder.default')->replaceArgument(2, $config['profile']['menu']);
     }
 }

--- a/src/CustomerBundle/Menu/ProfileMenuBuilder.php
+++ b/src/CustomerBundle/Menu/ProfileMenuBuilder.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Menu;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+final class ProfileMenuBuilder
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var array
+     */
+    private $routes;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @param array $routes Routes to add to the menu (format: [['label' => ..., 'route' => ...]])
+     */
+    public function __construct(FactoryInterface $factory, TranslatorInterface $translator, array $routes, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->factory = $factory;
+        $this->translator = $translator;
+        $this->routes = $routes;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @param array $itemOptions The options given to the created menuItem
+     */
+    public function createProfileMenu(array $itemOptions = []): ItemInterface
+    {
+        $menu = $this->factory->createItem('customer_profile', $itemOptions);
+
+        $this->buildProfileMenu($menu, $itemOptions);
+
+        return $menu;
+    }
+
+    /**
+     * @param ItemInterface $menu The item to fill with $routes
+     */
+    public function buildProfileMenu(ItemInterface $menu, array $itemOptions = []): void
+    {
+        foreach ($this->routes as $route) {
+            $menu->addChild(
+                $this->translator->trans($route['label'], [], $route['domain']),
+                array_merge($itemOptions, ['route' => $route['route'], 'routeParameters' => $route['route_parameters']])
+            );
+        }
+
+        $event = new ProfileMenuEvent($menu);
+        $this->eventDispatcher->dispatch('sonata.customer.profile.configure_menu', $event);
+    }
+}

--- a/src/CustomerBundle/Menu/ProfileMenuEvent.php
+++ b/src/CustomerBundle/Menu/ProfileMenuEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Menu;
+
+use Knp\Menu\ItemInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+final class ProfileMenuEvent extends Event
+{
+    /**
+     * @var ItemInterface
+     */
+    private $menu;
+
+    public function __construct(ItemInterface $menu)
+    {
+        $this->menu = $menu;
+    }
+
+    public function getMenu(): ItemInterface
+    {
+        return $this->menu;
+    }
+}

--- a/src/CustomerBundle/Resources/config/block.xml
+++ b/src/CustomerBundle/Resources/config/block.xml
@@ -8,5 +8,12 @@
             <argument type="service" id="sonata.customer.manager"/>
             <argument type="service" id="sonata.admin.pool" on-invalid="ignore"/>
         </service>
+        <service id="sonata.customer.block.profile_menu" class="Sonata\CustomerBundle\Block\ProfileMenuBlockService">
+            <tag name="sonata.block"/>
+            <argument>sonata.customer.block.profile_menu</argument>
+            <argument type="service" id="templating"/>
+            <argument type="service" id="knp_menu.menu_provider"/>
+            <argument type="service" id="sonata.customer.profile.menu_builder"/>
+        </service>
     </services>
 </container>

--- a/src/CustomerBundle/Resources/config/menu.xml
+++ b/src/CustomerBundle/Resources/config/menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.customer.profile.menu_builder.default" class="Sonata\CustomerBundle\Menu\ProfileMenuBuilder">
+            <argument type="service" id="knp_menu.factory"/>
+            <argument type="service" id="translator"/>
+            <argument type="collection"/>
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+    </services>
+</container>

--- a/src/CustomerBundle/Resources/config/routing/customer.xml
+++ b/src/CustomerBundle/Resources/config/routing/customer.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="sonata_customer_dashboard" path="/" methods="GET">
+        <default key="_controller">SonataCustomerBundle:Dashboard:dashboard</default>
+    </route>
     <route id="sonata_customer_addresses" path="/address">
         <default key="_controller">SonataCustomerBundle:Customer:addresses</default>
     </route>

--- a/src/CustomerBundle/Resources/config/twig.xml
+++ b/src/CustomerBundle/Resources/config/twig.xml
@@ -5,5 +5,8 @@
             <tag name="twig.extension"/>
             <argument type="service" id="sonata.delivery.selector.default"/>
         </service>
+        <service id="sonata.customer.twig.global" class="Sonata\CustomerBundle\Twig\GlobalVariables">
+            <argument type="string">%sonata.customer.profile.template%</argument>
+        </service>
     </services>
 </container>

--- a/src/CustomerBundle/Resources/translations/SonataCustomerBundle.en.xliff
+++ b/src/CustomerBundle/Resources/translations/SonataCustomerBundle.en.xliff
@@ -3,6 +3,10 @@
     <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
         <body>
             <!-- Begin - Titles -->
+            <trans-unit id="sonata_profile_title">
+                <source>sonata_profile_title</source>
+                <target>Dashboard</target>
+            </trans-unit>
             <trans-unit id="customer">
                 <source>customer</source>
                 <target>Customer</target>
@@ -248,6 +252,10 @@
             <trans-unit id="link_list_addresses">
                 <source>link_list_addresses</source>
                 <target>Addresses</target>
+            </trans-unit>
+            <trans-unit id="link_list_dashboard">
+                <source>link_list_dashboard</source>
+                <target>Dashboard</target>
             </trans-unit>
             <!-- End - Sidemenu translations -->
             <!-- Begin - List translations -->

--- a/src/CustomerBundle/Resources/translations/SonataCustomerBundle.fr.xliff
+++ b/src/CustomerBundle/Resources/translations/SonataCustomerBundle.fr.xliff
@@ -3,6 +3,10 @@
     <file source-language="en" target-language="fr" datatype="plaintext" original="SonataCustomerBundle.en.xliff">
         <body>
             <!-- Begin - Titles -->
+            <trans-unit id="sonata_profile_title">
+                <source>sonata_profile_title</source>
+                <target>Mon tableau de bord</target>
+            </trans-unit>
             <trans-unit id="customer">
                 <source>customer</source>
                 <target>Client</target>
@@ -248,6 +252,10 @@
             <trans-unit id="link_list_addresses">
                 <source>link_list_addresses</source>
                 <target>Adresses</target>
+            </trans-unit>
+            <trans-unit id="link_list_dashboard">
+                <source>link_list_dashboard</source>
+                <target>Mon tableau de bord</target>
             </trans-unit>
             <!-- End - Sidemenu translations -->
             <!-- Begin - List translations -->

--- a/src/CustomerBundle/Resources/translations/SonataCustomerBundle.ru.xliff
+++ b/src/CustomerBundle/Resources/translations/SonataCustomerBundle.ru.xliff
@@ -3,6 +3,10 @@
     <file source-language="en" target-language="ru" datatype="plaintext" original="SonataCustomerBundle.en.xliff">
         <body>
             <!-- Begin - Titles -->
+            <trans-unit id="sonata_profile_title">
+                <source>sonata_profile_title</source>
+                <target>Профиль</target>
+            </trans-unit>
             <trans-unit id="customer">
                 <source>customer</source>
                 <target>Покупатель</target>
@@ -248,6 +252,10 @@
             <trans-unit id="link_list_addresses">
                 <source>link_list_addresses</source>
                 <target>Адреса</target>
+            </trans-unit>
+            <trans-unit id="link_list_dashboard">
+                <source>link_list_dashboard</source>
+                <target>Профиль</target>
             </trans-unit>
             <!-- End - Sidemenu translations -->
             <!-- Begin - List translations -->

--- a/src/CustomerBundle/Resources/views/Addresses/list.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/list.html.twig
@@ -1,4 +1,4 @@
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_customer.profileTemplate %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}address_list{% endtrans %}{% endblock %}

--- a/src/CustomerBundle/Resources/views/Addresses/new.html.twig
+++ b/src/CustomerBundle/Resources/views/Addresses/new.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_customer.profileTemplate %}
 
 {% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}address_new{% endtrans %}{% endblock %}
 

--- a/src/CustomerBundle/Resources/views/Profile/action.html.twig
+++ b/src/CustomerBundle/Resources/views/Profile/action.html.twig
@@ -1,0 +1,33 @@
+{#
+This file is part of the Sonata package.
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+
+{% block sonata_page_breadcrumb %}
+    {% if breadcrumb_context is not defined %}
+        {% set breadcrumb_context = 'user_index' %}
+    {% endif %}
+    <div class="row-fluid clearfix">
+        {{ sonata_block_render_event('breadcrumb', { 'context': breadcrumb_context, 'current_uri': app.request.requestUri }) }}
+    </div>
+{% endblock %}
+
+<h2>{% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}sonata_profile_title{% endtrans %}{% endblock %}</h2>
+
+<div class="sonata-user-show row row-fluid">
+
+    <div class="span2 col-lg-2" style="padding: 8px 0;">
+        {% block sonata_profile_menu %}
+            {{ sonata_block_render({'type': 'sonata.customer.block.profile_menu'}, {'current_uri': app.request.requestUri}) }}
+        {% endblock %}
+    </div>
+
+    <div class="span10 col-lg-10">
+        {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+
+        {% block sonata_profile_content '' %}
+    </div>
+
+</div>

--- a/src/CustomerBundle/Resources/views/Profile/action_with_user_menu.html.twig
+++ b/src/CustomerBundle/Resources/views/Profile/action_with_user_menu.html.twig
@@ -1,0 +1,43 @@
+{#
+This file is part of the Sonata package.
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+
+{% block sonata_page_breadcrumb %}
+    {% if breadcrumb_context is not defined %}
+        {% set breadcrumb_context = 'user_index' %}
+    {% endif %}
+    <div class="row-fluid clearfix">
+        {{ sonata_block_render_event('breadcrumb', { 'context': breadcrumb_context, 'current_uri': app.request.requestUri }) }}
+    </div>
+{% endblock %}
+
+<h2>{% block sonata_profile_title %}{% trans from 'SonataCustomerBundle' %}sonata_profile_title{% endtrans %}{% endblock %}</h2>
+
+<div class="sonata-user-show row row-fluid">
+
+    <div class="span2 col-lg-2" style="padding: 8px 0;">
+        {% block sonata_profile_menu %}
+
+            {% block sonata_customer_profile_menu %}
+                <h3>{% trans from 'SonataCustomerBundle' %}customer{% endtrans %}</h3>
+                {{ sonata_block_render({'type': 'sonata.customer.block.profile_menu'}, {'current_uri': app.request.requestUri}) }}
+            {% endblock %}
+
+            {% block sonata_user_profile_menu %}
+                <h3>{% trans from 'SonataUserBundle' %}show.label_username{% endtrans %}</h3>
+                {{ sonata_block_render({'type': 'sonata.user.block.profile_menu'}, {'current_uri': app.request.requestUri}) }}
+            {% endblock %}
+
+        {% endblock %}
+    </div>
+
+    <div class="span10 col-lg-10">
+        {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+
+        {% block sonata_profile_content '' %}
+    </div>
+
+</div>

--- a/src/CustomerBundle/Resources/views/Profile/dashboard.html.twig
+++ b/src/CustomerBundle/Resources/views/Profile/dashboard.html.twig
@@ -1,0 +1,47 @@
+{#
+This file is part of the Sonata package.
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+
+{% extends sonata_customer.profileTemplate %}
+
+{% block sonata_profile_content %}
+    {% sonata_template_box 'This is the shop profile template. Feel free to override it.' %}
+
+    <div class="row row-fluid">
+        {% set has_center = false %}
+        {% for block in blocks %}
+            {% if block.position == 'center' %}
+                {% set has_center = true %}
+            {% endif %}
+        {% endfor %}
+
+        <div class="{% if has_center %}span4 col-lg-4{% else %}span6 col-lg-6{% endif %}">
+            {% for block in blocks %}
+                {% if block.position == 'left' %}
+                    {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
+                {% endif %}
+            {% endfor %}
+        </div>
+
+        {% if has_center %}
+            <div class="span4 col-lg-4">
+                {% for block in blocks %}
+                    {% if block.position == 'center' %}
+                        {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+
+        <div class="{% if has_center %}span4 col-lg-4{% else %}span6 col-lg-6{% endif %}">
+            {% for block in blocks %}
+                {% if block.position == 'right' %}
+                    {{ sonata_block_render({ 'type': block.type, 'settings': block.settings}) }}
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/src/CustomerBundle/SonataCustomerBundle.php
+++ b/src/CustomerBundle/SonataCustomerBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\CustomerBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\CustomerBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\CustomerBundle\Form\Type\AddressType;
 use Sonata\CustomerBundle\Form\Type\AddressTypeType;
 use Sonata\CustomerBundle\Form\Type\ApiAddressType;
@@ -25,6 +26,7 @@ class SonataCustomerBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
+        $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $this->registerFormMapping();
     }
 

--- a/src/CustomerBundle/Twig/GlobalVariables.php
+++ b/src/CustomerBundle/Twig/GlobalVariables.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Twig;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class GlobalVariables
+{
+    /**
+     * @var string
+     */
+    protected $profileTemplate;
+
+    public function __construct(string $profileTemplate)
+    {
+        $this->profileTemplate = $profileTemplate;
+    }
+
+    public function getProfileTemplate(): string
+    {
+        return $this->profileTemplate;
+    }
+}

--- a/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
+++ b/src/InvoiceBundle/Resources/views/Invoice/view.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_customer.profileTemplate %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataInvoiceBundle' %}sonata.invoice.title_invoice{% endtrans %} - {{ invoice.reference }}{% endblock %}

--- a/src/OrderBundle/Resources/views/Order/index.html.twig
+++ b/src/OrderBundle/Resources/views/Order/index.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_customer.profileTemplate %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataOrderBundle' %}order_list{% endtrans %}{% endblock %}

--- a/src/OrderBundle/Resources/views/Order/view.html.twig
+++ b/src/OrderBundle/Resources/views/Order/view.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "@SonataUser/Profile/action.html.twig" %}
+{% extends sonata_customer.profileTemplate %}
 
 
 {% block sonata_profile_title %}{% trans from 'SonataOrderBundle' %}sonata.order.title_order{% endtrans %} - {{ order.reference }}{% endblock %}

--- a/tests/CustomerBundle/Controller/CustomerControllerTest.php
+++ b/tests/CustomerBundle/Controller/CustomerControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CustomerBundle\Controller\CustomerController;
+
+class CustomerControllerTest extends TestCase
+{
+    /**
+     * @var CustomerController
+     */
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new CustomerController();
+    }
+
+    public function testItIsInstantiable(): void
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/tests/CustomerBundle/Menu/ProfileMenuBuilderTest.php
+++ b/tests/CustomerBundle/Menu/ProfileMenuBuilderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Tests\Menu;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\CustomerBundle\Menu\ProfileMenuBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ */
+final class ProfileMenuBuilderTest extends TestCase
+{
+    public function testCreateProfileMenu(): void
+    {
+        $menu = $this->createMock(ItemInterface::class);
+        $factory = $this->createMock(FactoryInterface::class);
+
+        $factory->expects($this->once())
+            ->method('createItem')
+            ->willReturn($menu);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $builder = new ProfileMenuBuilder($factory, $translator, [], $eventDispatcher);
+
+        $genMenu = $builder->createProfileMenu();
+
+        $this->assertInstanceOf(ItemInterface::class, $genMenu);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This PR copy part of profile functionality from SonataUserBundle, becouse it was drop in 4.0 version. I changed some code and added extra configuration like template and menu_builder. This change will fix #547 issue and allow easy intagrate with other profile. 


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this PR add features. 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #547 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/ecommerce/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added configurable profile to CustomerBundle
```