### PR TITLE
Fix mssql limit issue

### DIFF
--- a/src/ProductBundle/Entity/ProductCategoryManager.php
+++ b/src/ProductBundle/Entity/ProductCategoryManager.php
@@ -101,10 +101,9 @@ class ProductCategoryManager extends BaseEntityManager implements ProductCategor
                 AND (c.enabled = :categoryEnabled OR c.enabled IS NULL)
                 AND p.parent_id IS NULL
                 AND pc.category_id = :categoryId
-                LIMIT %d
                 ) AS cnt';
 
-        $sql = sprintf($sql, $metadata->table['name'], $productMetadata->table['name'], $categoryMetadata->table['name'], $productMetadata->table['name'], $limit);
+        $sql = sprintf($sql, $metadata->table['name'], $productMetadata->table['name'], $categoryMetadata->table['name'], $productMetadata->table['name']);
 
         $statement = $this->getConnection()->prepare($sql);
         $statement->bindValue('productEnabled', 1);
@@ -113,9 +112,10 @@ class ProductCategoryManager extends BaseEntityManager implements ProductCategor
         $statement->bindValue('categoryId', $category->getId());
 
         $statement->execute();
-        $res = $statement->fetchAll();
+        $result = $statement->fetchAll();
+        $count = $result[0]['cntId'];
 
-        return $res[0]['cntId'];
+        return $limit > $count ? $count : $limit;
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR replace limit from database to php. This will resolve problem with diffrence usages of limit function in some sql. 
#### SQL Server / MS Access Syntax:
```sql
SELECT TOP number|percent column_name(s)
FROM table_name
WHERE condition;
```
#### MySQL Syntax:
```sql
SELECT column_name(s)
FROM table_name
WHERE condition
LIMIT number;
```

#### Oracle Syntax:
```sql
SELECT column_name(s)
FROM table_name
WHERE ROWNUM <= number;
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is PATCH.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of https://github.com/sonata-project/dev-kit/issues/689
