### PR TITLE
Remove mapping from product collection to generic Collection Entity

### DIFF
--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -220,7 +220,7 @@ class SonataProductExtension extends Extension
              'orphanRemoval' => false,
         ]);
 
-        if ($addCollectionAssociation){
+        if ($addCollectionAssociation) {
             $collector->addAssociation($config['class']['collection'], 'mapOneToMany', [
                 'fieldName' => 'productCollection',
                 'targetEntity' => $config['class']['product_collection'],

--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -192,6 +192,11 @@ class SonataProductExtension extends Extension
         ]);
 
         $addCollectionAssociation = false;
+
+        /**
+         * NEXT_MAJOR: remove this check, the inverse declaration below
+         * and association added to the Collection entity
+         */
         if(\property_exists($config['class']['collection'], 'productCollection')){
             $addCollectionAssociation = true;
         }

--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -193,11 +193,11 @@ class SonataProductExtension extends Extension
 
         /**
          * NEXT_MAJOR: remove this check, the inverse declaration below
-         * and association added to the Collection entity
+         * and association added to the Collection entity.
          */
         $addCollectionAssociation = false;
-        
-        if(\property_exists($config['class']['collection'], 'productCollection')){
+
+        if (property_exists($config['class']['collection'], 'productCollection')) {
             $addCollectionAssociation = true;
         }
 
@@ -220,7 +220,7 @@ class SonataProductExtension extends Extension
              'orphanRemoval' => false,
         ]);
 
-        if($addCollectionAssociation){
+        if ($addCollectionAssociation){
             $collector->addAssociation($config['class']['collection'], 'mapOneToMany', [
                 'fieldName' => 'productCollection',
                 'targetEntity' => $config['class']['product_collection'],

--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -191,6 +191,11 @@ class SonataProductExtension extends Extension
              'orphanRemoval' => false,
         ]);
 
+        $addCollectionAssociation = false;
+        if(\property_exists($config['class']['collection'], 'productCollection')){
+            $addCollectionAssociation = true;
+        }
+
         $collector->addAssociation($config['class']['product_collection'], 'mapManyToOne', [
              'fieldName' => 'collection',
              'targetEntity' => $config['class']['collection'],
@@ -198,7 +203,7 @@ class SonataProductExtension extends Extension
                 'persist',
              ],
              'mappedBy' => null,
-             'inversedBy' => 'productCollection',
+             'inversedBy' => ($addCollectionAssociation ? 'productCollection' : null),
              'joinColumns' => [
                  [
                      'name' => 'collection_id',
@@ -210,15 +215,17 @@ class SonataProductExtension extends Extension
              'orphanRemoval' => false,
         ]);
 
-        $collector->addAssociation($config['class']['collection'], 'mapOneToMany', [
-            'fieldName' => 'productCollection',
-            'targetEntity' => $config['class']['product_collection'],
-            'cascade' => [
-                'persist',
-            ],
-            'mappedBy' => 'collection',
-            'orphanRemoval' => false,
-        ]);
+        if($addCollectionAssociation){
+            $collector->addAssociation($config['class']['collection'], 'mapOneToMany', [
+                'fieldName' => 'productCollection',
+                'targetEntity' => $config['class']['product_collection'],
+                'cascade' => [
+                    'persist',
+                ],
+                'mappedBy' => 'collection',
+                'orphanRemoval' => false,
+            ]);
+        }
 
         /*
          * PRODUCT

--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -191,12 +191,12 @@ class SonataProductExtension extends Extension
              'orphanRemoval' => false,
         ]);
 
-        $addCollectionAssociation = false;
-
         /**
          * NEXT_MAJOR: remove this check, the inverse declaration below
          * and association added to the Collection entity
          */
+        $addCollectionAssociation = false;
+        
         if(\property_exists($config['class']['collection'], 'productCollection')){
             $addCollectionAssociation = true;
         }


### PR DESCRIPTION
### Remove mapping to Classification\Collection to stop forcing people to add an extra property to their generic Collection class. 
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because (I think) this is a bugfix. not sure though... Some people might actually rely on the association being there? For our use case, it is a bug. 

Another option would be to check if the productCollection property exists in the Collection class and if so add the association? We could remove the association altogether in a new major? I would like one's input on this. 

Closes #644

## Changelog

```markdown

### Fixed
- Only add association mapping from ProductCollection to Collection when property exists
- Only add inversed side definition in ProductionCollection mapping when property exists. 
```

