### PR TITLE
Fix ProfileMenuBlockService and add tests

### DIFF
--- a/src/CustomerBundle/Block/ProfileMenuBlockService.php
+++ b/src/CustomerBundle/Block/ProfileMenuBlockService.php
@@ -58,7 +58,7 @@ final class ProfileMenuBlockService extends MenuBlockService
         ]);
     }
 
-    private function getMenu(BlockContextInterface $blockContext): ItemInterface
+    protected function getMenu(BlockContextInterface $blockContext): ItemInterface
     {
         $settings = $blockContext->getSettings();
 

--- a/tests/CustomerBundle/Block/ProfileMenuBlockServiceTest.php
+++ b/tests/CustomerBundle/Block/ProfileMenuBlockServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Tests\Block;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Knp\Menu\Provider\MenuProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\CustomerBundle\Block\ProfileMenuBlockService;
+use Sonata\CustomerBundle\Menu\ProfileMenuBuilder;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ */
+class ProfileMenuBlockServiceTest extends TestCase
+{
+    /**
+     * @var ProfileMenuBlockService
+     */
+    private $profileMenuBlockService;
+
+    protected function setUp()
+    {
+        /**
+         * prepere profileMenuBuilder.
+         */
+        $menu = $this->createMock(ItemInterface::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $factory = $this->createMock(FactoryInterface::class);
+        $factory
+            ->method('createItem')
+            ->willReturn($menu);
+
+        $profileMenuBuilder = new ProfileMenuBuilder($factory, $translator, [], $eventDispatcher);
+
+        /**
+         * prepere profileMenuBlockService.
+         */
+        $engineInterfaceMock = $this->createMock(EngineInterface::class);
+        $menuProviderInterfaceMock = $this->createMock(MenuProviderInterface::class);
+
+        $this->profileMenuBlockService = new ProfileMenuBlockService(
+            'sonata.customer.block.profile_menu',
+            $engineInterfaceMock,
+            $menuProviderInterfaceMock,
+            $profileMenuBuilder
+        );
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertSame('Ecommerce Profile Menu', $this->profileMenuBlockService->getName());
+    }
+}

--- a/tests/CustomerBundle/Controller/DashboardControllerTest.php
+++ b/tests/CustomerBundle/Controller/DashboardControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CustomerBundle\Controller\DashboardController;
+
+class DashboardControllerTest extends TestCase
+{
+    /**
+     * @var DashboardController
+     */
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new DashboardController();
+    }
+
+    public function testItIsInstantiable(): void
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/tests/CustomerBundle/Twig/GlobalVariablesTest.php
+++ b/tests/CustomerBundle/Twig/GlobalVariablesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CustomerBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CustomerBundle\Twig\GlobalVariables;
+
+/**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ */
+class GlobalVariablesTest extends TestCase
+{
+    /**
+     * @var GlobalVariables
+     */
+    private $globalVariables;
+
+    protected function setUp()
+    {
+        $this->globalVariables = new GlobalVariables('SonataCustomerBundle:Profile:action.html.twig');
+    }
+
+    public function testGetProfileTemplate(): void
+    {
+        $this->assertSame('SonataCustomerBundle:Profile:action.html.twig', $this->globalVariables->getProfileTemplate());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because PR #634 have little bug and need tests.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/ecommerce/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash on Compile Error: Access level to Sonata\CustomerBundle\Block\ProfileMenuBlockService::getMenu() must be protected
```
<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
