### PR TITLE
Fix php8 build

### DIFF
--- a/tests/Component/Delivery/SelectorTest.php
+++ b/tests/Component/Delivery/SelectorTest.php
@@ -264,7 +264,7 @@ class SelectorTest extends TestCase
         $deliveryMethod_high_bis = new ServiceDelivery();
         $deliveryMethod_high_bis->setCode('ups_high_bis');
         $deliveryMethod_high_bis->setEnabled(true);
-        $deliveryMethod_high_bis->setPriority(2);
+        $deliveryMethod_high_bis->setPriority(3);
 
         $deliveryPool = new DeliveryPool();
         $deliveryPool->addMethod($deliveryMethod_low);

--- a/tests/Component/Generator/MysqlReferenceTest.php
+++ b/tests/Component/Generator/MysqlReferenceTest.php
@@ -67,6 +67,8 @@ class MysqlReferenceTest extends TestCase
         $metadata->table = ['name' => 'tableName'];
 
         $connection = $this->createMock(Connection::class);
+        $statement = $this->createMock(\PDOStatement::class);
+        $statement->expects($this->once())->method('fetch')->willReturn(false);
 
         $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($this->any())
@@ -75,7 +77,7 @@ class MysqlReferenceTest extends TestCase
 
         $connection->expects($this->any())
             ->method('query')
-            ->willReturn(new \PDOStatement());
+            ->willReturn($statement);
 
         $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->any())->method('getManager')->willReturn($em);


### PR DESCRIPTION
\PDOStatement now throws an exception if the PDO is not initialized
instead of false. And the sort on php8 is stable, so we better test with
non equal elements, so the order does not change between php7 and php8.