### PR TITLE
Fix TwigStringExtensionCompilerPass priority

### DIFF
--- a/src/ProductBundle/SonataProductBundle.php
+++ b/src/ProductBundle/SonataProductBundle.php
@@ -21,6 +21,7 @@ use Sonata\ProductBundle\DependencyInjection\Compiler\TwigStringExtensionCompile
 use Sonata\ProductBundle\Form\Type\ApiProductParentType;
 use Sonata\ProductBundle\Form\Type\ApiProductType;
 use Sonata\ProductBundle\Form\Type\ProductDeliveryStatusType;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,7 +30,7 @@ class SonataProductBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new AddProductProviderCompilerPass());
-        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
 
         $this->registerFormMapping();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR fix case when TwigStringExtensionCompilerPass is build after TwigEnvironmentPass - then u filter is not registred.


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is PATCH.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Changelog is not require. It is fix for non release PR https://github.com/sonata-project/ecommerce/pull/681
