### PR TITLE
Replace truncate filter with u filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,13 @@
         "symfony/routing": "^4.3",
         "symfony/security-core": "^4.3",
         "symfony/security-http": "^4.3",
+        "symfony/string": "^5.1",
         "symfony/templating": "^4.3",
         "symfony/translation": "^4.3",
         "symfony/twig-bridge": "^4.3",
-        "symfony/validator": "^4.3"
+        "symfony/validator": "^4.3",
+        "twig/string-extra": "^3.0",
+        "twig/twig": "^2.12.1"
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.2 || >=3.0",
@@ -70,12 +73,13 @@
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "nelmio/api-doc-bundle": "^2.13",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^5.1"
     },
     "suggest": {
         "friendsofsymfony/rest-bundle": "For using the public API methods.",
         "jms/serializer": "For using the public API methods.",
-        "nelmio/api-doc-bundle": "For using the public API methods."
+        "nelmio/api-doc-bundle": "For using the public API methods.",
+        "twig/extra-bundle": "Auto configures the Twig Intl extension"
     },
     "config": {
         "sort-packages": true

--- a/src/ProductBundle/DependencyInjection/SonataProductExtension.php
+++ b/src/ProductBundle/DependencyInjection/SonataProductExtension.php
@@ -17,8 +17,10 @@ use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Twig\Extra\String\StringExtension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -54,6 +56,8 @@ class SonataProductExtension extends Extension
         $pool = $container->getDefinition('sonata.product.pool');
         // this value is altered by the AddProductProviderCompilerPass class
         $pool->addMethodCall('__hack', $config['products']);
+
+        $this->configureStringExtension($container);
 
         $this->registerParameters($container, $config);
         $this->registerDoctrineMapping($config);
@@ -346,6 +350,16 @@ class SonataProductExtension extends Extension
 
         foreach ($productSeo as $key => $value) {
             $container->setParameter(sprintf('sonata.product.seo.product.%s', $key), $value);
+        }
+    }
+
+    private function configureStringExtension(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('twig.extension.string') || !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) {
+            $definition = new Definition(StringExtension::class);
+            $definition->addTag('twig.extension');
+
+            $container->setDefinition(StringExtension::class, $definition);
         }
     }
 }

--- a/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/form_basket_element.html.twig
+++ b/src/ProductBundle/Resources/skeleton/product/Resources/views/Entity/form_basket_element.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
 
 {% block product_description %}
     <b><a href="{{ url('sonata_product_view', {'productId': basketElement.product.id, 'slug': basketElement.product.slug}) }}">{{ basketElement.name }}</a></b> <br />
-    {{ basketElement.product.description|truncate(200, true, '...')|raw }}
+    {{ basketElement.product.description|u.truncate(200, true, '...')|raw }}
 {% endblock %}
 
 {#

--- a/tests/ProductBundle/DependencyInjection/SonataProductExtensionTest.php
+++ b/tests/ProductBundle/DependencyInjection/SonataProductExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\ProductBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\ProductBundle\DependencyInjection\SonataProductExtension;
+use Twig\Extra\String\StringExtension;
+
+class SonataProductExtensionTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', []);
+    }
+
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new SonataProductExtension(),
+        ];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This bundle was using `truncate` filter without explicitly require `twig/extensions`, with this PR it uses `u` filter.

I added `twig/extra-bundle` to autoload the Twig extension and a fallback in case Flex is not used.

Ref: sonata-project/SonataAdminBundle#6132


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `twig/string-extra` dependency.
### Changed
- Changed use of `truncate` filter with `u` filter.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
