### PR TITLE
Fix RestFul API

### DIFF
--- a/src/BasketBundle/Resources/config/api_controllers.xml
+++ b/src/BasketBundle/Resources/config/api_controllers.xml
@@ -8,5 +8,6 @@
             <argument type="service" id="sonata.basket.builder.standard"/>
             <argument type="service" id="form.factory"/>
         </service>
+        <service id="Sonata\BasketBundle\Controller\Api\BasketController" alias="sonata.basket.controller.api.basket" public="true"/>
     </services>
 </container>

--- a/src/BasketBundle/Resources/config/routing/api.xml
+++ b/src/BasketBundle/Resources/config/routing/api.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://friendsofsymfony.github.com/schema/rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
-    <import type="rest" resource="sonata.basket.controller.api.basket" name-prefix="sonata_api_ecommerce_basket_"/>
+    <import type="rest" resource="Sonata\BasketBundle\Controller\Api\BasketController" name-prefix="sonata_api_ecommerce_basket_"/>
 </routes>

--- a/src/CustomerBundle/Resources/config/api_controllers.xml
+++ b/src/CustomerBundle/Resources/config/api_controllers.xml
@@ -5,11 +5,13 @@
             <argument type="service" id="sonata.address.manager"/>
             <argument type="service" id="form.factory"/>
         </service>
+        <service id="Sonata\CustomerBundle\Controller\Api\AddressController" alias="sonata.customer.controller.api.address" public="true"/>
         <service id="sonata.customer.controller.api.customer" class="Sonata\CustomerBundle\Controller\Api\CustomerController">
             <argument type="service" id="sonata.customer.manager"/>
             <argument type="service" id="sonata.order.manager"/>
             <argument type="service" id="sonata.address.manager"/>
             <argument type="service" id="form.factory"/>
         </service>
+        <service id="Sonata\CustomerBundle\Controller\Api\CustomerController" alias="sonata.customer.controller.api.customer" public="true"/>
     </services>
 </container>

--- a/src/CustomerBundle/Resources/config/routing/api.xml
+++ b/src/CustomerBundle/Resources/config/routing/api.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://friendsofsymfony.github.com/schema/rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
-    <import type="rest" resource="sonata.customer.controller.api.address" name-prefix="sonata_api_ecommerce_address_"/>
-    <import type="rest" resource="sonata.customer.controller.api.customer" name-prefix="sonata_api_ecommerce_customer_"/>
+    <import type="rest" resource="Sonata\CustomerBundle\Controller\Api\AddressController" name-prefix="sonata_api_ecommerce_address_"/>
+    <import type="rest" resource="Sonata\CustomerBundle\Controller\Api\CustomerController" name-prefix="sonata_api_ecommerce_customer_"/>
 </routes>

--- a/src/InvoiceBundle/Resources/config/api_controllers.xml
+++ b/src/InvoiceBundle/Resources/config/api_controllers.xml
@@ -4,5 +4,6 @@
         <service id="sonata.invoice.controller.api.invoice" class="Sonata\InvoiceBundle\Controller\Api\InvoiceController">
             <argument type="service" id="sonata.invoice.manager"/>
         </service>
+        <service id="Sonata\InvoiceBundle\Controller\Api\InvoiceController" alias="sonata.invoice.controller.api.invoice" public="true"/>
     </services>
 </container>

--- a/src/InvoiceBundle/Resources/config/routing/api.xml
+++ b/src/InvoiceBundle/Resources/config/routing/api.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://friendsofsymfony.github.com/schema/rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
-    <import type="rest" resource="sonata.invoice.controller.api.invoice" name-prefix="sonata_api_ecommerce_invoice_"/>
+    <import type="rest" resource="Sonata\InvoiceBundle\Controller\Api\InvoiceController" name-prefix="sonata_api_ecommerce_invoice_"/>
 </routes>

--- a/src/OrderBundle/Resources/config/api_controllers.xml
+++ b/src/OrderBundle/Resources/config/api_controllers.xml
@@ -4,5 +4,6 @@
         <service id="sonata.order.controller.api.order" class="Sonata\OrderBundle\Controller\Api\OrderController">
             <argument type="service" id="sonata.order.manager"/>
         </service>
+        <service id="Sonata\OrderBundle\Controller\Api\OrderController" alias="sonata.order.controller.api.order" public="true"/>
     </services>
 </container>

--- a/src/OrderBundle/Resources/config/routing/api.xml
+++ b/src/OrderBundle/Resources/config/routing/api.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://friendsofsymfony.github.com/schema/rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
-    <import type="rest" resource="sonata.order.controller.api.order" name-prefix="sonata_api_ecommerce_order_"/>
+    <import type="rest" resource="Sonata\OrderBundle\Controller\Api\OrderController" name-prefix="sonata_api_ecommerce_order_"/>
 </routes>

--- a/src/ProductBundle/Resources/config/api_controllers.xml
+++ b/src/ProductBundle/Resources/config/api_controllers.xml
@@ -7,5 +7,6 @@
             <argument type="service" id="form.factory"/>
             <argument type="service" id="sonata.formatter.pool"/>
         </service>
+        <service id="Sonata\ProductBundle\Controller\Api\ProductController" alias="sonata.product.controller.api.product" public="true"/>
     </services>
 </container>

--- a/src/ProductBundle/Resources/config/routing/api.xml
+++ b/src/ProductBundle/Resources/config/routing/api.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://friendsofsymfony.github.com/schema/rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
-    <import type="rest" resource="sonata.product.controller.api.product" name-prefix="sonata_api_ecommerce_product_"/>
+    <import type="rest" resource="Sonata\ProductBundle\Controller\Api\ProductController" name-prefix="sonata_api_ecommerce_product_"/>
 </routes>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of https://github.com/sonata-project/dev-kit/issues/778

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added public alias `Sonata\BasketBundle\Controller\Api\BasketController` for `sonata.basket.controller.api.basket` service
- Added public alias `Sonata\CustomerBundle\Controller\Api\AddressController` for `sonata.customer.controller.api.address` service
- Added public alias `Sonata\CustomerBundle\Controller\Api\CustomerController` for `sonata.customer.controller.api.customer` service
- Added public alias `Sonata\InvoiceBundle\Controller\Api\InvoiceController` for `sonata.invoice.controller.api.invoice` service
- Added public alias `Sonata\OrderBundle\Controller\Api\OrderController` for `sonata.order.controller.api.order` service
- Added public alias `Sonata\ProductBundle\Controller\Api\ProductController` for `sonata.product.controller.api.product` service
### Fixed
- fix RestFul API - `Class could not be determined for Controller identified` Error
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
