### PR TITLE
Translate flash messages

### DIFF
--- a/src/BasketBundle/Controller/BasketController.php
+++ b/src/BasketBundle/Controller/BasketController.php
@@ -376,7 +376,8 @@ class BasketController extends Controller
 
                 $this->get('sonata.customer.manager')->save($customer);
 
-                $this->get('session')->getFlashBag()->add('sonata_customer_success', 'address_add_success');
+                $message = $this->get('translator')->trans('address_add_success', [], 'SonataCustomerBundle');
+                $this->get('session')->getFlashBag()->add('sonata_customer_success', $message);
             }
 
             $basket->setCustomer($customer);
@@ -439,7 +440,8 @@ class BasketController extends Controller
 
                 $this->get('sonata.customer.manager')->save($customer);
 
-                $this->get('session')->getFlashBag()->add('sonata_customer_success', 'address_add_success');
+                $message = $this->get('translator')->trans('address_add_success', [], 'SonataCustomerBundle');
+                $this->get('session')->getFlashBag()->add('sonata_customer_success', $message);
             }
 
             $basket->setCustomer($customer);

--- a/src/CustomerBundle/Controller/CustomerController.php
+++ b/src/CustomerBundle/Controller/CustomerController.php
@@ -113,7 +113,8 @@ class CustomerController extends Controller
 
         $this->getAddressManager()->delete($address);
 
-        $this->get('session')->getFlashBag()->add('sonata_customer_success', 'customer_address_delete');
+        $message = $this->get('translator')->trans('customer_address_delete', [], 'SonataCustomerBundle');
+        $this->get('session')->getFlashBag()->add('sonata_customer_success', $message);
 
         return new RedirectResponse($this->generateUrl('sonata_customer_addresses'));
     }
@@ -170,7 +171,8 @@ class CustomerController extends Controller
 
             $this->getCustomerManager()->save($customer);
 
-            $this->get('session')->getFlashBag()->add('sonata_customer_success', $id ? 'address_edit_success' : 'address_add_success');
+            $message = $this->get('translator')->trans($id ? 'address_edit_success' : 'address_add_success', [], 'SonataCustomerBundle');
+            $this->get('session')->getFlashBag()->add('sonata_customer_success', $message);
 
             $url = $this->get('session')->get('sonata_address_redirect', $this->generateUrl('sonata_customer_addresses'));
 

--- a/src/OrderBundle/Controller/OrderCRUDController.php
+++ b/src/OrderBundle/Controller/OrderCRUDController.php
@@ -43,7 +43,8 @@ class OrderCRUDController extends CRUDController
             $this->getInvoiceTransformer()->transformFromOrder($order, $invoice);
             $this->getInvoiceManager()->save($invoice);
 
-            $this->addFlash('sonata_flash_success', $this->get('translator')->trans('oRDER_TO_INVOICE_generate_success', [], 'SonataOrderBundle'));
+            $message = $this->get('translator')->trans('oRDER_TO_INVOICE_generate_success', [], 'SonataOrderBundle');
+            $this->addFlash('sonata_flash_success', $message);
         }
 
         return $this->redirect($this->generateUrl('admin_sonata_invoice_invoice_edit', ['id' => $invoice->getId()]));

--- a/src/ProductBundle/Controller/BaseProductController.php
+++ b/src/ProductBundle/Controller/BaseProductController.php
@@ -146,7 +146,8 @@ abstract class BaseProductController extends Controller
                 return new JsonResponse(['error' => $this->get('translator')->trans('variation_not_found', [], 'SonataProductBundle')]);
             }
 
-            $this->get('session')->getFlashBag()->add('sonata_product_error', 'variation_not_found');
+            $message = $this->get('translator')->trans('variation_not_found', [], 'SonataProductBundle');
+            $this->get('session')->getFlashBag()->add('sonata_product_error', $message);
 
             // Go to master product
             $variation = $product;

--- a/src/ProductBundle/Controller/ProductVariationAdminController.php
+++ b/src/ProductBundle/Controller/ProductVariationAdminController.php
@@ -74,7 +74,8 @@ class ProductVariationAdminController extends Controller
 
                     $manager->persist($variation);
                 } catch (\Exception $e) {
-                    $this->addFlash('sonata_flash_error', 'flash_create_variation_error');
+                    $message = $this->getTranslator()->trans('flash_create_variation_error', [], 'SonataProductBundle');
+                    $this->addFlash('sonata_flash_error', $message);
 
                     return new RedirectResponse($this->admin->generateUrl('create'));
                 }
@@ -82,7 +83,8 @@ class ProductVariationAdminController extends Controller
 
             $manager->flush();
 
-            $this->addFlash('sonata_flash_success', $this->getTranslator()->trans('flash_create_variation_success', [], 'SonataProductBundle'));
+            $message = $this->getTranslator()->trans('flash_create_variation_success', [], 'SonataProductBundle');
+            $this->addFlash('sonata_flash_success', $message);
 
             return new RedirectResponse($this->admin->generateUrl('list'));
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Translator dependencies was remove in `twig-extensions 1.x`. Messages should be translate before add it to `flash bag`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/ecommerce/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/ecommerce/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Translate flash message before add it to `flash bag`
```
