### PR TITLE
 Update Swagger definition in order to be compatible with string identifiers

### DIFF
--- a/src/BasketBundle/Controller/Api/BasketController.php
+++ b/src/BasketBundle/Controller/Api/BasketController.php
@@ -125,7 +125,7 @@ class BasketController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Basket identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Basket identifier"}
      *  },
      *  output={"class"="Sonata\Component\Basket\BasketInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -136,7 +136,7 @@ class BasketController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Basket identifier
      *
      * @return BasketInterface
      */
@@ -150,7 +150,7 @@ class BasketController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Basket identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Basket identifier"}
      *  },
      *  output={"class"="Sonata\Component\Basket\BasketInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -161,7 +161,7 @@ class BasketController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Basket identifier
      *
      * @return BasketElementInterface[]
      */
@@ -197,7 +197,7 @@ class BasketController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Basket identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Basket identifier"}
      *  },
      *  input={"class"="sonata_basket_api_form_basket", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\Component\Basket\BasketInterface", "groups"={"sonata_api_read"}},
@@ -208,7 +208,7 @@ class BasketController
      *  }
      * )
      *
-     * @param int     $id      Basket identifier
+     * @param string  $id      Basket identifier
      * @param Request $request Symfony request
      *
      * @return View|FormInterface
@@ -223,7 +223,7 @@ class BasketController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Basket identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Basket identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when basket is successfully deleted",
@@ -232,7 +232,7 @@ class BasketController
      *  }
      * )
      *
-     * @param int $id Basket identifier
+     * @param string $id Basket identifier
      *
      * @throws NotFoundHttpException
      *
@@ -256,7 +256,7 @@ class BasketController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Basket identifier"},
+     *      {"name"="id", "dataType"="string", "description"="Basket identifier"},
      *  },
      *  input={"class"="sonata_basket_api_form_basket_element", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\Component\Basket\BasketInterface", "groups"={"sonata_api_read"}},
@@ -267,7 +267,7 @@ class BasketController
      *  }
      * )
      *
-     * @param int     $id      Basket identifier
+     * @param string  $id      Basket identifier
      * @param Request $request Symfony request
      *
      * @return View|FormInterface
@@ -282,8 +282,8 @@ class BasketController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="basketId", "dataType"="integer", "requirement"="\d+", "description"="Basket identifier"},
-     *      {"name"="elementId", "dataType"="integer", "requirement"="\d+", "description"="Element identifier"},
+     *      {"name"="basketId", "dataType"="string", "description"="Basket identifier"},
+     *      {"name"="elementId", "dataType"="string", "description"="Element identifier"},
      *  },
      *  input={"class"="sonata_basket_api_form_basket_element", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\Component\Basket\BasketInterface", "groups"={"sonata_api_read"}},
@@ -294,8 +294,8 @@ class BasketController
      *  }
      * )
      *
-     * @param int     $basketId  Basket identifier
-     * @param int     $elementId Basket element identifier
+     * @param string  $basketId  Basket identifier
+     * @param string  $elementId Basket element identifier
      * @param Request $request   Symfony request
      *
      * @return View|FormInterface
@@ -310,8 +310,8 @@ class BasketController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="basketId", "dataType"="integer", "requirement"="\d+", "description"="Basket identifier"},
-     *      {"name"="elementId", "dataType"="integer", "requirement"="\d+", "description"="Element identifier"},
+     *      {"name"="basketId", "dataType"="string", "description"="Basket identifier"},
+     *      {"name"="elementId", "dataType"="string", "description"="Element identifier"},
      *  },
      *  statusCodes={
      *      200="Returned when basket is successfully deleted",
@@ -320,8 +320,8 @@ class BasketController
      *  }
      * )
      *
-     * @param int $basketId  Basket identifier
-     * @param int $elementId Basket element identifier
+     * @param string $basketId  Basket identifier
+     * @param string $elementId Basket element identifier
      *
      * @throws NotFoundHttpException
      *
@@ -367,8 +367,8 @@ class BasketController
     /**
      * Write a basket, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Basket identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Basket identifier
      *
      * @return View|FormInterface
      */
@@ -411,9 +411,9 @@ class BasketController
     /**
      * Write a basket element, this method is used by both POST and PUT action methods.
      *
-     * @param int     $basketId  Sonata ecommerce basket identifier
+     * @param string  $basketId  Sonata ecommerce basket identifier
      * @param Request $request   Symfony Request service
-     * @param int     $elementId Sonata ecommerce basket element identifier
+     * @param string  $elementId Sonata ecommerce basket element identifier
      *
      * @return View|FormInterface
      */
@@ -471,7 +471,7 @@ class BasketController
     /**
      * Retrieves basket with identifier $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Basket identifier
      *
      * @throws NotFoundHttpException
      *
@@ -491,7 +491,7 @@ class BasketController
     /**
      * Retrieves basket element with identifier $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id BasketElement identifier
      *
      * @throws NotFoundHttpException
      *
@@ -511,7 +511,7 @@ class BasketController
     /**
      * Retrieves product with identifier $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @throws NotFoundHttpException
      *
@@ -531,7 +531,7 @@ class BasketController
     /**
      * Throws an exception if it already exists a basket with a specific customer identifier.
      *
-     * @param $customerId
+     * @param string $customerId Customer identifier
      *
      * @throws HttpException
      */

--- a/src/CustomerBundle/Controller/Api/AddressController.php
+++ b/src/CustomerBundle/Controller/Api/AddressController.php
@@ -22,6 +22,7 @@ use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Customer\AddressManagerInterface;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -95,7 +96,7 @@ class AddressController
      * @ApiDoc(
      *  resource=true,
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Address identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Address identifier"}
      *  },
      *  output={"class"="Sonata\Component\Customer\AddressInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -106,7 +107,7 @@ class AddressController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Address identifier
      *
      * @return AddressInterface
      */
@@ -141,7 +142,7 @@ class AddressController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Address identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Address identifier"}
      *  },
      *  input={"class"="sonata_customer_api_form_address", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\CustomerBundle\Model\Address", "groups"={"sonata_api_read"}},
@@ -151,7 +152,7 @@ class AddressController
      *  }
      * )
      *
-     * @param int     $id      Address identifier
+     * @param string  $id      Address identifier
      * @param Request $request Symfony request
      *
      * @return View|FormInterface
@@ -166,7 +167,7 @@ class AddressController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Address identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Address identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when customer is successfully deleted",
@@ -175,7 +176,7 @@ class AddressController
      *  }
      * )
      *
-     * @param int $id Address identifier
+     * @param string $id Address identifier
      *
      * @throws NotFoundHttpException
      *
@@ -197,7 +198,7 @@ class AddressController
     /**
      * Retrieves address with identifier $id or throws an exception if it doesn't exist.
      *
-     * @param int $id
+     * @param string $id Address identifier
      *
      * @throws NotFoundHttpException
      *
@@ -217,8 +218,8 @@ class AddressController
     /**
      * Write an address, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Address identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Address identifier
      *
      * @return View|FormInterface
      */

--- a/src/CustomerBundle/Controller/Api/CustomerController.php
+++ b/src/CustomerBundle/Controller/Api/CustomerController.php
@@ -18,12 +18,14 @@ use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Sonata\Component\Customer\AddressInterface;
 use Sonata\Component\Customer\AddressManagerInterface;
 use Sonata\Component\Customer\CustomerInterface;
 use Sonata\Component\Customer\CustomerManagerInterface;
 use Sonata\Component\Order\OrderManagerInterface;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -107,7 +109,7 @@ class CustomerController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Customer identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Customer identifier"}
      *  },
      *  output={"class"="Sonata\Component\Customer\CustomerInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -118,7 +120,7 @@ class CustomerController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Customer identifier
      *
      * @return CustomerInterface
      */
@@ -153,7 +155,7 @@ class CustomerController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Customer identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Customer identifier"}
      *  },
      *  input={"class"="sonata_customer_api_form_customer", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\CustomerBundle\Model\Customer", "groups"={"sonata_api_read"}},
@@ -164,7 +166,7 @@ class CustomerController
      *  }
      * )
      *
-     * @param int     $id      Customer identifier
+     * @param string  $id      Customer identifier
      * @param Request $request Symfony request
      *
      * @return View|FormInterface
@@ -179,7 +181,7 @@ class CustomerController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Customer identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Customer identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when customer is successfully deleted",
@@ -188,7 +190,7 @@ class CustomerController
      *  }
      * )
      *
-     * @param int $id Customer identifier
+     * @param string $id Customer identifier
      *
      * @throws NotFoundHttpException
      *
@@ -212,7 +214,7 @@ class CustomerController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Customer identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Customer identifier"}
      *  },
      *  output={"class"="Sonata\Component\Order\OrderInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -223,7 +225,7 @@ class CustomerController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Customer identifier
      *
      * @return array
      */
@@ -239,7 +241,7 @@ class CustomerController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Customer identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Customer identifier"}
      *  },
      *  output={"class"="Sonata\Component\Customer\AddressInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -250,7 +252,7 @@ class CustomerController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Customer identifier
      *
      * @return array
      */
@@ -264,7 +266,7 @@ class CustomerController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Customer identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Customer identifier"}
      *  },
      *  input={"class"="sonata_customer_api_form_address", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\CustomerBundle\Model\Address", "groups"={"sonata_api_read"}},
@@ -276,12 +278,12 @@ class CustomerController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int     $id      Customer identifier
+     * @param string  $id      Customer identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
      *
-     * @return Address
+     * @return AddressInterface
      */
     public function postCustomerAddressAction($id, Request $request)
     {
@@ -308,8 +310,8 @@ class CustomerController
     /**
      * Write a customer, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Customer identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Customer identifier
      *
      * @return View|FormInterface
      */
@@ -349,7 +351,7 @@ class CustomerController
     /**
      * Retrieves customer with identifier $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Customer identifier
      *
      * @throws NotFoundHttpException
      *

--- a/src/InvoiceBundle/Controller/Api/InvoiceController.php
+++ b/src/InvoiceBundle/Controller/Api/InvoiceController.php
@@ -84,7 +84,7 @@ class InvoiceController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Invoice identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Invoice identifier"}
      *  },
      *  output={"class"="Sonata\Component\Invoice\InvoiceInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -95,7 +95,7 @@ class InvoiceController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Invoice identifier
      *
      * @return InvoiceInterface
      */
@@ -109,7 +109,7 @@ class InvoiceController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Invoice identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Invoice identifier"}
      *  },
      *  output={"class"="Sonata\Component\Invoice\InvoiceElementInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -120,7 +120,7 @@ class InvoiceController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Invoice identifier
      *
      * @return array
      */
@@ -132,7 +132,7 @@ class InvoiceController
     /**
      * Retrieves invoice with identifier $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Invoice identifier
      *
      * @throws NotFoundHttpException
      *

--- a/src/OrderBundle/Controller/Api/OrderController.php
+++ b/src/OrderBundle/Controller/Api/OrderController.php
@@ -86,7 +86,7 @@ class OrderController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Order identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Order identifier"}
      *  },
      *  output={"class"="Sonata\Component\Order\OrderInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -97,7 +97,7 @@ class OrderController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Order identifier
      *
      * @return OrderInterface
      */
@@ -111,7 +111,7 @@ class OrderController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Order identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Order identifier"}
      *  },
      *  output={"class"="Sonata\Component\Order\OrderElementInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -122,7 +122,7 @@ class OrderController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Order identifier
      *
      * @return array
      */
@@ -134,7 +134,7 @@ class OrderController
     /**
      * Retrieves order with id $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Order identifier
      *
      * @throws NotFoundHttpException
      *

--- a/src/ProductBundle/Controller/Api/ProductController.php
+++ b/src/ProductBundle/Controller/Api/ProductController.php
@@ -30,6 +30,7 @@ use Sonata\Component\Product\ProductManagerInterface;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\FormatterBundle\Formatter\Pool as FormatterPool;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -119,7 +120,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"}
      *  },
      *  output={"class"="Sonata\Component\Product\ProductInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -130,7 +131,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return ProductInterface
      */
@@ -168,7 +169,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"},
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"},
      *      {"name"="provider", "dataType"="string", "requirement"="[A-Za-z0-9.]*", "description"="Product provider"}
      *  },
      *  input={"class"="sonata_product_api_form_product", "name"="", "groups"={"sonata_api_write"}},
@@ -180,7 +181,7 @@ class ProductController
      *  }
      * )
      *
-     * @param int     $id       Product identifier
+     * @param string  $id       Product identifier
      * @param string  $provider Product provider name
      * @param Request $request  Symfony request
      *
@@ -196,7 +197,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when post is successfully deleted",
@@ -205,7 +206,7 @@ class ProductController
      *  }
      * )
      *
-     * @param int $id Product identifier
+     * @param string $id Product identifier
      *
      * @throws NotFoundHttpException
      *
@@ -230,7 +231,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"}
      *  },
      *  output={"class"="Sonata\Component\Product\ProductCategoryInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -241,7 +242,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return ProductCategoryInterface[]
      */
@@ -255,7 +256,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"}
      *  },
      *  output={"class"="Sonata\ClassificationBundle\Model\CategoryInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -266,7 +267,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return CategoryInterface[]
      */
@@ -280,7 +281,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"}
      *  },
      *  output={"class"="Sonata\Component\Product\ProductCollectionInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -291,7 +292,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return ProductCollectionInterface[]
      */
@@ -305,7 +306,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"}
      *  },
      *  output={"class"="Sonata\ClassificationBundle\Model\CollectionInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -316,7 +317,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return CollectionInterface[]
      */
@@ -330,7 +331,7 @@ class ProductController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Product identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Product identifier"}
      *  },
      *  output={"class"="Sonata\Component\Product\DeliveryInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -341,7 +342,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return DeliveryInterface[]
      */
@@ -366,7 +367,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return PackageInterface[]
      */
@@ -391,7 +392,7 @@ class ProductController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @return ProductInterface[]
      */
@@ -403,9 +404,9 @@ class ProductController
     /**
      * Write a product, this method is used by both POST and PUT action methods.
      *
-     * @param string   $provider Product provider name
-     * @param Request  $request  Symfony request
-     * @param int|null $id       Product identifier
+     * @param string      $provider Product provider name
+     * @param Request     $request  Symfony request
+     * @param string|null $id       Product identifier
      *
      * @return View|FormInterface
      */
@@ -455,7 +456,7 @@ class ProductController
     /**
      * Retrieves product with identifier $id or throws an exception if it doesn't exist.
      *
-     * @param $id
+     * @param string $id Product identifier
      *
      * @throws NotFoundHttpException
      *


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Update OpenAPI (Swagger) definition in order to be compatible with string identifiers (like UUIDs).

These changes are consistent with the API narrowing made at sonata-project/admin-bundle (see AdminInterface::id()).

I am targeting this branch, because these changes respect BC.

Part of https://github.com/sonata-project/dev-kit/issues/778

Based on: https://github.com/sonata-project/SonataUserBundle/pull/1198

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/ecommerce/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed requirements that were only allowing integers for model identifiers at Open API definitions.
### Fixed
- Fixed support for string model identifiers at Open API definitions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
